### PR TITLE
Fix error message for -> RAFT.CONFIG SET loglevel <option>

### DIFF
--- a/config.c
+++ b/config.c
@@ -180,7 +180,7 @@ static RRStatus processConfigParam(const char *keyword, const char *value,
         int loglevel = parseLogLevel(value);
         if (loglevel < 0) {
             snprintf(errbuf, errbuflen-1,
-                     "invalid '%s', must be 'error', 'info', 'verbose', 'debug' or 'trace'", keyword);
+                     "invalid '%s', must be 'error', 'info', 'verbose', 'debug'", keyword);
             return RR_ERROR;
         }
         redis_raft_loglevel = loglevel;

--- a/config.c
+++ b/config.c
@@ -180,7 +180,7 @@ static RRStatus processConfigParam(const char *keyword, const char *value,
         int loglevel = parseLogLevel(value);
         if (loglevel < 0) {
             snprintf(errbuf, errbuflen-1,
-                     "invalid '%s', must be 'error', 'info', 'verbose', 'debug'", keyword);
+                     "invalid '%s', must be 'error', 'info', 'verbose' or 'debug'", keyword);
             return RR_ERROR;
         }
         redis_raft_loglevel = loglevel;


### PR DESCRIPTION
* When setting the `loglevel` config option for redisraft module with an invalid argument, we get below error message:
```
127.0.0.1:5001> RAFT.CONFIG SET loglevel invalid
(error) ERR invalid 'loglevel', must be 'error', 'info', 'verbose', 'debug' or 'trace'
```

* But, when passing the `trace` argument to the same command, the error message still gets thrown.
```
127.0.0.1:5001> RAFT.CONFIG SET loglevel trace
(error) ERR invalid 'loglevel', must be 'error', 'info', 'verbose', 'debug' or 'trace'
```

It seems there is no such `loglevel` argument called `trace`.

The possible log-levels defined are:
```
-> redisraft/config.c

static char *loglevels[] = {
    "error",
    "info",
    "verbose",
    "debug",
    NULL
};
```

This PR corrects the message by removing the stale/wrong argument provided in the error string literal.