### PR TITLE
Fix API compatibility with Redis unstable.

### DIFF
--- a/snapshot.c
+++ b/snapshot.c
@@ -688,6 +688,15 @@ void rdbSaveSnapshotInfo(RedisModuleIO *rdb, void *value)
     ShardingInfoRDBSave(rdb);
 }
 
+/* Do nothing -- AOF should never be used with RedisRaft, but we have to specify
+ * a callback. */
+static void aofRewriteCallback(RedisModuleIO *io, RedisModuleString *key, void *value)
+{
+    UNUSED(io);
+    UNUSED(key);
+    UNUSED(value);
+}
+
 static void clearSnapshotInfo(void *value)
 {
 }
@@ -696,6 +705,7 @@ RedisModuleTypeMethods RedisRaftTypeMethods = {
     .version = REDISMODULE_TYPE_METHOD_VERSION,
     .rdb_load = rdbLoadSnapshotInfo,
     .rdb_save = rdbSaveSnapshotInfo,
+    .aof_rewrite = aofRewriteCallback,
     .free = clearSnapshotInfo
 };
 


### PR DESCRIPTION
The fix introduced by redis/redis#8670 makes it mandatory for modules to
specify persistence callbacks for registered data types.