### PR TITLE
Tests: remove clutter.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/*.gcda
 **/*.gcno
 tests/tests_main
+tests/tmp/
 **/__pycache__
 **/*.swp
 .build/

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-log_file=tests.log
+log_file=tests/tmp/tests.log
 log_file_format=%(message)s
 log_file_level=debug
 optional_tests=

--- a/tests/test_log.c
+++ b/tests/test_log.c
@@ -38,6 +38,7 @@ static int teardown_log(void **state)
     RaftLog *log = (RaftLog *) *state;
     RaftLogClose(log);
     unlink(LOGNAME);
+    unlink(LOGNAME ".idx");
     return 0;
 }
 


### PR DESCRIPTION
Log temporary files are now created in tests/tmp.

Every launched instance gets a GUID and a dedicated directory, so the
keepfiles trick is no longer needed when preserving data files (we
simply leave the dirs as-is).
