### PR TITLE
Remove raftize-all-commands settings.

### DIFF
--- a/benchmark/benchmark.json
+++ b/benchmark/benchmark.json
@@ -30,8 +30,7 @@
             "args": [
                 "--redis", "../redis/src/redis-server",
                 "--raftmodule", "redisraft.so",
-                "--modulearg", "raft-log-fsync=no",
-                "--modulearg", "raftize-all-commands=yes",
+                "--modulearg", "raft-log-fsync", "no",
                 "--nodes", "3"
             ]
         },
@@ -41,7 +40,6 @@
             "args": [
                 "--redis", "../redis/src/redis-server",
                 "--raftmodule", "redisraft.so",
-                "--modulearg", "raftize-all-commands=yes",
                 "--nodes", "3"
             ]
         }

--- a/common.c
+++ b/common.c
@@ -168,55 +168,6 @@ RRStatus checkRaftState(RedisRaftCtx *rr, RaftReq *req)
 
 }
 
-static void raftize_commands(RedisModuleCommandFilterCtx *filter)
-{
-    static char *excluded_commands[] = {
-        "auth",
-        "ping",
-        "save",
-        "module",
-        "raft",
-        "info",
-        "client",
-        "config",
-        "monitor",
-        "command",
-        "shutdown",
-        "quit",
-        NULL
-    };
-
-    /* If we're intercepting an RM_Call() processing a Raft entry,
-     * skip.
-     */
-    if (checkInRedisModuleCall()) {
-        return;
-    }
-
-    size_t cmdname_len;
-    const char *cmdname = RedisModule_StringPtrLen(
-            RedisModule_CommandFilterArgGet(filter, 0), &cmdname_len);
-
-    /* Don't process any RAFT.* command */
-    if (cmdname_len > 4 && strncasecmp(cmdname, "raft.", 5) == 0) {
-       return;
-    }
-
-    /* Don't process any excluded command */
-    char **c = excluded_commands;
-    while (*c != NULL) {
-        size_t len = strlen(*c);
-        if (cmdname_len == len && strncasecmp(cmdname, *c, len) == 0) {
-            return;
-        }
-        c++;
-    }
-
-    /* Prepend RAFT to the original command */
-    RedisModuleString *raft_str = RedisModule_CreateString(NULL, "RAFT", 4);
-    RedisModule_CommandFilterArgInsert(filter, 0, raft_str);
-}
-
 /* Parse a -MOVED reply and update the returned address in addr.
  * Both standard Redis Cluster reply (with the hash slot) or the simplified
  * RedisRaft reply are supported.
@@ -230,28 +181,4 @@ bool parseMovedReply(const char *str, NodeAddr *addr)
     /* Handle current or cluster-style -MOVED replies. */
     const char *p = strrchr(str, ' ');
     return NodeAddrParse(p + 1, strlen(p), addr);
-}
-
-
-RRStatus setRaftizeMode(RedisRaftCtx *rr, RedisModuleCtx *ctx, bool flag)
-{
-    /* Is it supported by Redis? */
-    if (!RedisModule_RegisterCommandFilter) {
-        /* No; but if flag is false no harm is done. */
-        return flag ? RR_ERROR : RR_OK;
-    }
-
-    /* Disable */
-    if (rr->registered_filter && !flag) {
-        RedisModule_UnregisterCommandFilter(ctx, rr->registered_filter);
-        rr->registered_filter = NULL;
-    } else if (!rr->registered_filter && flag) {
-        rr->registered_filter = RedisModule_RegisterCommandFilter(ctx, 
-                    raftize_commands, REDISMODULE_CMDFILTER_NOSELF);
-        if (!rr->registered_filter) {
-            return RR_ERROR;
-        }
-    }
-
-    return RR_OK;
 }

--- a/docs/Clustering.md
+++ b/docs/Clustering.md
@@ -51,7 +51,6 @@ this point (but are likely to be mandatory as we move on):
 
 We assume that RedisRaft is configured as follows:
 
-* Raftize is enabled.
 * Follower proxy is disabled.
 * Nodes have their `addr` configuration set with an IP address and not a host
   name, to be compliant with Redis Cluster addressing.
@@ -191,7 +190,6 @@ Use the following RedisRaft configuration:
 * The `cluster-start-hslot` and `cluster-end-hslot` parameters should be set to
   their default values, which indicate all slots are managed by the local
   cluster (no sharding).
-* The `raftize-all-commands` parameter should be set to `yes` (default).
 * The `follower-proxy` parameter should be set to `no` (default).
 
 ### Redis Cluster Mode with Sharding

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -327,20 +327,6 @@ Valid values for this setting are *yes* and *no*.
 
 *Default: yes*
 
-### `raftize-all-commands`
-
-Determines if RedisRaft automatically intercepts all Redis commands and processes them through the Raft Log.
-
-See [Explicit Mode](Development.md#explicit-mode) for more information.
-
-Valid values for this setting are *yes* and *no*.
-
-*Default: yes*
-
-> :bulb: Note that interception of all commands requires a Redis version that
-> supports the Redis Module Command Filtering API. Older versions of Redis will
-> fail to enable this.
-
 ### `cluster-mode`
 
 If enabled, RedisRaft operates in a Redis Cluster compatible mode (with or without sharding).

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -268,16 +268,6 @@ For example:
 This sends the `SET mykey myvalue` Redis command to RedisRaft, causing it
 to execute with the strongly-consistent guarantees.
 
-On the other hand, performing the same operation without the `RAFT` command
-prefix causes it to execute locally **with no such guarantees** and, what's more, **without being replicated to other nodes**.
-
-To disable automatic interception and work in explicit mode, use the
-`raftize-all-commands no` configuration directive.
-
-> :warning: Unless you really know what you're doing, there's probably no reason
-> to use this mode.
-
-
 TODO/Wish List
 --------------
 

--- a/redisraft.c
+++ b/redisraft.c
@@ -648,6 +648,17 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         }
 
         RedisModule_ReplySetArrayLength(ctx, len);
