### PR TITLE
Docs: remove memory-only references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ library](https://github.com/willemt/raft) by Willem-Hendrik Thiart.
 * Strong consistency (in the language of [CAP](https://en.wikipedia.org/wiki/CAP_theorem), this system prioritizes consistency and partition-tolerance).
 * Support for most Redis data types and commands
 * Dynamic cluster configuration (adding / removing nodes)
-* Persistent or in-memory Raft log
 * Snapshots for log compaction
 * Configurable quorum or fast reads
 

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -31,8 +31,6 @@ The cluster uses heartbeat messages to detect failed nodes. In the event of a fa
 
 A RedisRaft cluster will remain available (i.e., able to process reads and writes) as long as the majority of its nodes remains online and able to communicate with each other. If this is not the case, the cluster becomes unavailable.
 
-RedisRaft nodes may persist data to disk for better durability or operate in-memory only.
-
 The RedisRaft consensus algorithm enforces the following invariants:
 
     1. A node must never lose the data it has acknowledged (i.e., written in the log)
@@ -43,8 +41,6 @@ So long as a node persists its log data to disk, it will survive crashes, OS res
 However, if a node's log files are lost or corrupted, then that node needs to be removed from the cluster and re-joined.
 
 Every cluster node is identified by a unique, logical ID. So re-joining a node involves logically removing the old ID and re-joining the node with new ID.
-
-An in-memory node will naturally lose its data on every process crash/restart. In other words, a simple re-start of an in-memory node is the equivalent of losing a disk on a persistent node.
 
 ## What are RedisRaft's limitations?
 


### PR DESCRIPTION
This feature is not currently in use and may stay so as it offers little
advantage over persisting to disk without fsync().