### PR TITLE
Leader informs removed node when its removal is committed

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -111,6 +111,7 @@ RRStatus CommandSpecInit(RedisModuleCtx *ctx)
             { "raft.loadsnapshot",      CMD_SPEC_DONT_INTERCEPT },
             { "raft.debug",             CMD_SPEC_DONT_INTERCEPT },
             { "raft.info",              CMD_SPEC_DONT_INTERCEPT },
+            { "raft.nodeshutdown",      CMD_SPEC_DONT_INTERCEPT },
             { NULL,                     0 }
     };
 

--- a/raft.c
+++ b/raft.c
@@ -242,26 +242,14 @@ static void raftSendNodeShutdown(raft_node_t *raft_node)
         return;
     }
 
-    char tmp[32];
-    snprintf(tmp, sizeof(tmp), "%d", raft_node_get_id(raft_node));
-
-    char* argv[2] = {
-        "RAFT.NODESHUTDOWN",
-        tmp
-    };
-
-    size_t argvlen[2] = {
-        strlen("RAFT.NODESHUTDOWN"),
-        strlen(tmp)
-    };
-
     if (!ConnIsConnected(node->conn)) {
         NODE_TRACE(node, "not connected, state=%s", ConnGetStateStr(node->conn));
         return;
     }
 
-    if (redisAsyncCommandArgv(ConnGetRedisCtx(node->conn), NULL,
-                        node, 2, (const char **)argv, argvlen) != REDIS_OK) {
+    if (redisAsyncCommand(ConnGetRedisCtx(node->conn), NULL, NULL,
+                "%s %d", "RAFT.NODESHUTDOWN",
+                (int) raft_node_get_id(raft_node)) != REDIS_OK) {
         NODE_TRACE(node, "failed to send raft.nodeshutdown");
     }
 }

--- a/raft.c
+++ b/raft.c
@@ -231,6 +231,40 @@ static void executeLogEntry(RedisRaftCtx *rr, raft_entry_t *entry, raft_index_t 
     }
 }
 
+static void raftSendNodeShutdown(raft_node_t *raft_node)
+{
+    if (!raft_node) {
+        return;
+    }
+
+    Node *node = raft_node_get_udata(raft_node);
+    if (!node) {
+        return;
+    }
+
+    char tmp[32];
+    snprintf(tmp, sizeof(tmp), "%d", raft_node_get_id(raft_node));
+
+    char* argv[2] = {
+        "RAFT.NODESHUTDOWN",
+        tmp
+    };
+
+    size_t argvlen[2] = {
+        strlen("RAFT.NODESHUTDOWN"),
+        strlen(tmp)
+    };
+
+    if (!ConnIsConnected(node->conn)) {
+        NODE_TRACE(node, "not connected, state=%s", ConnGetStateStr(node->conn));
+        return;
+    }
+
+    if (redisAsyncCommandArgv(ConnGetRedisCtx(node->conn), NULL,
+                        node, 2, (const char **)argv, argvlen) != REDIS_OK) {
+        NODE_TRACE(node, "failed to send raft.nodeshutdown");
+    }
+}
 
 /* ------------------------------------ RequestVote ------------------------------------ */
 
@@ -475,6 +509,11 @@ static int raftApplyLog(raft_server_t *raft, void *user_data, raft_entry_t *entr
                 LOG_DEBUG("Removing this node from the cluster");
                 return RAFT_ERR_SHUTDOWN;
             }
+
+            if (raft_is_leader(raft)) {
+                raftSendNodeShutdown(raft_get_node(raft, req->id));
+            }
+
             break;
         case RAFT_LOGTYPE_NORMAL:
             executeLogEntry(rr, entry, entry_idx);
@@ -2169,6 +2208,27 @@ exit:
     RaftReqFree(req);
 }
 
+static void handleNodeShutdown(RedisRaftCtx *rr, RaftReq *req)
+{
+    if (req->r.node_shutdown.id != raft_get_nodeid(rr->raft)) {
+        LOG_ERROR("Received invalid nodeshutdown message with id : %d.",
+                  req->r.node_shutdown.id);
+        return;
+    }
+
+    LOG_INFO("*** NODE REMOVED, SHUTTING DOWN.");
+
+    if (rr->config->raft_log_filename) {
+        RaftLogArchiveFiles(rr);
+    }
+
+    if (rr->config->rdb_filename) {
+        archiveSnapshot(rr);
+    }
+
+    RaftReqFree(req);
+    exit(0);
+}
 
 static RaftReqHandler RaftReqHandlers[] = {
     NULL,
@@ -2186,5 +2246,6 @@ static RaftReqHandler RaftReqHandlers[] = {
     handleShardGroupAdd,    /* RR_SHARDGROUP_ADD */
     handleShardGroupGet,    /* RR_SHARDGROUP_GET */
     handleShardGroupLink,   /* RR_SHARDGROUP_LINK */
+    handleNodeShutdown,     /* RR_NODE_SHUTDOWN */
     NULL
 };

--- a/raft.c
+++ b/raft.c
@@ -248,7 +248,7 @@ static void raftSendNodeShutdown(raft_node_t *raft_node)
     }
 
     if (redisAsyncCommand(ConnGetRedisCtx(node->conn), NULL, NULL,
-                "%s %d", "RAFT.NODESHUTDOWN",
+                "RAFT.NODESHUTDOWN %d",
                 (int) raft_node_get_id(raft_node)) != REDIS_OK) {
         NODE_TRACE(node, "failed to send raft.nodeshutdown");
     }

