### PR TITLE
Log code cleanup.

### DIFF
--- a/redisraft.h
+++ b/redisraft.h
@@ -524,7 +524,6 @@ raft_index_t RaftLogCount(RaftLog *log);
 raft_index_t RaftLogFirstIdx(RaftLog *log);
 raft_index_t RaftLogCurrentIdx(RaftLog *log);
 long long int RaftLogRewrite(RedisRaftCtx *rr, const char *filename, raft_index_t last_idx, raft_term_t last_term);
-long long int RaftLogRewriteAppend(RedisRaftCtx *rr, RaftLog *target_log, raft_index_t from_idx);
 void RaftLogRemoveFiles(const char *filename);
 void RaftLogArchiveFiles(RedisRaftCtx *rr);
 RRStatus RaftLogRewriteSwitch(RedisRaftCtx *rr, RaftLog *new_log, unsigned long new_log_entries);


### PR DESCRIPTION
* Remove dead code related to old rewrite-by-child stratey that has been
eliminated by dd87c0d.
* We no longer support a NULL rr->log.