### PR TITLE
Redis Cluster protocol compatibility by default.

### DIFF
--- a/TODO
+++ b/TODO
@@ -28,18 +28,6 @@ There is already a `RAFT.SHARDGROUP GET` command so it could be as simple as:
 - It sends a `RAFT.SHARDGROUP GET` request and updates the local configuration
   if anything changed (i.e. new / removed nodes).
 
-## Protocol compatibility
-
-Need to decide if we adopt Redis Cluster as the standard protocol for RedisRaft
-and always stick to it.
-
-Pros:
-- It's standard
-
-Cons:
-- Cannot use more descriptive errors like `-NOLEADER`
-- Ambiguous hash slot in `-MOVED <slot> <host:port>` replies.
-
 ---
 
 Other stuff:

--- a/cluster.c
+++ b/cluster.c
@@ -411,12 +411,12 @@ static void establishShardGroupConn(Connection *conn)
     sg->use_conn_addr = false;
 }
 
-/* Called periodically by the main loop when cluster mode is enabled.
+/* Called periodically by the main loop when sharding is enabled.
  *
  * Currently we use this to iterate all shardgroups and trigger an
  * update for shardgroups that have not been updated recently.
  */
-void ClusterPeriodicCall(RedisRaftCtx *rr)
+void ShardingPeriodicCall(RedisRaftCtx *rr)
 {
     /* See if we have any shardgroups that need a refresh.
      */
@@ -751,8 +751,8 @@ void ShardingInfoReset(RedisRaftCtx *rr)
 
     /* Add our local mapping */
     ShardGroup sg = {
-        .start_slot = rr->config->cluster_start_hslot,
-        .end_slot = rr->config->cluster_end_hslot,
+        .start_slot = rr->config->sharding_start_hslot,
+        .end_slot = rr->config->sharding_end_hslot,
         .nodes_num = 0,
         .nodes = NULL
     };
@@ -796,55 +796,11 @@ RedisModuleCallReply *execCommandGetKeys(RedisRaftCtx *rr, RaftRedisCommand *cmd
 
 /* Compute the hash slot for a RaftRedisCommandArray list of commands and update
  * the entry.
- *
- * FIXME: This is a LEGACY VERSION based on 'COMMAND GETKEYS', which is here only
- * to allow running on Redis versions older than 6.0.9.
- */
-
-static RRStatus legacy_computeHashSlot(RedisRaftCtx *rr, RaftReq *req)
-{
-    int slot = -1;
-
-    RaftRedisCommandArray *cmds = &req->r.redis.cmds;
-    for (int i = 0; i < cmds->len; i++) {
-        RaftRedisCommand *cmd = cmds->commands[i];
-
-        /* Iterate command keys */
-        RedisModuleCallReply *reply = execCommandGetKeys(rr, cmd);
-        for (int j = 0; j < RedisModule_CallReplyLength(reply); j++) {
-            size_t key_len;
-            const char *key = RedisModule_CallReplyStringPtr(
-                    RedisModule_CallReplyArrayElement(reply, j), &key_len);
-            int thisslot = keyHashSlot(key, key_len);
-
-            if (slot == -1) {
-                /* First key */
-                slot = thisslot;
-            } else {
-                if (slot != thisslot) {
-                    RedisModule_FreeCallReply(reply);
-                    return RR_ERROR;
-                }
-            }
-        }
-        RedisModule_FreeCallReply(reply);
-    }
-
-    req->r.redis.hash_slot = slot;
-
-    return RR_OK;
-}
-
-/* Compute the hash slot for a RaftRedisCommandArray list of commands and update
- * the entry.
  */
 
 RRStatus computeHashSlot(RedisRaftCtx *rr, RaftReq *req)
 {
     int slot = -1;
-
-    if (RedisModule_GetCommandKeys == NULL)
-        return legacy_computeHashSlot(rr, req);
 
     RaftRedisCommandArray *cmds = &req->r.redis.cmds;
     for (int i = 0; i < cmds->len; i++) {
@@ -1008,11 +964,6 @@ void handleClusterCommand(RedisRaftCtx *rr, RaftReq *req)
          * with a synthetic client that no longer has the original argv.
          */
         RedisModule_ReplyWithError(req->ctx, "ERR wrong number of arguments for 'cluster' command");
-        goto exit;
-    }
-
-    if (!rr->config->cluster_mode) {
-        RedisModule_ReplyWithError(req->ctx, "ERR not operating in Redis Cluster compatible mode");
         goto exit;
     }
 

--- a/cluster.c
+++ b/cluster.c
@@ -761,39 +761,6 @@ void ShardingInfoReset(RedisRaftCtx *rr)
     RedisModule_Assert(ret == RR_OK);
 }
 
-/* Issue a COMMAND GETKEYS command to fetch the list of keys addressed
- * by the specified command.
- *
- * THIS IS DEPRECATED! Starting with Redis 6.0.9 a Module API call is available
- * to fetch this information, so this is left here just for a short while to
- * maintain backwards compatibility.
- *
- * Using this technique is significantly slower.
- */
-
-RedisModuleCallReply *execCommandGetKeys(RedisRaftCtx *rr, RaftRedisCommand *cmd)
-{
-    RedisModuleString *getkeys = RedisModule_CreateString(rr->ctx, "GETKEYS", 7);
-    RedisModuleString *argv[cmd->argc + 1];
-
-    argv[0] = getkeys;
-    memcpy(&argv[1], &cmd->argv[0], cmd->argc * sizeof(RedisModuleString *));
-
-    RedisModule_ThreadSafeContextLock(rr->ctx);
-    RedisModuleCallReply *reply = RedisModule_Call(
-            rr->ctx, "COMMAND", "v", argv, cmd->argc + 1);
-    RedisModule_ThreadSafeContextUnlock(rr->ctx);
-
-    RedisModule_FreeString(rr->ctx, getkeys);
-
-    if (RedisModule_CallReplyType(reply) != REDISMODULE_REPLY_ARRAY) {
-        RedisModule_FreeCallReply(reply);
-        reply = NULL;
-    }
-
-    return reply;
-}
-
 /* Compute the hash slot for a RaftRedisCommandArray list of commands and update
  * the entry.
  */

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -327,31 +327,31 @@ Valid values for this setting are *yes* and *no*.
 
 *Default: yes*
 
-### `cluster-mode`
+### `sharding`
 
-If enabled, RedisRaft operates in a Redis Cluster compatible mode (with or without sharding).
+If enabled, RedisRaft handles dataset sharding in a way that is similar to Redis Cluster.
 
-See [Clustering](Cluster.md) for more information on clustering and sharding.
+See [Sharding](Sharding.md) for more information on clustering and sharding.
 
 Valid values for this setting are *yes* and *no*.
 
 *Default: no*
 
-### `cluster-start-hslot`
+### `sharding-start-hslot`
 
-The first hash-slot assigned to this RedisRaft cluster, when `cluster-mode` is enabled.
+The first hash-slot assigned to this RedisRaft cluster, if sharding is used.
 
-See [Clustering](Cluster.md) for more information on clustering and sharding.
+See [Sharding](Sharding.md) for more information on sharding.
 
 Valid values for this setting are 0-16383.
 
 *Default: 0*
 
-### `cluster-end-hslot`
+### `sharding-end-hslot`
 
-The last hash-slot assigned to this RedisRaft cluster, when `cluster-mode` is enabled.
+The last hash-slot assigned to this RedisRaft cluster, when sharding is used.
 
-See [Clustering](Cluster.md) for more information on clustering and sharding.
+See [Sharding](Sharding.md) for more information on sharding.
 
 Valid values for this setting are 0-16383.
 

--- a/docs/TOC.md
+++ b/docs/TOC.md
@@ -4,5 +4,5 @@ Table Of Contents
 * [Introduction](Introduction.md): A high-level introduction to RedisRaft.
 * [Using RedisRaft](Using.md): A developer's guide to RedisRaft.
 * [Deployment Guide](Deployment.md): How to plan, deploy, configure, and manage a RedisRaft cluster.
-* [Clustering](Clustering.md): Clustering support for RedisRaft.
+* [Sharding](Sharding.md): Sharding support for RedisRaft.
 * [Developing RedisRaft](Development.md): More information about the design and implementation of the RedisRaft module.

--- a/docs/Using.md
+++ b/docs/Using.md
@@ -23,13 +23,15 @@ current leader.
 
 A client should be aware of the addresses of all cluster nodes, but cannot automatically determine which node is the leader at any given time. Sending a Redis command to a non-leader node results in a redirect response:
 
-    -MOVED <addr>:<port>
+    -MOVED <slot> <addr>:<port>
 
 The client is then expected to establish a connection with the specified node and re-send the command.
 
+This response is compatible with the Redis Cluster specification, although the `<slot>` argument may contain a zero value if sharding is not enabled.
+
 It is also possible for a RedisRaft cluster to have no leader. In this case, the cluster may be in the process of electing a new leader, or the cluster may be down due to a loss of quorum. If no leader is present, the client will receive an error response such as this one:
 
-    -NOLEADER No Raft leader
+    -CLUSTERDOWN No Raft leader
 
 In this case, the client should retry the operation at a later time.
 

--- a/redisraft.c
+++ b/redisraft.c
@@ -213,14 +213,8 @@ static int cmdRaft(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     RaftReq *req = RaftReqInit(ctx, RR_REDISCOMMAND);
     RaftRedisCommand *cmd = RaftRedisCommandArrayExtend(&req->r.redis.cmds);
 
-    /* When sharding is used, this will get computed and overwritten later on,
-     * but we still initialize to -1 in case sharding is not enabled.
-     */
-    req->r.redis.hash_slot = -1;
-
     cmd->argc = argc - 1;
     cmd->argv = RedisModule_Alloc((argc - 1) * sizeof(RedisModuleString *));
-
 
     int i;
     for (i = 0; i < argc - 1; i++) {

--- a/redisraft.h
+++ b/redisraft.h
@@ -314,9 +314,9 @@ typedef struct RedisRaftConfig {
     unsigned long raft_log_max_file_size;
     bool raft_log_fsync;
     /* Cluster mode */
-    bool cluster_mode;                  /* Are we running in a cluster compatible mode? */
-    int cluster_start_hslot;            /* First cluster hash slot */
-    int cluster_end_hslot;              /* Last cluster hash slot */
+    bool sharding;                      /* Are we running in a sharding configuration? */
+    int sharding_start_hslot;           /* First cluster hash slot */
+    int sharding_end_hslot;             /* Last cluster hash slot */
     int shardgroup_update_interval;     /* Milliseconds between shardgroup updates */
 } RedisRaftConfig;
 
@@ -724,7 +724,7 @@ RRStatus ShardingInfoAddShardGroup(RedisRaftCtx *rr, ShardGroup *new_sg);
 RRStatus ShardingInfoUpdateShardGroup(RedisRaftCtx *rr, ShardGroup *new_sg);
 void ShardingInfoRDBSave(RedisModuleIO *rdb);
 void ShardingInfoRDBLoad(RedisModuleIO *rdb);
-void ClusterPeriodicCall(RedisRaftCtx *rr);
+void ShardingPeriodicCall(RedisRaftCtx *rr);
 RRStatus ShardGroupAppendLogEntry(RedisRaftCtx *rr, ShardGroup *sg, int type, void *user_data);
 void handleShardGroupLink(RedisRaftCtx *rr, RaftReq *req);
 

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -521,9 +521,9 @@ class Cluster(object):
                     # in this case we need to do nothing
                     if new_leader in self.nodes:
                         self.leader = new_leader
-                elif str(err).startswith('NOLEADER'):
+                elif str(err).startswith('CLUSTERDOWN'):
                     if no_leader_first:
-                        LOG.info("-NOLEADER response received, will retry"
+                        LOG.info("-CLUSTERDOWN response received, will retry"
                                  " for %s seconds", self.noleader_timeout)
                         #no_leader_first = False
                     time.sleep(0.5)

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -13,7 +13,7 @@ from pytest import raises
 
 
 def test_cross_slot_violation(cluster):
-    cluster.create(3, raft_args={'cluster-mode': 'yes'})
+    cluster.create(3, raft_args={'sharding': 'yes'})
     c = cluster.node(1).client
 
     # -CROSSSLOT on multi-key cross slot violation
@@ -34,9 +34,9 @@ def test_cross_slot_violation(cluster):
 def test_shard_group_sanity(cluster):
     # Create a cluster with just a single slot
     cluster.create(3, raft_args={
-        'cluster-mode': 'yes',
-        'cluster-start-hslot': '0',
-        'cluster-end-hslot': '0'})
+        'sharding': 'yes',
+        'sharding-start-hslot': '0',
+        'sharding-end-hslot': '0'})
 
     c = cluster.node(1).client
 
@@ -56,9 +56,9 @@ def test_shard_group_sanity(cluster):
 
 def test_shard_group_validation(cluster):
     cluster.create(3, raft_args={
-        'cluster-mode': 'yes',
-        'cluster-start-hslot': '0',
-        'cluster-end-hslot': '1000'})
+        'sharding': 'yes',
+        'sharding-start-hslot': '0',
+        'sharding-end-hslot': '1000'})
 
     c = cluster.node(1).client
 
@@ -82,9 +82,9 @@ def test_shard_group_validation(cluster):
 def test_shard_group_propagation(cluster):
     # Create a cluster with just a single slot
     cluster.create(3, raft_args={
-        'cluster-mode': 'yes',
-        'cluster-start-hslot': '0',
-        'cluster-end-hslot': '1000'})
+        'sharding': 'yes',
+        'sharding-start-hslot': '0',
+        'sharding-end-hslot': '1000'})
 
     c = cluster.node(1).client
     assert c.execute_command(
@@ -103,9 +103,9 @@ def test_shard_group_propagation(cluster):
 def test_shard_group_snapshot_propagation(cluster):
     # Create a cluster with just a single slot
     cluster.create(1, raft_args={
-        'cluster-mode': 'yes',
-        'cluster-start-hslot': '0',
-        'cluster-end-hslot': '1000'})
+        'sharding': 'yes',
+        'sharding-start-hslot': '0',
+        'sharding-end-hslot': '1000'})
 
     c = cluster.node(1).client
     assert c.execute_command(
@@ -127,9 +127,9 @@ def test_shard_group_snapshot_propagation(cluster):
 
 def test_shard_group_persistence(cluster):
     cluster.create(1, raft_args={
-        'cluster-mode': 'yes',
-        'cluster-start-hslot': '0',
-        'cluster-end-hslot': '1000'})
+        'sharding': 'yes',
+        'sharding-start-hslot': '0',
+        'sharding-end-hslot': '1000'})
 
     n1 = cluster.node(1)
     assert n1.client.execute_command(
@@ -164,14 +164,14 @@ def test_shard_group_persistence(cluster):
 
 def test_shard_group_linking(cluster_factory):
     cluster1 = cluster_factory().create(3, raft_args={
-        'cluster-mode': 'yes',
-        'cluster-start-hslot': '0',
-        'cluster-end-hslot': '1',
+        'sharding': 'yes',
+        'sharding-start-hslot': '0',
+        'sharding-end-hslot': '1',
         'shardgroup-update-interval': 500})
     cluster2 = cluster_factory().create(3, raft_args={
-        'cluster-mode': 'yes',
-        'cluster-start-hslot': '2',
-        'cluster-end-hslot': '16383',
+        'sharding': 'yes',
+        'sharding-start-hslot': '2',
+        'sharding-end-hslot': '16383',
         'shardgroup-update-interval': 500})
 
     # Not expected to have coverage
@@ -217,13 +217,13 @@ def test_shard_group_linking_checks(cluster_factory):
     # Create clusters with overlapping hash slots,
     # linking should fail.
     cluster1 = cluster_factory().create(3, raft_args={
-        'cluster-mode': 'yes',
-        'cluster-start-hslot': '0',
-        'cluster-end-hslot': '1'})
+        'sharding': 'yes',
+        'sharding-start-hslot': '0',
+        'sharding-end-hslot': '1'})
     cluster2 = cluster_factory().create(3, raft_args={
-        'cluster-mode': 'yes',
-        'cluster-start-hslot': '1',
-        'cluster-end-hslot': '16383'})
+        'sharding': 'yes',
+        'sharding-start-hslot': '1',
+        'sharding-end-hslot': '16383'})
 
     # Link
     with raises(ResponseError, match='failed to link'):

