### PR TITLE
convert cluster join to be synchronous

### DIFF
--- a/join.c
+++ b/join.c
@@ -63,7 +63,7 @@ static void handleNodeAddResponse(redisAsyncContext *c, void *r, void *privdata)
                 LOG_VERBOSE("Join redirected to leader: %s:%d", addr.host, addr.port);
                 NodeAddrListAddElement(&state->addr, &addr);
             }
-        } else if (strlen(reply->str) > 12 && !strcmp(reply->str, "CLUSTERDOWN ")) {
+        } else if (strlen(reply->str) > 12 && !strncmp(reply->str, "CLUSTERDOWN ", 12)) {
             LOG_ERROR("RAFT.NODE ADD error: %s, retrying.", reply->str);
         } else {
             LOG_ERROR("RAFT.NODE ADD failed: %s", reply->str);

--- a/join.c
+++ b/join.c
@@ -63,11 +63,11 @@ static void handleNodeAddResponse(redisAsyncContext *c, void *r, void *privdata)
                 LOG_VERBOSE("Join redirected to leader: %s:%d", addr.host, addr.port);
                 NodeAddrListAddElement(&state->addr, &addr);
             }
+        } else if (strlen(reply->str) > 12 && !strcmp(reply->str, "CLUSTERDOWN ")) {
+            LOG_ERROR("RAFT.NODE ADD error: %s, retrying.", reply->str);
         } else {
             LOG_ERROR("RAFT.NODE ADD failed: %s", reply->str);
-            if (!strcmp(reply->str, "node id has already been used in this cluster")) {
-                state->failed = true;
-            }
+            state->failed = true;
         }
     } else if (reply->type != REDIS_REPLY_ARRAY || reply->elements != 2) {
         LOG_ERROR("RAFT.NODE ADD invalid reply.");

--- a/raft.c
+++ b/raft.c
@@ -1961,32 +1961,7 @@ exit:
     RaftReqFree(req);
 }
 
