### PR TITLE
Update config syntax.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,9 @@ endif
 .PHONY: all
 all: redisraft.so
 
-redisraft.so: deps $(OBJECTS)
+$(OBJECTS): | $(BUILDDIR)/.deps_installed
+
+redisraft.so: $(OBJECTS)
 	$(CC) $(LDFLAGS) -o $@ $(OBJECTS) $(LIBS)
 
 clean: clean-tests
@@ -137,9 +139,9 @@ integration-lcov-report:
 
 # ------------------------- Build dependencies -------------------------
 
-# FIXME: When modifying deps, this will prevent detecting picking up the changes.
-
-.PHONY: deps
-deps:
+$(BUILDDIR)/.deps_installed:
 	mkdir -p $(BUILDDIR)
+	mkdir -p $(BUILDDIR)/lib
+	mkdir -p $(BUILDDIR)/include
 	$(MAKE) -C deps PREFIX=$(BUILDDIR)
+	touch $(BUILDDIR)/.deps_installed

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To create a three-node cluster, start the first node:
     redis-server \
         --port 5001 --dbfilename raft1.rdb \
         --loadmodule <path-to>/redisraft.so \
-            raft-log-filename=raftlog1.db addr=localhost:5001
+            raft-log-filename raftlog1.db addr localhost:5001
 
 Then initialize the cluster:
 
@@ -57,7 +57,7 @@ Now start the second node, and run the `RAFT.CLUSTER JOIN` command to join it to
     redis-server \
         --port 5002 --dbfilename raft2.rdb \
         --loadmodule <path-to>/redisraft.so \
-            raft-log-filename=raftlog2.db addr=localhost:5002
+            raft-log-filename raftlog2.db addr localhost:5002
 
     redis-cli -p 5002 RAFT.CLUSTER JOIN localhost:5001
 
@@ -66,7 +66,7 @@ Now add the third node in the same way:
     redis-server \
         --port 5003 --dbfilename raft3.rdb \
         --loadmodule <path-to>/redisraft.so \
-            raft-log-filename=raftlog3.db addr=localhost:5003
+            raft-log-filename raftlog3.db addr localhost:5003
 
     redis-cli -p 5003 RAFT.CLUSTER JOIN localhost:5001
 

--- a/benchmark/redisraft_cluster.sh
+++ b/benchmark/redisraft_cluster.sh
@@ -71,10 +71,10 @@ for n in $(seq ${nodes}); do
     raftlog=redisraft${n}.db
     rm -f ${raftlog} ${raftlog}.idx
     ${redis} --loadmodule ${raftmodule} \
-        id=${n} \
-        addr=127.0.0.1:${p} \
-        raft-log-filename=redisraft${n}.db \
-        follower-proxy=yes \
+        id ${n} \
+        addr 127.0.0.1:${p} \
+        raft-log-filename redisraft${n}.db \
+        follower-proxy yes \
         ${module_args[@]} \
         --logfile redis${n}.log \
         --port ${p} \

--- a/config.c
+++ b/config.c
@@ -540,7 +540,7 @@ RRStatus ConfigParseArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
 
         if (i + 1 >= argc) {
             RedisModule_Log(ctx, REDIS_WARNING, "No argument specified for keyword '%.*s'",
-                kwlen, kw);
+                (int) kwlen, kw);
             return RR_ERROR;
         }
 