--- a/utils/create-cluster/create-cluster
+++ b/utils/create-cluster/create-cluster
@@ -8,7 +8,7 @@ PORT=5000
 TIMEOUT=2000
 NODES=3
 LOGLEVEL=notice
-CLUSTER_MODE=yes
+SHARDING=yes
 ADDITIONAL_OPTIONS=""
 
 # You may want to put the above config parameters into config.sh in order to
@@ -32,7 +32,7 @@ start_instance() {
         --loadmodule ${REDISRAFT} \
             raft-log-filename raftlog-${port}.db \
             addr ${HOST}:${port} \
-            cluster-mode ${CLUSTER_MODE} \
+            sharding ${SHARDING} \
         ${ADDITIONAL_OPTIONS}
 }
 

--- a/utils/create-shard-groups/create-shard-groups
+++ b/utils/create-shard-groups/create-shard-groups
@@ -26,7 +26,7 @@ calc_hash_slot_config() {
         local end_slot=$((start_slot + slots_per_group - 1))
     fi
 
-    echo "cluster-start-hslot $start_slot cluster-end-hslot $end_slot"
+    echo "sharding-start-hslot $start_slot sharding-end-hslot $end_slot"
 }
 
 setup() {
@@ -39,7 +39,7 @@ setup() {
 REDIS_PATH=${REDIS_PATH}
 REDISRAFT=${REDISRAFT}
 PORT=5${group}00
-CLUSTER_MODE=yes
+SHARDING=yes
 ADDITIONAL_OPTIONS="$(calc_hash_slot_config $NUM_GROUPS $group) ${ADDITIONAL_OPTIONS}"
 _END_
         group=$((group + 1))


### PR DESCRIPTION
Adopt the Redis Cluster protocol as the only mode:
- Use `-MOVED` and `-CLUSTERDOWN` replies compatible with Redis Cluster.
- Always support `CLUSTER SLOTS`.

The old `cluster-mode` settings now only affects the sharding mechanism,
and is thus referred to as `sharding` from now on.

Also, removes the old get-keys implementation that was used before
RM_GetCommandKeys was added to the Redis Module API.