### PR TITLE
POC of integrating transfer leader into redisraft

### DIFF
--- a/redisraft.h
+++ b/redisraft.h
@@ -377,7 +377,9 @@ enum RaftReqType {
     RR_CLIENT_DISCONNECT,
     RR_SHARDGROUP_ADD,
     RR_SHARDGROUP_GET,
-    RR_SHARDGROUP_LINK
+    RR_SHARDGROUP_LINK,
+    RR_TRANSFER_LEADER,
+    RR_TIMEOUT_NOW,
 };
 
 extern const char *RaftReqTypeStr[];
@@ -515,6 +517,7 @@ typedef struct RaftReq {
             NodeAddr addr;
         } shardgroup_link;
         RaftDebugReq debug;
+        raft_node_id_t node_to_transfer_leader;
     } r;
 } RaftReq;
 


### PR DESCRIPTION
add 2 raft. commands to reddis
	raft.transfer_leader <node id>
	raft.timeout_now

user will issue a raft.transfer_leader command to existing leader
libraft itself will issue a callback at the redisraft callback handler to issue the raft.timeout_now at the right point in time