### PR TITLE
Update Jepsen CI Redis version.

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -29,5 +29,5 @@ jobs:
                   --test-count 20 \
                   --concurrency 4n \
                   --nemesis kill,pause,partition,member \
-                  --version 6.0.5 \
+                  --version 6.2.2 \
                   --raft-version ${{ steps.vars.outputs.git_sha }} | rg --passthrough 'Everything looks good'


### PR DESCRIPTION
Currently the test is broken because Redis 6.0.5 is no longer supported by RedisRaft.