### PR TITLE
Prepare RedisRaft to run Redis test suite.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ OBJECTS = \
 	  serialization.o \
 	  cluster.o \
 	  crc16.o \
-	  connection.o
+	  connection.o \
+	  commands.o
 
 ifeq ($(COVERAGE),1)
 CFLAGS += -fprofile-arcs -ftest-coverage

--- a/commands.c
+++ b/commands.c
@@ -1,0 +1,172 @@
+/*
+ * This file is part of RedisRaft.
+ *
+ * Copyright (c) 2021 Redis Labs
+ *
+ * RedisRaft is dual licensed under the GNU Affero General Public License version 3
+ * (AGPLv3) or the Redis Source Available License (RSAL).
+ */
+/* ------------------------------------ Command Classification ------------------------------------ */
+
+#include <string.h>
+#include <ctype.h>
+#include "redisraft.h"
+
+static RedisModuleDict *commandSpecDict = NULL;
+
+RRStatus CommandSpecInit(RedisModuleCtx *ctx)
+{
+    static CommandSpec commands[] = {
+            /* Core Redis Commands */
+            { "get",                    CMD_SPEC_READONLY },
+            { "strlen",                 CMD_SPEC_READONLY },
+            { "exists",                 CMD_SPEC_READONLY },
+            { "getbit",                 CMD_SPEC_READONLY },
+            { "getrange",               CMD_SPEC_READONLY },
+            { "substr",                 CMD_SPEC_READONLY },
+            { "mget",                   CMD_SPEC_READONLY },
+            { "llen",                   CMD_SPEC_READONLY },
+            { "lindex",                 CMD_SPEC_READONLY },
+            { "lrange",                 CMD_SPEC_READONLY },
+            { "scard",                  CMD_SPEC_READONLY },
+            { "sismember",              CMD_SPEC_READONLY },
+            { "srandmember",            CMD_SPEC_READONLY },
+            { "sinter",                 CMD_SPEC_READONLY },
+            { "sunion",                 CMD_SPEC_READONLY },
+            { "sdiff",                  CMD_SPEC_READONLY },
+            { "smembers",               CMD_SPEC_READONLY },
+            { "sscan",                  CMD_SPEC_READONLY },
+            { "zrange",                 CMD_SPEC_READONLY },
+            { "zrangebyscore",          CMD_SPEC_READONLY },
+            { "zrevrangebyscore",       CMD_SPEC_READONLY },
+            { "zrangebylex",            CMD_SPEC_READONLY },
+            { "zrevrangebylex",         CMD_SPEC_READONLY },
+            { "zcount",                 CMD_SPEC_READONLY },
+            { "zlexcount",              CMD_SPEC_READONLY },
+            { "zrevrange",              CMD_SPEC_READONLY },
+            { "zcard",                  CMD_SPEC_READONLY },
+            { "zscore",                 CMD_SPEC_READONLY },
+            { "zrank",                  CMD_SPEC_READONLY },
+            { "zrevrank",               CMD_SPEC_READONLY },
+            { "zscan",                  CMD_SPEC_READONLY },
+            { "hmget",                  CMD_SPEC_READONLY },
+            { "hlen",                   CMD_SPEC_READONLY },
+            { "hstrlen",                CMD_SPEC_READONLY },
+            { "hkeys",                  CMD_SPEC_READONLY },
+            { "hvals",                  CMD_SPEC_READONLY },
+            { "hgetall",                CMD_SPEC_READONLY },
+            { "hexists",                CMD_SPEC_READONLY },
+            { "hscan",                  CMD_SPEC_READONLY },
+            { "randomkey",              CMD_SPEC_READONLY },
+            { "keys",                   CMD_SPEC_READONLY },
+            { "scan",                   CMD_SPEC_READONLY },
+            { "dbsize",                 CMD_SPEC_READONLY },
+            { "ttl",                    CMD_SPEC_READONLY },
+            { "bitcount",               CMD_SPEC_READONLY },
+            { "georadius_ro",           CMD_SPEC_READONLY },
+            { "georadiusbymember_ro",   CMD_SPEC_READONLY },
+            { "geohash",                CMD_SPEC_READONLY },
+            { "geopos",                 CMD_SPEC_READONLY },
+            { "geodist",                CMD_SPEC_READONLY },
+            { "pfcount",                CMD_SPEC_READONLY },
+            { "sync",                   CMD_SPEC_UNSUPPORTED },
+            { "psync",                  CMD_SPEC_UNSUPPORTED },
+            { "reset",                  CMD_SPEC_UNSUPPORTED },
+            { "bgrewriteaof",           CMD_SPEC_UNSUPPORTED },
+            { "slaveof",                CMD_SPEC_UNSUPPORTED },
+            { "replicaof",              CMD_SPEC_UNSUPPORTED },
+            { "debug",                  CMD_SPEC_UNSUPPORTED },
+            { "auth",                   CMD_SPEC_DONT_INTERCEPT },
+            { "ping",                   CMD_SPEC_DONT_INTERCEPT },
+            { "save",                   CMD_SPEC_DONT_INTERCEPT },
+            { "bgsave",                 CMD_SPEC_DONT_INTERCEPT },
+            { "module",                 CMD_SPEC_DONT_INTERCEPT },
+            { "info",                   CMD_SPEC_DONT_INTERCEPT },
+            { "client",                 CMD_SPEC_DONT_INTERCEPT },
+            { "config",                 CMD_SPEC_DONT_INTERCEPT },
+            { "monitor",                CMD_SPEC_DONT_INTERCEPT },
+            { "command",                CMD_SPEC_DONT_INTERCEPT },
+            { "shutdown",               CMD_SPEC_DONT_INTERCEPT },
+            { "watch",                  CMD_SPEC_DONT_INTERCEPT },
+            { "unwatch",                CMD_SPEC_DONT_INTERCEPT },
+            { "quit",                   CMD_SPEC_DONT_INTERCEPT },
+            { "subscribe",              CMD_SPEC_DONT_INTERCEPT },
+            { "psubscribe",             CMD_SPEC_DONT_INTERCEPT },
+            { "unsubscribe",            CMD_SPEC_DONT_INTERCEPT },
+            { "punsubscribe",           CMD_SPEC_DONT_INTERCEPT },
+            { "publish",                CMD_SPEC_DONT_INTERCEPT },
+            { "pubsub",                 CMD_SPEC_DONT_INTERCEPT },
+            { "slowlog",                CMD_SPEC_DONT_INTERCEPT },
+            { "acl",                    CMD_SPEC_DONT_INTERCEPT },
+
+            /* RedisRaft Commands */
+            { "raft",                   CMD_SPEC_DONT_INTERCEPT },
+            { "raft.entry",             CMD_SPEC_DONT_INTERCEPT },
+            { "raft.config",            CMD_SPEC_DONT_INTERCEPT },
+            { "raft.cluster",           CMD_SPEC_DONT_INTERCEPT },
+            { "raft.shardgroup",        CMD_SPEC_DONT_INTERCEPT },
+            { "raft.node",              CMD_SPEC_DONT_INTERCEPT },
+            { "raft.ae",                CMD_SPEC_DONT_INTERCEPT },
+            { "raft.requestvote",       CMD_SPEC_DONT_INTERCEPT },
+            { "raft.loadsnapshot",      CMD_SPEC_DONT_INTERCEPT },
+            { "raft.debug",             CMD_SPEC_DONT_INTERCEPT },
+            { "raft.info",              CMD_SPEC_DONT_INTERCEPT },
+            { NULL,                     0 }
+    };
+
+    commandSpecDict = RedisModule_CreateDict(ctx);
+    for (int i = 0; commands[i].name != NULL; i++) {
+        if (RedisModule_DictSetC(commandSpecDict, commands[i].name,
+            strlen(commands[i].name), &commands[i]) != REDISMODULE_OK) {
+                RedisModule_FreeDict(ctx, commandSpecDict);
+                return RR_ERROR;
+        }
+    }
+
+    return RR_OK;
+}
+
+/* Look up the specified command in the command spec table and return the
+ * CommandSpec associated with it, or NULL.
+ */
+const CommandSpec *CommandSpecGet(const RedisModuleString *cmd)
+{
+    size_t cmd_len;
+    const char *cmd_str = RedisModule_StringPtrLen(cmd, &cmd_len);
+    char buf[64];
+    char *lcmd = buf;
+
+    if (cmd_len > sizeof(buf)) {
+        lcmd = RedisModule_Alloc(cmd_len);
+    }
+
+    for (size_t i = 0; i < cmd_len; i++) {
+        lcmd[i] = (char) tolower(cmd_str[i]);
+    }
+
+    CommandSpec *cs = RedisModule_DictGetC(commandSpecDict, lcmd, cmd_len, NULL);
+    if (lcmd != buf) {
+        RedisModule_Free(lcmd);
+    }
+
+    return cs;
+}
+
+/* For a given RaftRedisCommandArray, return a flags value that represents
+ * the aggregate flags of all commands. If a command is not listed in the
+ * command table, use default_flags.
+ */
+unsigned int CommandSpecGetAggregateFlags(RaftRedisCommandArray *array, unsigned int default_flags)
+{
+    unsigned int flags = 0;
+    for (int i = 0; i < array->len; i++) {
+        const CommandSpec *cs = CommandSpecGet(array->commands[i]->argv[0]);
+        if (cs) {
+            flags |= cs->flags;
+        } else {
+            flags |= default_flags;
+        }
+    }
+
+    return flags;
+}

