### PR TITLE
Fix potential snapshot info race.

### DIFF
--- a/common.c
+++ b/common.c
@@ -133,6 +133,7 @@ static void raftize_commands(RedisModuleCommandFilterCtx *filter)
     static char *excluded_commands[] = {
         "auth",
         "ping",
+        "save",
         "module",
         "raft",
         "info",


### PR DESCRIPTION
Updating the snapshot info must be done while still holding the thread
safe context lock, to make sure that a subsequent RDB save operation
will be correctly aligned with the log.