### PR TITLE
commit_index can remain constant, just can't decrease, fix assert

### DIFF
--- a/tests/integration/test_fuzzing.py
+++ b/tests/integration/test_fuzzing.py
@@ -171,7 +171,7 @@ def test_proxy_stability_under_load(cluster, workload):
     while start + duration > time.time():
         time.sleep(2)
         new_commit_index = cluster.node(cluster.leader).commit_index()
-        assert new_commit_index > last_commit_index
+        assert new_commit_index >= last_commit_index
         last_commit_index = new_commit_index
 
     workload.stop()


### PR DESCRIPTION
current assertion code expected that commit_index would always increase on every loop, but it could remain constant.  the correct assertion is that it doesn't decrease in value.