### PR TITLE
Fix unsynchronized access on configuration change

### DIFF
--- a/redisraft.c
+++ b/redisraft.c
@@ -95,11 +95,6 @@ static int cmdRaftNode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
             return REDISMODULE_OK;
         }
 
-        if (hasNodeIdBeenUsed(rr, node_id)) {
-            RedisModule_ReplyWithError(ctx, "node id has already been used in this cluster");
-            return REDISMODULE_OK;
-        }
-
         /* Parse address */
         NodeAddr node_addr = { 0 };
         if (getNodeAddrFromArg(ctx, argv[3], &node_addr) == RR_ERROR) {

--- a/redisraft.c
+++ b/redisraft.c
@@ -123,12 +123,6 @@ static int cmdRaftNode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
                 return REDISMODULE_OK;
         }
 
-        /* Also validate it exists */
-        if (!raft_get_node(rr->raft, node_id)) {
-            RedisModule_ReplyWithError(ctx, "node id does not exist");
-            return REDISMODULE_OK;
-        }
-
         req = RaftReqInit(ctx, RR_CFGCHANGE_REMOVENODE);
         req->r.cfgchange.id = node_id;
     } else {


### PR DESCRIPTION
Access to raft library from Redis thread is not synchronized. Moved add/remove node id validation to the Raft thread. 