--- a/raft.c
+++ b/raft.c
@@ -208,7 +208,7 @@ static void executeRaftRedisCommandArray(RaftRedisCommandArray *array,
             if (reply) {
                 RedisModule_ReplyWithCallReply(reply_ctx, reply);
             } else {
-                RedisModule_ReplyWithError(reply_ctx, "ERR Unknown command/arguments");
+                RedisModule_ReplyWithError(reply_ctx, "ERR Unknown command or wrong number of arguments");
             }
         }
 

--- a/redisraft.h
+++ b/redisraft.h
@@ -553,6 +553,20 @@ typedef struct SnapshotResult {
     char err[256];
 } SnapshotResult;
 
+/* Entry type for the internal command table used by RedisRaft,
+ * used to determine how different intercepted Redis commands are
+ * handled.
+ */
+typedef struct {
+    char *name;                 /* Command name */
+    unsigned int flags;         /* Command flags, see CMD_SPEC_* */
+} CommandSpec;
+
+#define CMD_SPEC_READONLY       (1<<1)      /* Command is a read-only command */
+#define CMD_SPEC_WRITE          (1<<2)      /* Command is a (potentially) write command */
+#define CMD_SPEC_UNSUPPORTED    (1<<3)      /* Command is not supported, should be rejected */
+#define CMD_SPEC_DONT_INTERCEPT (1<<4)      /* Command should not be intercepted to RAFT */
+
 /* Command filtering re-entrancy counter handling.
  *
  * This mechanism tracks calls from Redis Raft into Redis and used by the
@@ -746,5 +760,10 @@ void handleShardGroupLink(RedisRaftCtx *rr, RaftReq *req);
 /* join.c */
 void HandleClusterJoinCompleted(RedisRaftCtx *rr, RaftReq *pReq);
 void handleClusterJoin(RedisRaftCtx *rr, RaftReq *req);
