### PR TITLE
Shardgroup fixes.

### DIFF
--- a/cluster.c
+++ b/cluster.c
@@ -398,6 +398,7 @@ static void establishShardGroupConn(Connection *conn)
             sg->node_conn_idx = 0;
         }
         addr = &sg->nodes[sg->node_conn_idx++].addr;
+        sg->conn_addr = *addr;
     }
 
     LOG_DEBUG("Initiating shardgroup(%u) connection to %s:%u", sg->id, addr->host, addr->port);

--- a/cluster.c
+++ b/cluster.c
@@ -325,7 +325,7 @@ static void handleShardGroupResponse(redisAsyncContext *c, void *r, void *privda
         if (parseShardGroupReply(reply, &recv_sg) == RR_ERROR) {
             LOG_ERROR("RAFT.SHARDGROUP GET invalid reply.");
         } else {
-            LOG_INFO("Received shardgroup reply for %u!", sg->id);
+            LOG_DEBUG("Received shardgroup %u reply.", sg->id);
             sg->use_conn_addr = true;
             sg->last_updated = RedisModule_Milliseconds();
             sg->update_in_progress = false;

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -86,12 +86,13 @@ def cluster_factory(request):
     """
 
     created_clusters = []
-    cluster_args = {'base_port': 5000, 'base_id': 0}
+    cluster_args = {'base_port': 5000, 'base_id': 0, 'cluster_id': 0}
 
     def _create_cluster():
         _cluster = Cluster(create_config(request.config), **cluster_args)
         cluster_args['base_port'] += 100
         cluster_args['base_id'] += 100
+        cluster_args['cluster_id'] += 1
         created_clusters.append(_cluster)
         return _cluster
 

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -50,12 +50,13 @@ class PipeLogger(threading.Thread):
 
 class RedisRaft(object):
     def __init__(self, _id, port, config, raft_args=None,
-                 use_id_arg=True):
+                 use_id_arg=True, cluster_id=0):
         if raft_args is None:
             raft_args = {}
         else:
             raft_args = raft_args.copy()
         self.id = _id
+        self.cluster_id = cluster_id
         self.guid = str(uuid.uuid4())
         self.port = port
         self.executable = config.executable
@@ -149,9 +150,9 @@ class RedisRaft(object):
             executable=self.executable,
             args=args)
         self.stdout = PipeLogger(self.process.stdout,
-                                 '{}/stdout'.format(self.id))
+                                 'c{}/n{}/stdout'.format(self.cluster_id, self.id))
         self.stderr = PipeLogger(self.process.stderr,
-                                 '{}/stderr'.format(self.id))
+                                 'c{}/n{}/stderr'.format(self.cluster_id, self.id))
 
         if not verify:
             return
@@ -380,8 +381,9 @@ class RedisRaft(object):
 class Cluster(object):
     noleader_timeout = 10
 
-    def __init__(self, config, base_port=5000, base_id=0):
+    def __init__(self, config, base_port=5000, base_id=0, cluster_id=0):
         self.next_id = base_id + 1
+        self.cluster_id = cluster_id
         self.base_port = base_port
         self.nodes = {}
         self.leader = None
@@ -407,7 +409,8 @@ class Cluster(object):
         assert self.nodes == {}
         self.nodes = {x: RedisRaft(x, self.base_port + x,
                                    config=self.config,
-                                   raft_args=raft_args)
+                                   raft_args=raft_args,
+                                   cluster_id=self.cluster_id)
                       for x in range(1, node_count + 1)}
         self.next_id = node_count + 1
         for _id, node in self.nodes.items():

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -561,3 +561,20 @@ class Cluster(object):
             node.terminate()
         for node in self.nodes.values():
             node.start()
+
+
+def assert_after(func, timeout, retry_interval=0.5):
+    """
+    Call func() which is expected to perform certain assertions.
+    If assertions failed, retry with a retry_interval delay until
+    timeout has been reached -- at which point an exception is raised.
+    """
+    start_time = time.time()
+    while True:
+        try:
+            func()
+            break
+        except AssertionError:
+            if time.time() > start_time + timeout:
+                raise
+            time.sleep(retry_interval)


### PR DESCRIPTION
* Reduce logging verbosity of updates.
* Fix an issue resulting with `<redisraft> {conn:6} Failed to resolve '': unknown node or service` errors:

This PR is about storing the last attempted address in `conn_addr`. If the connection is successful, `use_conn_addr` is set to `true` so a subsequent reconnect will first attempt to reconnect to the same address before iterating nodes.

Before this fix `conn_addr` would not be initialized. Upon successful connection, `use_conn_addr` was set to true and if a reconnection was required it would use the uninitialized `conn_addr`.