### PR TITLE
add timeout to cluster joining

### DIFF
--- a/config.c
+++ b/config.c
@@ -18,6 +18,8 @@ static const char *CONF_ADDR = "addr";
 static const char *CONF_RAFT_INTERVAL = "raft-interval";
 static const char *CONF_REQUEST_TIMEOUT = "request-timeout";
 static const char *CONF_ELECTION_TIMEOUT = "election-timeout";
+static const char *CONF_CONNECTION_TIMEOUT = "connection-timeout";
+static const char *CONF_JOIN_TIMEOUT = "join-timeout";
 static const char *CONF_RAFT_RESPONSE_TIMEOUT = "raft-response-timeout";
 static const char *CONF_PROXY_RESPONSE_TIMEOUT = "proxy-response-timeout";
 static const char *CONF_RECONNECT_INTERVAL = "reconnect-interval";
@@ -119,6 +121,18 @@ static RRStatus processConfigParam(const char *keyword, const char *value,
         if (*errptr != '\0' || val <= 0)
             goto invalid_value;
         target->election_timeout = (int)val;
+    } else if (!strcmp(keyword, CONF_CONNECTION_TIMEOUT)) {
+        char *errptr;
+        unsigned long val = strtoul(value, &errptr, 10);
+        if (*errptr != '\0' || val <= 0)
+            goto invalid_value;
+        target->connection_timeout = (int)val;
+    } else if (!strcmp(keyword, CONF_JOIN_TIMEOUT)) {
+        char *errptr;
+        unsigned long val = strtoul(value, &errptr, 10);
+        if (*errptr != '\0' || val <= 0)
+            goto invalid_value;
+        target->join_timeout = (int)val;
     } else if (!strcmp(keyword, CONF_RAFT_RESPONSE_TIMEOUT)) {
         char *errptr;
         unsigned long val = strtoul(value, &errptr, 10);
@@ -295,6 +309,14 @@ void handleConfigGet(RedisModuleCtx *ctx, RedisRaftConfig *config, RedisModuleSt
         len++;
         replyConfigInt(ctx, CONF_ELECTION_TIMEOUT, config->election_timeout);
     }
+    if (stringmatch(pattern, CONF_CONNECTION_TIMEOUT, 1)) {
+        len++;
+        replyConfigInt(ctx, CONF_CONNECTION_TIMEOUT, config->connection_timeout);
+    }
+    if (stringmatch(pattern, CONF_JOIN_TIMEOUT, 1)) {
+        len++;
+        replyConfigInt(ctx, CONF_JOIN_TIMEOUT, config->join_timeout);
+    }
     if (stringmatch(pattern, CONF_RAFT_RESPONSE_TIMEOUT, 1)) {
         len++;
         replyConfigInt(ctx, CONF_RAFT_RESPONSE_TIMEOUT, config->raft_response_timeout);
@@ -366,6 +388,8 @@ void ConfigInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
     config->raft_interval = REDIS_RAFT_DEFAULT_INTERVAL;
     config->request_timeout = REDIS_RAFT_DEFAULT_REQUEST_TIMEOUT;
     config->election_timeout = REDIS_RAFT_DEFAULT_ELECTION_TIMEOUT;
+    config->connection_timeout = REDIS_RAFT_DEFAULT_CONNECTION_TIMEOUT;
+    config->join_timeout = REDIS_RAFT_DEFAULT_JOIN_TIMEOUT;
     config->reconnect_interval = REDIS_RAFT_DEFAULT_RECONNECT_INTERVAL;
     config->raft_response_timeout = REDIS_RAFT_DEFAULT_RAFT_RESPONSE_TIMEOUT;
     config->proxy_response_timeout = REDIS_RAFT_DEFAULT_PROXY_RESPONSE_TIMEOUT;

--- a/connection.c
+++ b/connection.c
@@ -63,8 +63,7 @@ Connection *ConnCreate(RedisRaftCtx *rr, void *privdata, ConnectionCallbackFunc 
     conn->free_callback = free_cb;
     conn->id = ++id;
 
-    conn->timeout = RedisModule_Calloc(1, sizeof(struct timeval));
-    conn->timeout->tv_usec = rr->config->connection_timeout;
+    conn->timeout.tv_usec = rr->config->connection_timeout;
 
     CONN_TRACE(conn, "Connection created.");
 
@@ -86,10 +85,6 @@ static void ConnFree(Connection *conn)
     CONN_TRACE(conn, "Connection freed.");
 
     LIST_REMOVE(conn, entries);
-
-    if (conn->timeout != NULL) {
-        RedisModule_Free(conn->timeout);
-    }
 
     RedisModule_Free(conn);
 }
@@ -224,9 +219,8 @@ static void handleResolved(uv_getaddrinfo_t *resolver, int status, struct addrin
 
     /* copy default options setup from redisAsyncConnect with support for timeout */
     redisOptions options = {0};
-    if (conn->timeout != NULL) {
-        options.timeout = conn->timeout;
-    }
+    options.timeout = &conn->timeout;
+
     REDIS_OPTIONS_SET_TCP(&options, conn->ipaddr, conn->addr.port);
 
     conn->rc = redisAsyncConnectWithOptions(&options);

--- a/connection.c
+++ b/connection.c
@@ -62,10 +62,9 @@ Connection *ConnCreate(RedisRaftCtx *rr, void *privdata, ConnectionCallbackFunc 
     conn->idle_callback = idle_cb;
     conn->free_callback = free_cb;
     conn->id = ++id;
-    if (rr->config->connection_timeout > 0) {
-        conn->timeout = RedisModule_Calloc(1, sizeof(struct timeval));
-        conn->timeout->tv_usec = rr->config->connection_timeout;
-    }
+
+    conn->timeout = RedisModule_Calloc(1, sizeof(struct timeval));
+    conn->timeout->tv_usec = rr->config->connection_timeout;
 
     CONN_TRACE(conn, "Connection created.");
 
@@ -249,8 +248,6 @@ static void handleResolved(uv_getaddrinfo_t *resolver, int status, struct addrin
     redisAsyncSetConnectCallback(conn->rc, handleConnected);
     redisAsyncSetDisconnectCallback(conn->rc, handleDisconnected);
 }
-
-
 
 RRStatus ConnConnect(Connection *conn, const NodeAddr *addr, ConnectionCallbackFunc connect_callback)
 {

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -267,6 +267,18 @@ This value should be sufficiently greater than `raft-interval` and
 
 *Default*: 1000
 
+### `connection-timeout`
+
+the number of milliseconds the cluster will wait for connections to other nodes to succeed before timing out.  We reccomend it be set if modifying `election-timeout` to be at least a 3x multiple of it.
+
+*Defaults*: 3000
+
+### `join-timeout`
+
+the number of seconds the node will continue to try and connect to the cluster using the provided and discovered nodes, looping through them until a connection is made or the timeout is reached.
+
+*Defaults*: 120
+
 ### `reconnect-interval`
 
 The number of milliseconds to wait to reconnect to a node when a node connection attempt fails.

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -269,13 +269,13 @@ This value should be sufficiently greater than `raft-interval` and
 
 ### `connection-timeout`
 
-the number of milliseconds the cluster will wait for connections to other nodes to succeed before timing out.  We reccomend it be set if modifying `election-timeout` to be at least a 3x multiple of it.
+The number of milliseconds the cluster will wait for connections to other nodes to succeed before timing out.
 
 *Defaults*: 3000
 
 ### `join-timeout`
 
-the number of seconds the node will continue to try and connect to the cluster using the provided and discovered nodes, looping through them until a connection is made or the timeout is reached.
+The number of seconds the node will continue to try and connect to the cluster using the provided and discovered nodes, looping through them until a connection is made, or the timeout is reached.
 
 *Defaults*: 120
 

--- a/join.c
+++ b/join.c
@@ -124,9 +124,7 @@ void joinIdleCallback(Connection *conn)
     time_t now;
     time(&now);
 
-    // This value should probably be dynamic and be considered a multiple of election time period? 2x?
-    // need to figure that out (i.e. perhaps     rr->config->election_timeout*2 ?
-    if (difftime(now, state->start) > 10) {
+    if (difftime(now, state->start) > rr->config->join_timeout) {
         LOG_ERROR("timed out trying to connect");
         ConnAsyncTerminate(conn);
         HandleClusterJoinFailed(rr);

--- a/join.c
+++ b/join.c
@@ -125,7 +125,7 @@ void joinIdleCallback(Connection *conn)
     time(&now);
 
     if (difftime(now, state->start) > rr->config->join_timeout) {
-        LOG_ERROR("timed out trying to connect");
+        LOG_ERROR("timed out trying to join cluster");
         ConnAsyncTerminate(conn);
         HandleClusterJoinFailed(rr);
         return;

--- a/raft.c
+++ b/raft.c
@@ -2010,6 +2010,8 @@ void HandleClusterJoinCompleted(RedisRaftCtx *rr)
     rr->state = REDIS_RAFT_UP;
 }
 
+void HandleClusterJoinFailed(RedisRaftCtx *rr) {}
+
 static void handleClientDisconnect(RedisRaftCtx *rr, RaftReq *req)
 {
     freeMultiExecState(req->r.client_disconnect.client_id);

--- a/redisraft.h
+++ b/redisraft.h
@@ -163,7 +163,7 @@ typedef struct Connection {
     long long last_connected_time;      /* Last connection time */
     unsigned long int connect_oks;      /* Successful connects */
     unsigned long int connect_errors;   /* Connection errors since last connection */
-    struct timeval *timeout;      /* Timeout to use if not null */
+    struct timeval *timeout;            /* Timeout to use if not null */
     void *privdata;                     /* User provided pointer */
 
     /* Connect callback is guaranteed after ConnConnect(); Callback should check

--- a/redisraft.h
+++ b/redisraft.h
@@ -163,7 +163,7 @@ typedef struct Connection {
     long long last_connected_time;      /* Last connection time */
     unsigned long int connect_oks;      /* Successful connects */
     unsigned long int connect_errors;   /* Connection errors since last connection */
-    struct timeval *timeout;            /* Timeout to use if not null */
+    struct timeval timeout;             /* Timeout to use if not null */
     void *privdata;                     /* User provided pointer */
 
     /* Connect callback is guaranteed after ConnConnect(); Callback should check

--- a/redisraft.h
+++ b/redisraft.h
@@ -615,6 +615,7 @@ void RaftRedisCommandArrayMove(RaftRedisCommandArray *target, RaftRedisCommandAr
 RRStatus RedisRaftInit(RedisModuleCtx *ctx, RedisRaftCtx *rr, RedisRaftConfig *config);
 RRStatus RedisRaftStart(RedisModuleCtx *ctx, RedisRaftCtx *rr);
 void HandleClusterJoinCompleted(RedisRaftCtx *rr);
+void HandleClusterJoinFailed(RedisRaftCtx *rr);
 
 void RaftReqFree(RaftReq *req);
 RaftReq *RaftReqInit(RedisModuleCtx *ctx, enum RaftReqType type);

--- a/redisraft.h
+++ b/redisraft.h
@@ -163,6 +163,7 @@ typedef struct Connection {
     long long last_connected_time;      /* Last connection time */
     unsigned long int connect_oks;      /* Successful connects */
     unsigned long int connect_errors;   /* Connection errors since last connection */
+    struct timeval *timeout;      /* Timeout to use if not null */
     void *privdata;                     /* User provided pointer */
 
     /* Connect callback is guaranteed after ConnConnect(); Callback should check
@@ -272,9 +273,11 @@ extern RedisRaftCtx redis_raft;
 extern raft_log_impl_t RaftLogImpl;
 
 #define REDIS_RAFT_DEFAULT_LOG_FILENAME             "redisraft.db"
-#define REDIS_RAFT_DEFAULT_INTERVAL                 100
-#define REDIS_RAFT_DEFAULT_REQUEST_TIMEOUT          200
-#define REDIS_RAFT_DEFAULT_ELECTION_TIMEOUT         1000
+#define REDIS_RAFT_DEFAULT_INTERVAL                 100 /* usec */
+#define REDIS_RAFT_DEFAULT_REQUEST_TIMEOUT          200 /* usec */
+#define REDIS_RAFT_DEFAULT_ELECTION_TIMEOUT         1000 /* usec */
+#define REDIS_RAFT_DEFAULT_CONNECTION_TIMEOUT       3000 /* usec */
+#define REDIS_RAFT_DEFAULT_JOIN_TIMEOUT             120 /* seconds */
 #define REDIS_RAFT_DEFAULT_RECONNECT_INTERVAL       100
 #define REDIS_RAFT_DEFAULT_PROXY_RESPONSE_TIMEOUT   10000
 #define REDIS_RAFT_DEFAULT_RAFT_RESPONSE_TIMEOUT    1000
@@ -308,6 +311,8 @@ typedef struct RedisRaftConfig {
     int raft_interval;
     int request_timeout;
     int election_timeout;
+    int connection_timeout;
+    int join_timeout;
     int reconnect_interval;
     int proxy_response_timeout;
     int raft_response_timeout;


### PR DESCRIPTION
add 2 config flags "connection-timeout" and "join-timeout" which control timeout on individual calls to hiredis as it tries to connect to individual nodes as well as how long the entire join operation can take in aggregate, before we error it out