+
+/* commands.c */
+RRStatus CommandSpecInit(RedisModuleCtx *ctx);
+unsigned int CommandSpecGetAggregateFlags(RaftRedisCommandArray *array, unsigned int default_flags);
+const CommandSpec *CommandSpecGet(const RedisModuleString *cmd);
 
 #endif  /* _REDISRAFT_H */

--- a/tests/redis-suite/run.sh
+++ b/tests/redis-suite/run.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+REDIS_DIR=${REDIS_DIR:-${PWD}/../redis}
+
+export REDIS_SERVER_BINARY=${REDIS_DIR}/src/redis-server
+export REDIS_CLI_BINARY=${REDIS_DIR}/src/redis-cli
+export ADDITIONAL_OPTIONS="raft-log-fsync no"
+
+setup() {
+    pushd ./utils/create-cluster
+    ./create-cluster stop
+    ./create-cluster clean
+    ./create-cluster start
+    ./create-cluster create
+    popd
+}
+
+teardown() {
+    pushd ./utils/create-cluster
+    ./create-cluster stop
+    popd
+}
+
+run_tests() {
+    local tests_dir=${PWD}/tests/redis-suite
+    pushd $REDIS_DIR
+    ./runtest \
+        --host 127.0.0.1 \
+        --port 5001 \
+        --cluster-mode \
+        --singledb \
+        --ignore-encoding \
+        --ignore-digest \
+        --skipfile ${tests_dir}/skip.txt \
+        --tags -needs:repl \
+        --tags -needs:debug \
+        --tags -needs:save \
+        --tags -needs:reset \
+        --tags -needs:config-maxmemory \
+        --tags -pause \
+        --tags -tracking \
+        $*
+    popd
+}
+
+# Make sure we're running from the right place
+if [ ! -f tests/redis-suite/run.sh ]; then
+    echo Please run this script from the top level directory.
+    exit 1
+fi
+
+setup
+run_tests $*
+teardown