+    } else if (!strncasecmp(cmd, "exec", cmdlen) && argc > 3) {
+        size_t exec_cmd_len;
+        const char *exec_cmd = RedisModule_StringPtrLen(argv[2], &exec_cmd_len);
+
+        RedisModuleCallReply *reply = RedisModule_Call(ctx, exec_cmd, "v", &argv[3], argc - 3);
+        if (!reply) {
+            RedisModule_ReplyWithError(ctx, "Bad command or failed to execute");
+        } else {
+            RedisModule_ReplyWithCallReply(ctx, reply);
+            RedisModule_FreeCallReply(reply);
+        }
     } else {
         RedisModule_ReplyWithError(ctx, "ERR invalid debug subcommand");
     }

--- a/redisraft.c
+++ b/redisraft.c
@@ -696,6 +696,8 @@ static void interceptRedisCommands(RedisModuleCommandFilterCtx *filter)
             "monitor",
             "command",
             "shutdown",
+            "watch",
+            "unwatch",
             "quit",
             NULL
     };

--- a/redisraft.h
+++ b/redisraft.h
@@ -302,7 +302,6 @@ typedef struct RedisRaftConfig {
     char *raft_log_filename;    /* Raft log file name, derived from dbfilename */
     bool follower_proxy;        /* Do follower nodes proxy requests to leader? */
     bool quorum_reads;          /* Reads have to go through quorum */
-    bool raftize_all_commands;  /* Automatically pass all commands through Raft? */
     /* Tuning */
     int raft_interval;
     int request_timeout;

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -13,10 +13,7 @@ from pytest import raises
 
 
 def test_cross_slot_violation(cluster):
-    cluster.create(3, raft_args={
-        'cluster-mode': 'yes',
-        'raftize-all-commands': 'yes'})
-
+    cluster.create(3, raft_args={'cluster-mode': 'yes'})
     c = cluster.node(1).client
 
     # -CROSSSLOT on multi-key cross slot violation
@@ -38,7 +35,6 @@ def test_shard_group_sanity(cluster):
     # Create a cluster with just a single slot
     cluster.create(3, raft_args={
         'cluster-mode': 'yes',
-        'raftize-all-commands': 'yes',
         'cluster-start-hslot': '0',
         'cluster-end-hslot': '0'})
 
@@ -61,7 +57,6 @@ def test_shard_group_sanity(cluster):
 def test_shard_group_validation(cluster):
     cluster.create(3, raft_args={
         'cluster-mode': 'yes',
-        'raftize-all-commands': 'yes',
         'cluster-start-hslot': '0',
         'cluster-end-hslot': '1000'})
 
@@ -88,7 +83,6 @@ def test_shard_group_propagation(cluster):
     # Create a cluster with just a single slot
     cluster.create(3, raft_args={
         'cluster-mode': 'yes',
-        'raftize-all-commands': 'yes',
         'cluster-start-hslot': '0',
         'cluster-end-hslot': '1000'})
 
@@ -110,7 +104,6 @@ def test_shard_group_snapshot_propagation(cluster):
     # Create a cluster with just a single slot
     cluster.create(1, raft_args={
         'cluster-mode': 'yes',
-        'raftize-all-commands': 'yes',
         'cluster-start-hslot': '0',
         'cluster-end-hslot': '1000'})
 
@@ -135,7 +128,6 @@ def test_shard_group_snapshot_propagation(cluster):
 def test_shard_group_persistence(cluster):
     cluster.create(1, raft_args={
         'cluster-mode': 'yes',
-        'raftize-all-commands': 'yes',
         'cluster-start-hslot': '0',
         'cluster-end-hslot': '1000'})
 
@@ -173,13 +165,11 @@ def test_shard_group_persistence(cluster):
 def test_shard_group_linking(cluster_factory):
     cluster1 = cluster_factory().create(3, raft_args={
         'cluster-mode': 'yes',
-        'raftize-all-commands': 'yes',
         'cluster-start-hslot': '0',
         'cluster-end-hslot': '1',
         'shardgroup-update-interval': 500})
     cluster2 = cluster_factory().create(3, raft_args={
         'cluster-mode': 'yes',
-        'raftize-all-commands': 'yes',
         'cluster-start-hslot': '2',
         'cluster-end-hslot': '16383',
         'shardgroup-update-interval': 500})
@@ -228,12 +218,10 @@ def test_shard_group_linking_checks(cluster_factory):
     # linking should fail.
     cluster1 = cluster_factory().create(3, raft_args={
         'cluster-mode': 'yes',
-        'raftize-all-commands': 'yes',
         'cluster-start-hslot': '0',
         'cluster-end-hslot': '1'})
     cluster2 = cluster_factory().create(3, raft_args={
         'cluster-mode': 'yes',
-        'raftize-all-commands': 'yes',
         'cluster-start-hslot': '1',
         'cluster-end-hslot': '16383'})
 


### PR DESCRIPTION
Remove the `raftize-all-commands` settings and always assume it is enabled.

Fixes #85 