### PR TITLE
Fix raftize re-entrancy issues (#13, #14).

### DIFF
--- a/common.c
+++ b/common.c
@@ -2,6 +2,8 @@
 
 #include "redisraft.h"
 
+int redis_raft_in_rm_call = 0;
+
 const char *getStateStr(RedisRaftCtx *rr)
 {
     static const char *state_str[] = { "uninitialized", "up", "loading", "joining" };
@@ -143,6 +145,13 @@ static void raftize_commands(RedisModuleCommandFilterCtx *filter)
         "command",
         NULL
     };
+
+    /* If we're intercepting an RM_Call() processing a Raft entry,
+     * skip.
+     */
+    if (checkInRedisModuleCall()) {
+        return;
+    }
 
     size_t cmdname_len;
     const char *cmdname = RedisModule_StringPtrLen(

--- a/raft.c
+++ b/raft.c
@@ -154,8 +154,10 @@ static void executeRaftRedisCommandArray(RaftRedisCommandArray *array,
             continue;
         }
 
+        enterRedisModuleCall();
         RedisModuleCallReply *reply = RedisModule_Call(
                 ctx, cmd, "v", &c->argv[1], c->argc - 1);
+        exitRedisModuleCall();
 
         if (reply_ctx) {
             if (reply) {


### PR DESCRIPTION
Redis Module API makes sure calls from the module back to Redis don't
get re-intercepted by the filtering hook. However, this guarantee is
valid for calls made on a normal context, but not on a thread safe
context.

In many cases Raft log entries are applied in a different context, which
causes the filter to re-raftize them. This leads with an endless loop
that bloats the log and does causes log entries to never apply to Redis.