### PR TITLE
Make the source file license annotations match LICENSE.agpl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2020 Redis Labs
 #
-# RedisRaft is dual licensed under the GNU General Public License version 3
+# RedisRaft is dual licensed under the GNU Affero General Public License version 3
 # (AGPLv3) or the Redis Source Available License (RSAL).
 
 OS := $(shell sh -c 'uname -s 2>/dev/null || echo none')

--- a/common.c
+++ b/common.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/config.c
+++ b/config.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/log.c
+++ b/log.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/node.c
+++ b/node.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/proxy.c
+++ b/proxy.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/raft.c
+++ b/raft.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/redisraft.c
+++ b/redisraft.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/redisraft.h
+++ b/redisraft.h
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/serialization.c
+++ b/serialization.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/snapshot.c
+++ b/snapshot.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/tests/dut_premble.h
+++ b/tests/dut_premble.h
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -3,7 +3,7 @@ This file is part of RedisRaft.
 
 Copyright (c) 2020 Redis Labs
 
-RedisRaft is dual licensed under the GNU General Public License version 3
+RedisRaft is dual licensed under the GNU Affero General Public License version 3
 (AGPLv3) or the Redis Source Available License (RSAL).
 """
 

--- a/tests/integration/raftlog.py
+++ b/tests/integration/raftlog.py
@@ -3,7 +3,7 @@ This file is part of RedisRaft.
 
 Copyright (c) 2020 Redis Labs
 
-RedisRaft is dual licensed under the GNU General Public License version 3
+RedisRaft is dual licensed under the GNU Affero General Public License version 3
 (AGPLv3) or the Redis Source Available License (RSAL).
 """
 

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -3,7 +3,7 @@ This file is part of RedisRaft.
 
 Copyright (c) 2020 Redis Labs
 
-RedisRaft is dual licensed under the GNU General Public License version 3
+RedisRaft is dual licensed under the GNU Affero General Public License version 3
 (AGPLv3) or the Redis Source Available License (RSAL).
 """
 

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -3,7 +3,7 @@ This file is part of RedisRaft.
 
 Copyright (c) 2020 Redis Labs
 
-RedisRaft is dual licensed under the GNU General Public License version 3
+RedisRaft is dual licensed under the GNU Affero General Public License version 3
 (AGPLv3) or the Redis Source Available License (RSAL).
 """
 

--- a/tests/integration/test_fuzzing.py
+++ b/tests/integration/test_fuzzing.py
@@ -3,7 +3,7 @@ This file is part of RedisRaft.
 
 Copyright (c) 2020 Redis Labs
 
-RedisRaft is dual licensed under the GNU General Public License version 3
+RedisRaft is dual licensed under the GNU Affero General Public License version 3
 (AGPLv3) or the Redis Source Available License (RSAL).
 """
 

--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -3,7 +3,7 @@ This file is part of RedisRaft.
 
 Copyright (c) 2020 Redis Labs
 
-RedisRaft is dual licensed under the GNU General Public License version 3
+RedisRaft is dual licensed under the GNU Affero General Public License version 3
 (AGPLv3) or the Redis Source Available License (RSAL).
 """
 

--- a/tests/integration/test_membership.py
+++ b/tests/integration/test_membership.py
@@ -3,7 +3,7 @@ This file is part of RedisRaft.
 
 Copyright (c) 2020 Redis Labs
 
-RedisRaft is dual licensed under the GNU General Public License version 3
+RedisRaft is dual licensed under the GNU Affero General Public License version 3
 (AGPLv3) or the Redis Source Available License (RSAL).
 """
 

--- a/tests/integration/test_multi.py
+++ b/tests/integration/test_multi.py
@@ -3,7 +3,7 @@ This file is part of RedisRaft.
 
 Copyright (c) 2020 Redis Labs
 
-RedisRaft is dual licensed under the GNU General Public License version 3
+RedisRaft is dual licensed under the GNU Affero General Public License version 3
 (AGPLv3) or the Redis Source Available License (RSAL).
 """
 

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -3,7 +3,7 @@ This file is part of RedisRaft.
 
 Copyright (c) 2020 Redis Labs
 
-RedisRaft is dual licensed under the GNU General Public License version 3
+RedisRaft is dual licensed under the GNU Affero General Public License version 3
 (AGPLv3) or the Redis Source Available License (RSAL).
 """
 

--- a/tests/integration/test_snapshots.py
+++ b/tests/integration/test_snapshots.py
@@ -3,7 +3,7 @@ This file is part of RedisRaft.
 
 Copyright (c) 2020 Redis Labs
 
-RedisRaft is dual licensed under the GNU General Public License version 3
+RedisRaft is dual licensed under the GNU Affero General Public License version 3
 (AGPLv3) or the Redis Source Available License (RSAL).
 """
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/tests/test_log.c
+++ b/tests/test_log.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/tests/test_serialization.c
+++ b/tests/test_serialization.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/tests/test_util.c
+++ b/tests/test_util.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 

--- a/util.c
+++ b/util.c
@@ -3,7 +3,7 @@
  *
  * Copyright (c) 2020 Redis Labs
  *
- * RedisRaft is dual licensed under the GNU General Public License version 3
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
  * (AGPLv3) or the Redis Source Available License (RSAL).
  */
 


### PR DESCRIPTION
Update the references in source files which refer to the GPLv3,
whereas the LICENSE.agpl file refers to this source as licensed
under AGPLv3.

@yossigo thank you for dual-licensing this code with AGPLv3!