--- a/tests/redis-suite/skip.txt
+++ b/tests/redis-suite/skip.txt
@@ -1,0 +1,110 @@
+-- Blocking commands not supported
+BLPOP, LPUSH + DEL should not awake blocked client
+BLPOP, LPUSH + DEL + SET should not awake blocked client
+BLPOP with same key multiple times should work (issue #801)
+MULTI/EXEC is isolated from the point of view of BLPOP
+BLPOP with variadic LPUSH
+BRPOPLPUSH with zero timeout should block indefinitely
+BLMOVE left left with zero timeout should block indefinitely
+BLMOVE left right with zero timeout should block indefinitely
+BLMOVE right left with zero timeout should block indefinitely
+BLMOVE right right with zero timeout should block indefinitely
+BLMOVE (left, left) with a client BLPOPing the target list
+BLMOVE (left, right) with a client BLPOPing the target list
+BLMOVE (right, left) with a client BLPOPing the target list
+BLMOVE (right, right) with a client BLPOPing the target list
+BRPOPLPUSH with wrong destination type
+BRPOPLPUSH maintains order of elements after failure
+BRPOPLPUSH with multiple blocked clients
+Linked LMOVEs
+PUSH resulting from BRPOPLPUSH affect WATCH
+BLPOP when new key is moved into place
+BLPOP when result key is created by SORT..STORE
+BLPOP: with single empty list argument
+BLPOP: with non-integer timeout
+BLPOP: arguments are empty
+BRPOP: with single empty list argument
+BRPOP: with non-integer timeout
+BRPOP: arguments are empty
+client unblock tests
+BZPOPMIN, ZADD + DEL should not awake blocked client
+BZPOPMIN, ZADD + DEL + SET should not awake blocked client
+BZPOPMIN with same key multiple times should work
+MULTI/EXEC is isolated from the point of view of BZPOPMIN
+BZPOPMIN with variadic ZADD
+BZPOPMIN with zero timeout should block indefinitely
+BZPOPMIN, ZADD + DEL should not awake blocked client
+BZPOPMIN, ZADD + DEL + SET should not awake blocked client
+BZPOPMIN with same key multiple times should work
+MULTI/EXEC is isolated from the point of view of BZPOPMIN
+BZPOPMIN with variadic ZADD
+BZPOPMIN with zero timeout should block indefinitely
+
+-- RESP3 Not supported
+-- See: https://github.com/RedisLabs/redisraft/issues/100
+ZINTER RESP3 - ziplist
+Basic ZPOP - ziplist RESP3
+ZPOP with count - ziplist RESP3
+ZINTER RESP3 - skiplist
+Basic ZPOP - skiplist RESP3
+ZPOP with count - skiplist RESP3
+ZRANGESTORE RESP3
+ZRANDMEMBER with RESP3
+HRANDFIELD with RESP3
+
+-- Streams not supported
+-- See: https://github.com/RedisLabs/redisraft/issues/59
+Blocking XREAD waiting new data
+XREAD: XADD + DEL should not awake client
+XREAD: XADD + DEL + LPUSH should not awake client
+XREAD with same stream name multiple times should work
+XREAD + multiple XADD inside transaction
+XREAD streamID edge (blocking)
+XGROUP DESTROY should unblock XREADGROUP with -NOGROUP
+RENAME can unblock XREADGROUP with data
+RENAME can unblock XREADGROUP with -NOGROUP
+
+-- Timeouts and termination of Lua scripts is not possible when scripts are
+-- replicated and executed by individual nodes.
+EXEC and script timeout
+MULTI-EXEC body and script timeout
+just EXEC and script timeout
+Blocking commands ignores the timeout
+Timedout read-only scripts can be killed by SCRIPT KILL even when use pcall
+Timedout script does not cause a false dead client
+Timedout script link is still usable after Lua returns
+Timedout scripts that modified data can't be killed by SCRIPT KILL
+
+
+-- MULTI/EXEC handling incompatibilities, mainly becuase RedisRaft implements
+-- its own logic while passing some non-data commands to Redis. Consider our
+-- options with Module API extensions to better control this.
+MUTLI / EXEC basics
+WATCH inside MULTI is not allowed
+EXEC fails if there are errors while queueing commands #1
+If EXEC aborts, the client MULTI state is cleared
+EXEC works on WATCHed key not modified
+After successful EXEC key is no longer watched
+After failed EXEC key is no longer watched
+It is possible to UNWATCH
+FLUSHALL does not touch non affected keys
+FLUSHDB does not touch non affected keys
+DISCARD should clear the WATCH dirty flag on the client
+DISCARD should UNWATCH all the keys
+MULTI and script timeout
+command stats for MULTI
+
+-- RAFT command prefix shows up in SLOWLOG.
+SLOWLOG - Rewritten commands are logged as their original command
+
+-- RAFT command prefix shows up in MONITOR
+MONITOR can log executed commands
+MONITOR can log commands issued by the scripting engine
+MONITOR correctly handles multi-exec cases
+
+-- TODO: check what's wrong
+UNLINK can reclaim memory in background
+
+-- Blocked clients not supported
+Test read commands are not blocked by client pause
+Test write commands are paused by RO

--- a/utils/create-cluster/create-cluster
+++ b/utils/create-cluster/create-cluster
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 # Settings
-REDIS_PATH="${PWD}/../../../redis/src"
-REDISRAFT="${PWD}/../../redisraft.so"
-HOST=127.0.0.1
-PORT=5000
-TIMEOUT=2000
-NODES=3
-LOGLEVEL=notice
-SHARDING=yes
-ADDITIONAL_OPTIONS=""
+REDIS_SERVER_BINARY=${REDIS_SERVER_BINARY:-${PWD}/../../../redis/src/redis-server}
+REDIS_CLI_BINARY=${REDIS_CLI_BINARY:-${PWD}/../../../redis/src/redis-cli}
+REDISRAFT=${REDISRAFT:-${PWD}/../../redisraft.so}
+HOST=${HOST:-127.0.0.1}
+PORT=${PORT:-5000}
+TIMEOUT=${TIMEOUT:-2000}
+NODES=${NODES:-3}
+LOGLEVEL=${LOGLEVEL:-notice}
+SHARDING=${SHARDING:-yes}
+ADDITIONAL_OPTIONS=${ADDITIONAL_OPTIONS:-}
 
 # You may want to put the above config parameters into config.sh in order to
 # override the defaults without modifying this script.
@@ -23,7 +24,7 @@ start_instance() {
     local port=$1
 
     echo "Starting $port"
-    $REDIS_PATH/redis-server \
+    $REDIS_SERVER_BINARY \
         --port $port \
         --loglevel $LOGLEVEL \
         --logfile ${port}.log \
@@ -40,7 +41,7 @@ stop_instance() {
     local port=$1
 
     echo "Stopping $port"
-    ${REDIS_PATH}/redis-cli -p $port shutdown nosave
+    ${REDIS_CLI_BINARY} -p $port shutdown nosave
 }
 
 # Computed vars
@@ -58,13 +59,13 @@ fi
 if [ "$1" == "create" ]
 then
     PORT=$((PORT+1))
-    ${REDIS_PATH}/redis-cli -p $PORT raft.cluster init
+    ${REDIS_CLI_BINARY} -p $PORT raft.cluster init
     sleep 1
 
     p=$PORT
     while [ $((p < ENDPORT)) != "0" ]; do
         p=$((p+1))
-        ${REDIS_PATH}/redis-cli -p $p raft.cluster join ${HOST}:${PORT}
+        ${REDIS_CLI_BINARY} -p $p raft.cluster join ${HOST}:${PORT}
     done
     exit 0
 fi
@@ -90,7 +91,7 @@ then
     while [ 1 ]; do
         clear
         echo "`date` | $HOST:$PORT | RAFT.INFO"
-        ${REDIS_PATH}/redis-cli -p $PORT --raw raft.info
+        ${REDIS_CLI_BINARY} -p $PORT --raw raft.info
         sleep 1
     done
     exit 0
@@ -115,7 +116,7 @@ then
     shift
     while [ $((PORT < ENDPORT)) != "0" ]; do
         PORT=$((PORT+1))
-        ${REDIS_PATH}/redis-cli -p $PORT $@
+        ${REDIS_CLI_BINARY} -p $PORT $@
     done
     exit 0
 fi
@@ -139,7 +140,7 @@ then
     INSTANCE=$2
     shift 2
     PORT=$((PORT+INSTANCE))
-    ${REDIS_PATH}/redis-cli -p $PORT $@
+    ${REDIS_CLI_BINARY} -p $PORT $@
     exit 0
 fi
 


### PR DESCRIPTION
This fixes a few relatively minor issues and establishes the script and configuration required to run the Redis test suite on a RedisRaft cluster. At this point not all tests work yet but a `skip.txt` skips those that don't and documents why/what needs to be done - so it's a good scoping excercise.

One notable change here is the introduction of `commands.c` as a single unified to classify Redis commands into different categories:

* Read-only commands that need to go through quorum reads (but skip the log)
* Administrative commands that are not intercepted by RedisRaft
* Unsupported commands which should be blocked.