--- a/redisraft.c
+++ b/redisraft.c
@@ -672,6 +672,30 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     return REDISMODULE_OK;
 }
 
+static int cmdRaftNodeShutdown(RedisModuleCtx *ctx,
+                               RedisModuleString **argv, int argc)
+{
+    RedisRaftCtx *rr = &redis_raft;
+
+    if (argc != 2) {
+        RedisModule_WrongArity(ctx);
+        return REDISMODULE_OK;
+    }
+
+    long long node_id;
+    if (RedisModule_StringToLongLong(argv[1], &node_id) != REDISMODULE_OK ||
+        (node_id && !VALID_NODE_ID(node_id))) {
+        RedisModule_ReplyWithError(ctx, "invalid node id");
+        return REDISMODULE_OK;
+    }
+
+    RaftReq *req = RaftReqInit(ctx, RR_NODE_SHUTDOWN);
+    req->r.node_shutdown.id = (raft_node_id_t) node_id;
+
+    RaftReqSubmit(rr, req);
+
+    return REDISMODULE_OK;
+}
 
 static void handleClientDisconnect(RedisModuleCtx *ctx,
         RedisModuleEvent eid, uint64_t subevent, void *data)
@@ -767,6 +791,11 @@ static int registerRaftCommands(RedisModuleCtx *ctx)
 
     if (RedisModule_CreateCommand(ctx, "raft.debug",
                 cmdRaftDebug, "admin", 0, 0, 0) == REDISMODULE_ERR) {
+        return REDISMODULE_ERR;
+    }
+
+    if (RedisModule_CreateCommand(ctx, "raft.nodeshutdown",
+                cmdRaftNodeShutdown, "admin", 0, 0, 0) == REDISMODULE_ERR) {
         return REDISMODULE_ERR;
     }
 

--- a/redisraft.h
+++ b/redisraft.h
@@ -382,7 +382,8 @@ enum RaftReqType {
     RR_CLIENT_DISCONNECT,
     RR_SHARDGROUP_ADD,
     RR_SHARDGROUP_GET,
-    RR_SHARDGROUP_LINK
+    RR_SHARDGROUP_LINK,
+    RR_NODE_SHUTDOWN
 };
 
 extern const char *RaftReqTypeStr[];
@@ -520,6 +521,9 @@ typedef struct RaftReq {
             NodeAddr addr;
         } shardgroup_link;
         RaftDebugReq debug;
+        struct {
+            raft_node_id_t id;
+        } node_shutdown;
     } r;
 } RaftReq;
 

--- a/tests/integration/test_membership.py
+++ b/tests/integration/test_membership.py
@@ -126,19 +126,17 @@ def test_full_cluster_remove(cluster):
         expected_nodes -= 1
         leader.wait_for_num_nodes(expected_nodes)
 
-    # TODO: Currently, shutdown feature does not work reliably. This part of the
-    #       test should be enabled after implementing it.
-    # # make sure other nodes are down
-    # for node_id in (2, 3, 4, 5):
-    #     assert cluster.node(node_id).verify_down()
-    #
-    # # and make sure they start up in uninitialized state
-    # for node_id in (2, 3, 4, 5):
-    #     cluster.node(node_id).terminate()
-    #     cluster.node(node_id).start()
-    #
-    # for node_id in (2, 3, 4, 5):
-    #     assert cluster.node(node_id).raft_info()['state'] == 'uninitialized'
+    # make sure other nodes are down
+    for node_id in (2, 3, 4, 5):
+        assert cluster.node(node_id).verify_down()
+
+    # and make sure they start up in uninitialized state
+    for node_id in (2, 3, 4, 5):
+        cluster.node(node_id).terminate()
+        cluster.node(node_id).start()
+
+    for node_id in (2, 3, 4, 5):
+        assert cluster.node(node_id).raft_info()['state'] == 'uninitialized'
 
 
 @pytest.mark.parametrize("use_snapshot", [False, True])


### PR DESCRIPTION
While removing a node from the cluster, leader node might stop replicating entries to that node as soon as the removal entry is appended to the leader's log file. So, target node may not see its removal entry. To inform the node that it is removed, leader sends an out-of-band, best-effort message to that node. 