### PR TITLE
Enable raft library logs only if log level is debug

### DIFF
--- a/config.c
+++ b/config.c
@@ -59,7 +59,7 @@ static int parseLogLevel(const char *value)
 {
     int i;
     for (i = 0; loglevels[i] != NULL; i++) {
-        if (!strcmp(value, loglevels[i])) {
+        if (!strcasecmp(value, loglevels[i])) {
             return i;
         }
     }

--- a/raft.c
+++ b/raft.c
@@ -1029,6 +1029,12 @@ static void initRaftLibrary(RedisRaftCtx *rr)
     }
     raft_set_election_timeout(rr->raft, rr->config->election_timeout);
     raft_set_request_timeout(rr->raft, rr->config->request_timeout);
+
+    // To avoid performance hit, get library logs only if log level is debug
+    if (redis_raft_loglevel != LOGLEVEL_DEBUG) {
+        redis_raft_callbacks.log = NULL;
+    }
+
     raft_set_callbacks(rr->raft, &redis_raft_callbacks, rr);
 }
 


### PR DESCRIPTION
- Enable raft library logs only if log level is debug
- Accept case-insensitive config