-static void handleClusterJoin(RedisRaftCtx *rr, RaftReq *req)
-{
-    if (checkRaftNotLoading(rr, req) == RR_ERROR) {
-        goto exit;
-    }
-
-    if (rr->state != REDIS_RAFT_UNINITIALIZED) {
-        RedisModule_ReplyWithError(req->ctx, "ERR Already cluster member");
-        goto exit;
-    }
-
-    /* Create a Snapshot Info meta-key */
-    initializeSnapshotInfo(rr);
-
-    /* Initiate cluster join */
-    InitiateJoinCluster(rr, req->r.cluster_join.addr);
-
-    rr->state = REDIS_RAFT_JOINING;
-
-    RedisModule_ReplyWithSimpleString(req->ctx, "OK");
-
-exit:
-    RaftReqFree(req);
-}
-
-void HandleClusterJoinCompleted(RedisRaftCtx *rr)
+void HandleClusterJoinCompleted(RedisRaftCtx *rr, RaftReq *req)
 {
     /* Initialize Raft log.  We delay this operation as we want to create the log
      * with the proper dbid which is only received now.
@@ -2008,9 +1983,10 @@ void HandleClusterJoinCompleted(RedisRaftCtx *rr)
     }
 
     rr->state = REDIS_RAFT_UP;
-}
 
-void HandleClusterJoinFailed(RedisRaftCtx *rr) {}
+    RedisModule_ReplyWithSimpleString(req->ctx, "OK");
+    RaftReqFree(req);
+}
 
 static void handleClientDisconnect(RedisRaftCtx *rr, RaftReq *req)
 {

--- a/redisraft.h
+++ b/redisraft.h
@@ -616,8 +616,6 @@ void RaftRedisCommandArrayMove(RaftRedisCommandArray *target, RaftRedisCommandAr
 /* raft.c */
 RRStatus RedisRaftInit(RedisModuleCtx *ctx, RedisRaftCtx *rr, RedisRaftConfig *config);
 RRStatus RedisRaftStart(RedisModuleCtx *ctx, RedisRaftCtx *rr);
-
-
 void RaftReqFree(RaftReq *req);
 RaftReq *RaftReqInit(RedisModuleCtx *ctx, enum RaftReqType type);
 RaftReq *RaftDebugReqInit(RedisModuleCtx *ctx, enum RaftDebugReqType type);

--- a/redisraft.h
+++ b/redisraft.h
@@ -598,9 +598,6 @@ void NodeAddrListAddElement(NodeAddrListElement **head, const NodeAddr *addr);
 void NodeAddrListConcat(NodeAddrListElement **head, const NodeAddrListElement *other);
 void NodeAddrListFree(NodeAddrListElement *head);
 
-/* join.c */
-void InitiateJoinCluster(RedisRaftCtx *rr, const NodeAddrListElement *addr);
-
 /* node.c */
 Node *NodeCreate(RedisRaftCtx *rr, int id, const NodeAddr *addr);
 void HandleNodeStates(RedisRaftCtx *rr);
@@ -619,8 +616,7 @@ void RaftRedisCommandArrayMove(RaftRedisCommandArray *target, RaftRedisCommandAr
 /* raft.c */
 RRStatus RedisRaftInit(RedisModuleCtx *ctx, RedisRaftCtx *rr, RedisRaftConfig *config);
 RRStatus RedisRaftStart(RedisModuleCtx *ctx, RedisRaftCtx *rr);
-void HandleClusterJoinCompleted(RedisRaftCtx *rr);
-void HandleClusterJoinFailed(RedisRaftCtx *rr);
+
 
 void RaftReqFree(RaftReq *req);
 RaftReq *RaftReqInit(RedisModuleCtx *ctx, enum RaftReqType type);
@@ -735,5 +731,9 @@ void ShardingInfoRDBLoad(RedisModuleIO *rdb);
 void ShardingPeriodicCall(RedisRaftCtx *rr);
 RRStatus ShardGroupAppendLogEntry(RedisRaftCtx *rr, ShardGroup *sg, int type, void *user_data);
 void handleShardGroupLink(RedisRaftCtx *rr, RaftReq *req);
+
+/* join.c */
+void HandleClusterJoinCompleted(RedisRaftCtx *rr, RaftReq *pReq);
+void handleClusterJoin(RedisRaftCtx *rr, RaftReq *req);
 
 #endif  /* _REDISRAFT_H */

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -146,7 +146,7 @@ class RedisRaft(object):
         if extra_raft_args is None:
             extra_raft_args = []
         args = [self.executable] + self.args + self.raft_args + extra_raft_args
-        logging.info(f"starting node: args = {args}")
+        logging.info("starting node: args = %s".format(args))
         self.process = subprocess.Popen(
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             executable=self.executable,
@@ -417,7 +417,7 @@ class Cluster(object):
             if _id == 1:
                 node.init()
             else:
-                logging.info(f"{_id} joining")
+                logging.info("%s joining".format(_id))
                 node.join(['localhost:{}'.format(self.base_port + 1)])
         self.leader = 1
         self.node(1).wait_for_num_voting_nodes(len(self.nodes))

--- a/tests/integration/test_membership.py
+++ b/tests/integration/test_membership.py
@@ -167,7 +167,7 @@ def test_remove_and_rejoin_node_with_same_id_fails(cluster, use_snapshot):
     cluster.node(cluster.leader).wait_for_num_nodes(2)
 
     logger.info("Re-add node")
-    new_node = cluster.add_node(port=port, node_id=node_id)
+    new_node = cluster.add_node(port=port, node_id=node_id, expect_error="Failed to join cluster, check logs")
 
     logger.info("Waiting for timeout")
 

--- a/tests/integration/test_membership.py
+++ b/tests/integration/test_membership.py
@@ -167,13 +167,18 @@ def test_remove_and_rejoin_node_with_same_id_fails(cluster, use_snapshot):
     cluster.node(cluster.leader).wait_for_num_nodes(2)
 
     logger.info("Re-add node")
-    new_node = cluster.add_node(port=port, node_id=node_id, expect_error="Failed to join cluster, check logs")
+    failed_correctly = False
+    try:
+        new_node = cluster.add_node(port=port, node_id=node_id, single_run=True)
+        logger.info("Waiting for timeout")
 
-    logger.info("Waiting for timeout")
+        # TODO: Detect the error immediately (by inspecting the logs?) instead of retrying until timeout
+        with raises(RedisRaftTimeout):
+            new_node.wait_for_node_voting()
+    except RedisError as err:
+        failed_correctly = "Failed to join cluster, check logs" in str(err)
 
-    # TODO: Detect the error immediately (by inspecting the logs?) instead of retrying until timeout
-    with raises(RedisRaftTimeout):
-        new_node.wait_for_node_voting()
+    assert failed_correctly, "didn't fail as expected"
 
 
 def test_node_history_with_same_address(cluster):

--- a/tests/integration/test_membership.py
+++ b/tests/integration/test_membership.py
@@ -167,18 +167,8 @@ def test_remove_and_rejoin_node_with_same_id_fails(cluster, use_snapshot):
     cluster.node(cluster.leader).wait_for_num_nodes(2)
 
     logger.info("Re-add node")
-    failed_correctly = False
-    try:
+    with raises(ResponseError, match='Failed to join'):
         new_node = cluster.add_node(port=port, node_id=node_id, single_run=True)
-        logger.info("Waiting for timeout")
-
-        # TODO: Detect the error immediately (by inspecting the logs?) instead of retrying until timeout
-        with raises(RedisRaftTimeout):
-            new_node.wait_for_node_voting()
-    except RedisError as err:
-        failed_correctly = "Failed to join cluster, check logs" in str(err)
-
-    assert failed_correctly, "didn't fail as expected"
 
 
 def test_node_history_with_same_address(cluster):


### PR DESCRIPTION
instead of returning an immediate OK, will only return an OK (or ERR) when the join completes or times out.

as join can now fail, modify tests to handle that situation