### PR TITLE
Update to -- RedisModule_GetDetachedThreadSafeContext -- API call

### DIFF
--- a/raft.c
+++ b/raft.c
@@ -1100,7 +1100,7 @@ RRStatus RedisRaftInit(RedisModuleCtx *ctx, RedisRaftCtx *rr, RedisRaftConfig *c
     uv_timer_init(rr->loop, &rr->node_reconnect_timer);
     uv_handle_set_data((uv_handle_t *) &rr->node_reconnect_timer, rr);
 
-    rr->ctx = RedisModule_GetThreadSafeContext(NULL);
+    rr->ctx = RedisModule_GetDetachedThreadSafeContext(ctx);
     rr->config = config;
 
     /* Client state for MULTI support */


### PR DESCRIPTION
* Get the module thread-safe context using the **RedisModule_GetDetachedThreadSafeContext** API call.
* Refer Issue - https://github.com/RedisLabs/redisraft/issues/121