--- a/config.c
+++ b/config.c
@@ -535,22 +535,21 @@ RRStatus ConfigParseArgs(RedisModuleCtx *ctx, RedisModuleString **argv, int argc
     int i;
 
     for (i = 0; i < argc; i++) {
-        size_t arglen;
-        const char *arg = RedisModule_StringPtrLen(argv[i], &arglen);
+        size_t kwlen;
+        const char *kw = RedisModule_StringPtrLen(argv[i], &kwlen);
 
-        char argbuf[arglen + 1];
-        memcpy(argbuf, arg, arglen);
-        argbuf[arglen] = '\0';
-
-        const char *val = NULL;
-        char *eq = strchr(argbuf, '=');
-        if (eq != NULL) {
-            *eq = '\0';
-            val = eq + 1;
+        if (i + 1 >= argc) {
+            RedisModule_Log(ctx, REDIS_WARNING, "No argument specified for keyword '%.*s'",
+                kwlen, kw);
+            return RR_ERROR;
         }
 
+        size_t vallen;
+        const char *val = RedisModule_StringPtrLen(argv[i + 1], &vallen);
+        i++;
+
         char errbuf[256];
-        if (processConfigParam(argbuf, val, target, true,
+        if (processConfigParam(kw, val, target, true,
                     errbuf, sizeof(errbuf)) != RR_OK) {
             RedisModule_Log(ctx, REDIS_WARNING, "%s", errbuf);
             return RR_ERROR;

--- a/docs/Clustering.md
+++ b/docs/Clustering.md
@@ -209,10 +209,10 @@ of the same RedisRaft cluster should have the same configuration.
 
 For example, if you're creating three equal shards you may use:
 
-* `cluster-start-hslot=0` and `cluster-end-hslot=5460` for RedisRaft cluster 1.
-* `cluster-start-hslot=5461` and `cluster-end-hslot=10921` for RedisRaft cluster
+* `cluster-start-hslot 0` and `cluster-end-hslot 5460` for RedisRaft cluster 1.
+* `cluster-start-hslot 5461` and `cluster-end-hslot 10921` for RedisRaft cluster
   2.
-* `cluster-start-hslot=10922` and `cluster-end-hslot=16383` for RedisRaft
+* `cluster-start-hslot 10922` and `cluster-end-hslot 16383` for RedisRaft
   cluster 3.
 
 After creating the three clusters, you will need to configure each cluster to
@@ -243,7 +243,7 @@ configuration of 5 shards and also disable `fsync` to favor performance over
 safety. Our `config.sh` will look like so:
 
     NUM_GROUPS=5
-    ADDITIONAL_OPTIONS="raft-log-fsync=no"
+    ADDITIONAL_OPTIONS="raft-log-fsync no"
 
 Next, we execute `create-shard-groups` to set up our environment:
 

--- a/docs/Clustering.md
+++ b/docs/Clustering.md
@@ -53,7 +53,7 @@ We assume that RedisRaft is configured as follows:
 
 * Raftize is enabled.
 * Follower proxy is disabled.
-* Nodes have their addr= configuration set with an IP address and not a host
+* Nodes have their `addr` configuration set with an IP address and not a host
   name, to be compliant with Redis Cluster addressing.
 * The new `cluster-mode` parameter is set to `yes`.
 

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -177,7 +177,7 @@ RedisRaft nodes communicate with each other over the Redis port, using dedicated
 
 * The port Redis listens must not be blocked.
 * The address and port advertised by each node must be correct. RedisRaft infers this from the network interface's address and the port configured by Redis. In some
-  cases, this inference may be wrong (e.g., when multiple network interfaces are in use, on container network that involves NAT, etc.) In these cases, the `addr=` argument can be used to specify the correct address and port.
+  cases, this inference may be wrong (e.g., when multiple network interfaces are in use, on container network that involves NAT, etc.) In these cases, the `addr` argument can be used to specify the correct address and port.
 
 The `node<n>:` fields describe the various nodes as currently configured, including:
 

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -74,14 +74,14 @@ For example, here's how to start a Redis instance and configure RedisRaft via th
     redis-server \
         --bind 0.0.0.0 --port 5001 --dbfilename raft1.rdb \
         --loadmodule <path-to>/redisraft.so \
-            raft-log-filename=raftlog1.db addr=127.0.0.1:5001
+            raft-log-filename raftlog1.db addr 127.0.0.1:5001
 
 Note the following:
 * Here, the `--bind` and `--port` configure Redis to accept incoming connections on all network interfaces (by binding to `0.0.0.0`, disabling Redis protected mode) and to listen on port 5001.
 * The `--dbfilename` argument sets the name of the RDB file used for Raft snapshots.
 * The `--loadmodule` argument loads the RedisRaft module and accepts additional RedisRaft configuration directives (in this case, `raft-log-filename` and `addr`).
-* The module-specific `raft-log-filename=` argument set the name of the RedisRaft log file.
-* The module-specific `addr=` argument indicates how RedisRaft should advertise itself to other nodes. This is an optional argument. If not supplied, `addr` is inferred from the system's network interfaces and the Redis configuration. In this case we use `localhost`, as we're going to run our nodes as local processes for demonstration purposes. In a real production deployment, you want to run all of your nodes on separate machines / racks / availability zones, etc.
+* The module-specific `raft-log-filename` argument set the name of the RedisRaft log file.
+* The module-specific `addr` argument indicates how RedisRaft should advertise itself to other nodes. This is an optional argument. If not supplied, `addr` is inferred from the system's network interfaces and the Redis configuration. In this case we use `localhost`, as we're going to run our nodes as local processes for demonstration purposes. In a real production deployment, you want to run all of your nodes on separate machines / racks / availability zones, etc.
 
 ### Redis Configuration
 
@@ -134,7 +134,7 @@ The command to launch a new node should look familiar. Since we're running this 
     redis-server \
         --bind 0.0.0.0 --port 5002 --dbfilename raft2.rdb \
         --loadmodule <path-to>/redisraft.so \
-            raft-log-filename=raftlog2.db addr=127.0.0.1:5002
+            raft-log-filename raftlog2.db addr 127.0.0.1:5002
 
 As before, we can confirm the new node has also started in `uninitialized` state and is waiting to become part of a cluster.
 

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -249,7 +249,7 @@ This mode has several limitations:
 * It uses a single connection and therefore may introduce additional performance
   limitations.
 
-To enable Follower Proxy mode, specify `follower-proxy=yes` as a
+To enable Follower Proxy mode, specify `follower-proxy yes` as a
 configuration directive.
 
 ### Explicit Mode
@@ -272,7 +272,7 @@ On the other hand, performing the same operation without the `RAFT` command
 prefix causes it to execute locally **with no such guarantees** and, what's more, **without being replicated to other nodes**.
 
 To disable automatic interception and work in explicit mode, use the
-`raftize-all-commands=no` configuration directive.
+`raftize-all-commands no` configuration directive.
 
 > :warning: Unless you really know what you're doing, there's probably no reason
 > to use this mode.

--- a/docs/Using.md
+++ b/docs/Using.md
@@ -235,4 +235,4 @@ extremely inefficient as it would bloat the log with meaningless entries, since
 reads don't modify the dataset).
 
 It's possible to disable quorum reads to trade consistency and the
-risk of stale reads for better read performance. To disable quorum reads, use the `quorum-reads=no` configuration directive.
+risk of stale reads for better read performance. To disable quorum reads, use the `quorum-reads no` configuration directive.

--- a/jepsen/docker/control/Dockerfile
+++ b/jepsen/docker/control/Dockerfile
@@ -19,9 +19,9 @@ RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
     chmod +x /usr/bin/lein && \
     lein self-install
 
-RUN git clone https://github.com/jepsen-io/redis /jepsen && \
+ARG JEPSEN_REPO=https://github.com/jepsen-io/redis
+RUN git clone $JEPSEN_REPO /jepsen && \
     cd /jepsen && \
-    sed -i 's#git@github.com:\(.*\)\.git#https://github.com/\1#g' src/jepsen/redis/db.clj && \
     lein install
 
 ADD entrypoint.sh /entrypoint.sh

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -13,6 +13,7 @@ import os
 import os.path
 import subprocess
 import threading
+import itertools
 import random
 import logging
 import signal
@@ -84,7 +85,8 @@ class RedisRaft(object):
             if defkey not in raft_args:
                 raft_args[defkey] = defval
 
-        self.raft_args = ['{}={}'.format(k, v) for k, v in raft_args.items()]
+        self.raft_args = [str(x) for x in
+            itertools.chain.from_iterable(raft_args.items())]
         self.client = redis.Redis(host='localhost', port=self.port)
         self.client.connection_pool.connection_kwargs['parser_class'] = \
             redis.connection.PythonParser

--- a/utils/create-cluster/create-cluster
+++ b/utils/create-cluster/create-cluster
@@ -30,9 +30,9 @@ start_instance() {
         --dbfilename dump-${port}.rdb \
         --daemonize yes \
         --loadmodule ${REDISRAFT} \
-            raft-log-filename=raftlog-${port}.db \
-            addr=${HOST}:${port} \
-            cluster-mode=${CLUSTER_MODE} \
+            raft-log-filename raftlog-${port}.db \
+            addr ${HOST}:${port} \
+            cluster-mode ${CLUSTER_MODE} \
         ${ADDITIONAL_OPTIONS}
 }
 

--- a/utils/create-shard-groups/create-shard-groups
+++ b/utils/create-shard-groups/create-shard-groups
@@ -26,7 +26,7 @@ calc_hash_slot_config() {
         local end_slot=$((start_slot + slots_per_group - 1))
     fi
 
-    echo "cluster-start-hslot=$start_slot cluster-end-hslot=$end_slot"
+    echo "cluster-start-hslot $start_slot cluster-end-hslot $end_slot"
 }
 
 setup() {


### PR DESCRIPTION
Making the configuration interface a bit more readable by moving from `keyword=value` to `keyword value`. This has been addressed by #65.
