### PR TITLE
Fix recent redis-testsuite failures.

### DIFF
--- a/.github/workflows/redis-suite.yml
+++ b/.github/workflows/redis-suite.yml
@@ -3,6 +3,7 @@ name: Redis Test Suite
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   redis-suite:

--- a/raft.c
+++ b/raft.c
@@ -134,13 +134,32 @@ static void executeRaftRedisCommandArray(RaftRedisCommandArray *array,
         enterRedisModuleCall();
         RedisModuleCallReply *reply = RedisModule_Call(
                 ctx, cmd, "v", &c->argv[1], c->argc - 1);
+        int ret_errno = errno;
         exitRedisModuleCall();
 
         if (reply_ctx) {
             if (reply) {
                 RedisModule_ReplyWithCallReply(reply_ctx, reply);
             } else {
-                RedisModule_ReplyWithError(reply_ctx, "ERR Unknown command or wrong number of arguments");
+                /* Try to produce an error message which is similar to Redis */
+                int trunc_cmdlen = cmdlen > 256 ? 256 : cmdlen;
+                size_t errmsg_len = 128 + trunc_cmdlen;   /* Big enough for msg + cmd */
+                char *errmsg = RedisModule_Alloc(errmsg_len);
+
+                switch (ret_errno) {
+                    case ENOENT:
+                        snprintf(errmsg, errmsg_len, "ERR unknown command `%.*s`", trunc_cmdlen, cmd);
+                        break;
+                    case EINVAL:
+                        snprintf(errmsg, errmsg_len, "ERR wrong number of arguments for '%.*s' command",
+                                trunc_cmdlen, cmd);
+                        break;
+                    default:
+                        snprintf(errmsg, errmsg_len, "ERR failed to execute command '%.*s'",
+                                trunc_cmdlen, cmd);
+                }
+                RedisModule_ReplyWithError(reply_ctx, errmsg);
+                RedisModule_Free(errmsg);
             }
         }
 

--- a/tests/redis-suite/skip.txt
+++ b/tests/redis-suite/skip.txt
@@ -41,6 +41,25 @@ BZPOPMIN with variadic ZADD
 BZPOPMIN with zero timeout should block indefinitely
 BLPOP: with zero timeout should block indefinitely
 BRPOP: with zero timeout should block indefinitely
+BLMPOP_LEFT, LPUSH + DEL should not awake blocked client
+BLMPOP_LEFT, LPUSH + DEL + SET should not awake blocked client
+MULTI/EXEC is isolated from the point of view of BLMPOP_LEFT
+BLMPOP_LEFT with variadic LPUSH
+BLMPOP with multiple blocked clients
+Circular BRPOPLPUSH
+BRPOPLPUSH does not affect WATCH while still blocked
+BLMPOP_LEFT: with zero timeout should block indefinitely
+BLMPOP_RIGHT: with zero timeout should block indefinitely
+BLMPOP_LEFT when new key is moved into place
+BLMPOP_LEFT when result key is created by SORT..STORE
+BLMPOP_LEFT: with single empty list argument
+BLMPOP_LEFT: with non-integer timeout
+BLMPOP_LEFT: arguments are empty
+BLMPOP_RIGHT when new key is moved into place
+BLMPOP_RIGHT when result key is created by SORT..STORE
+BLMPOP_RIGHT: with single empty list argument
+BLMPOP_RIGHT: with non-integer timeout
+BLMPOP_RIGHT: arguments are empty
 
 -- RESP3 Not supported
 -- See: https://github.com/RedisLabs/redisraft/issues/100
@@ -56,6 +75,9 @@ HRANDFIELD with RESP3
 RESP3 attributes
 RESP3 attributes readraw
 RESP3 attributes on RESP2
+ZINTER RESP3 - listpack
+Basic ZPOP - listpack RESP3
+ZPOP with count - listpack RESP3
 
 -- Streams not supported
 -- See: https://github.com/RedisLabs/redisraft/issues/59


### PR DESCRIPTION
*  Improve error message compatibility.

Before this commit, a generic error was produced for RM_Call() failures.
Now we're evaluating the returned error code and produce an error
message that is more compatible with Redis.

* Skip recent tests that are incompatible.
