### PR TITLE
Fix issues around node startup and log loading.

### DIFF
--- a/raft.c
+++ b/raft.c
@@ -475,6 +475,10 @@ static raft_node_id_t raftLogGetNodeId(raft_server_t *raft, void *user_data, raf
 
 static int raftNodeHasSufficientLogs(raft_server_t *raft, void *user_data, raft_node_t *raft_node)
 {
+    RedisRaftCtx *rr = (RedisRaftCtx *) user_data;
+    if (rr->state == REDIS_RAFT_LOADING)
+        return 0;
+
     Node *node = raft_node_get_udata(raft_node);
     assert (node != NULL);
 
@@ -587,7 +591,7 @@ RRStatus applyLoadedRaftLog(RedisRaftCtx *rr)
     /* Special case: if no other nodes, set commit index to the latest
      * entry in the log.
      */
-    if (raft_get_num_nodes(rr->raft) == 1) {
+    if (raft_get_num_voting_nodes(rr->raft) == 1 || raft_get_num_nodes(rr->raft) == 1) {
         raft_set_commit_idx(rr->raft, raft_get_current_idx(rr->raft));
     }
 

--- a/redisraft.c
+++ b/redisraft.c
@@ -89,7 +89,7 @@ static int cmdRaftNode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     RaftReq *req = NULL;
     size_t cmd_len;
 
-    if (rr->state == REDIS_RAFT_UNINITIALIZED) {
+    if (rr->state != REDIS_RAFT_UP) {
         RedisModule_ReplyWithError(ctx, "NOCLUSTER No Raft Cluster");
         return REDISMODULE_OK;
     }


### PR DESCRIPTION
During log loading, historic nodes could be resurrected and communicated
with; this is bad in particular if such nodes exist, or if a node ends
up sending messages to itself because the old node shared the same
endpoint.

Commit index not always properly initialized when the log indicates a
single voting node exists.