### PR TITLE
Move snapshot out of keyspace.

### DIFF
--- a/join.c
+++ b/join.c
@@ -117,9 +117,6 @@ void handleClusterJoin(RedisRaftCtx *rr, RaftReq *req)
         goto exit_fail;
     }
 
-    /* Create a Snapshot Info meta-key */
-    initializeSnapshotInfo(rr);
-
     JoinLinkState *state = RedisModule_Calloc(1, sizeof(*state));
     state->type = RedisModule_Calloc(1, strlen(type)+1);
     strcpy(state->type, type);

--- a/raft.c
+++ b/raft.c
@@ -716,7 +716,6 @@ RRStatus applyLoadedRaftLog(RedisRaftCtx *rr)
             raft_get_current_idx(rr->raft),
             raft_get_last_applied_idx(rr->raft));
 
-    initializeSnapshotInfo(rr);
     return RR_OK;
 }
 
@@ -975,9 +974,6 @@ RRStatus initCluster(RedisModuleCtx *ctx, RedisRaftCtx *rr, RedisRaftConfig *con
     rr->state = REDIS_RAFT_UP;
     raft_become_leader(rr->raft);
     raft_set_current_term(rr->raft, 1);
-
-    /* Create a Snapshot Info meta-key */
-    initializeSnapshotInfo(rr);
 
     /* We need to create the first add node entry.  Because we don't have
      * callbacks set yet, we also need to manually push this in our log

--- a/redisraft.h
+++ b/redisraft.h
@@ -706,7 +706,6 @@ RRStatus ConfigureRedis(RedisModuleCtx *ctx);
 /* snapshot.c */
 extern RedisModuleTypeMethods RedisRaftTypeMethods;
 extern RedisModuleType *RedisRaftType;
-void initializeSnapshotInfo(RedisRaftCtx *rr);
 void handleLoadSnapshot(RedisRaftCtx *rr, RaftReq *req);
 void checkLoadSnapshotProgress(RedisRaftCtx *rr);
 RRStatus initiateSnapshot(RedisRaftCtx *rr);


### PR DESCRIPTION
Before this commit, snapshot information was persisted by creating a
module data type and having a fake key in the keyspace. The RDB save and
load callbacks would then be triggered to store or load the information.

With new versions of the module API that support RDB AUX saving and
loading, it is no longer necessary to have a fake key.

Fixes #111 