### PR TITLE
Fix #2: Check node id uniqueness on join

### DIFF
--- a/docs/Flow.puml
+++ b/docs/Flow.puml
@@ -1,0 +1,52 @@
+# Sequence Diagrams
+
+The data flow diagrams are generated with [PlantUML](https://plantuml.com).
+
+To edit them interactively, it's easiest to use PyCharm (or any other JetBrains IDE)
+with the builtin support for Markdown with embedded PlantUML.
+
+## Editing with PyCharm
+
+[Follow the instructions](https://www.jetbrains.com/help/idea/markdown.html)
+to configure the Markdown editor with PlantUML support.
+
+## Rendering to SVG
+
+Make sure to install the PlantUML CLI (`brew install plantuml` on a Mac).
+
+Then, run:
+
+    plantuml -tsvg *.puml
+
+
+# CLUSTER JOIN
+
+@startuml
+
+actor user
+participant "Node 2" as node2
+participant "Node 1" as node1
+participant "Node 3" as node3
+
+activate node1
+activate node3
+
+user -> node2: RAFT.CLUSTER\nJOIN <node1>
+activate node2
+node2 -> node2: cmdRaftCluster\n  RaftReqSubmit\n    -> RR_CLUSTER_JOIN
+node2 -> node2: RaftReqHandleQueue\n  handleClusterJoin\n    -> state: REDIS_RAFT_JOINING
+node2 -> node1: HandleNodeStates\n  initiateNodeAdd\n      NodeConnect\n        sendNodeAddRequest\n          redisAsyncCommand\n            RAFT.NODE ADD 2 <node1>
+
+node1 -> node1: cmdRaftNode\n  hasNodeIdBeenUsed\n  RaftReqSubmit\n  -> RR_CFGCHANGE_ADDNODE
+node1 -> node1: RaftReqHandleQueue\n  handleCfgChange\n    raft_recv_entry\n      RAFT_LOGTYPE_ADD_NONVOTING_NODE
+node1 --> node2: <node_id> <dbid>
+
+node2 -> node2: handleNodeAddResponse\n  HandleClusterJoinCompleted\n    -> state: REDIS_RAFT_UP
+node1 -> node1: raftNotifyMembershipEvent\n  RAFT_MEMBERSHIP_ADD\n  RAFT_LOGTYPE_ADD_NONVOTING_NODE\n    addUsedNodeId(2)
+node1 -> node2: <<replicate log>>
+node1 -> node3: <<replicate log>>
+
+node2 -> node2: raftNotifyMembershipEvent\n  RAFT_MEMBERSHIP_ADD\n  RAFT_LOGTYPE_ADD_NONVOTING_NODE\n    addUsedNodeId(2)
+node3 -> node3: raftNotifyMembershipEvent\n  RAFT_MEMBERSHIP_ADD\n  RAFT_LOGTYPE_ADD_NONVOTING_NODE\n    addUsedNodeId(2)
+
+@enduml

--- a/node.c
+++ b/node.c
@@ -329,14 +329,16 @@ void handleNodeAddResponse(redisAsyncContext *c, void *r, void *privdata)
     } else if (reply->type != REDIS_REPLY_ARRAY || reply->elements != 2) {
         LOG_ERROR("RAFT.NODE ADD invalid reply.\n");
     } else {
-        LOG_INFO("Joined Raft cluster, node id: %lu, dbid: %.*s\n",
-                reply->element[0]->integer,
+        raft_node_id_t node_id = reply->element[0]->integer;
+
+        LOG_INFO("Joined Raft cluster, node id: %u, dbid: %.*s\n",
+                node_id,
                 reply->element[1]->len, reply->element[1]->str);
 
         strncpy(rr->snapshot_info.dbid, reply->element[1]->str, reply->element[1]->len);
         rr->snapshot_info.dbid[RAFT_DBID_LEN] = '\0';
 
-        rr->config->id = reply->element[0]->integer;
+        rr->config->id = node_id;
 
         HandleClusterJoinCompleted(rr);
     }

--- a/raft.c
+++ b/raft.c
@@ -1327,12 +1327,6 @@ static void handleCfgChange(RedisRaftCtx *rr, RaftReq *req)
         goto exit;
     }
 
-    if (req->type == RR_CFGCHANGE_REMOVENODE &&
-            req->r.cfgchange.id == raft_get_nodeid(rr->raft)) {
-        RedisModule_ReplyWithError(req->ctx, "ERR cannot remove leader node");
-        goto exit;
-    }
-
     entry = raft_entry_new(sizeof(req->r.cfgchange));
     entry->id = rand();
 

--- a/redisraft.h
+++ b/redisraft.h
@@ -133,6 +133,11 @@ typedef struct SnapshotCfgEntry {
     struct SnapshotCfgEntry *next;
 } SnapshotCfgEntry;
 
+typedef struct NodeIdEntry {
+    raft_node_id_t id;
+    struct NodeIdEntry *next;
+} NodeIdEntry;
+
 #define RAFT_DBID_LEN   32
 
 /* Snapshot metadata.  There is a single instance of this struct available at all times,
@@ -150,6 +155,7 @@ typedef struct RaftSnapshotInfo {
     raft_term_t last_applied_term;
     raft_index_t last_applied_idx;
     SnapshotCfgEntry *cfg;
+    NodeIdEntry *used_node_ids;  /* All node ids that are, or have ever been, part of this cluster */
 } RaftSnapshotInfo;
 
 /* State of the RAFT.CLUSTER JOIN operation.
@@ -430,7 +436,7 @@ typedef struct SnapshotResult {
 
 /* Command filtering re-entrancy counter handling.
  *
- * This mechanim tracks calls from Redis Raft into Redis and used by the
+ * This mechanism tracks calls from Redis Raft into Redis and used by the
  * command filtering hook to avoid raftizing commands as they're pushed from the log
  * to the FSM.
  *
@@ -496,6 +502,8 @@ RaftReq *RaftReqInit(RedisModuleCtx *ctx, enum RaftReqType type);
 RaftReq *RaftDebugReqInit(RedisModuleCtx *ctx, enum RaftDebugReqType type);
 void RaftReqSubmit(RedisRaftCtx *rr, RaftReq *req);
 void RaftReqHandleQueue(uv_async_t *handle);
+void addUsedNodeId(RedisRaftCtx *rr, raft_node_id_t node_id);
+bool hasNodeIdBeenUsed(RedisRaftCtx *rr, raft_node_id_t node_id);
 
 /* util.c */
 int RedisModuleStringToInt(RedisModuleString *str, int *value);

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -470,8 +470,8 @@ class Cluster(object):
     def add_initialized_node(self, node):
         self.nodes[node.id] = node
 
-    def add_node(self, raft_args=None, port=None, cluster_setup=True):
-        _id = self.next_id
+    def add_node(self, raft_args=None, port=None, cluster_setup=True, node_id=None):
+        _id = self.next_id if node_id is None else node_id
         self.next_id += 1
         if port is None:
             port = self.base_port + _id

--- a/tests/integration/test_membership.py
+++ b/tests/integration/test_membership.py
@@ -39,15 +39,14 @@ def test_node_join_redirects_to_leader(cluster):
     r3.wait_for_election()
 
 
-def test_leader_removal_not_allowed(cluster):
+def test_leader_removal_allowed(cluster):
     """
-    Leader node cannot be removed.
+    Leader node can be removed.
     """
 
     cluster.create(3)
     assert cluster.leader == 1
-    with raises(ResponseError, match='cannot remove leader'):
-        cluster.node(1).client.execute_command('RAFT.NODE', 'REMOVE', '1')
+    cluster.node(1).client.execute_command('RAFT.NODE', 'REMOVE', '1')
 
 
 def test_single_voting_change_enforced(cluster):


### PR DESCRIPTION
- We keep a list of all node ids that were ever members of the cluster
- When adding a node, this list is checked
- If the node id has ever been used, the node will not be joined