### PR TITLE
Increment term first before becoming leader in initCluster()

### DIFF
--- a/raft.c
+++ b/raft.c
@@ -989,8 +989,8 @@ RRStatus initCluster(RedisModuleCtx *ctx, RedisRaftCtx *rr, RedisRaftConfig *con
 
     /* Become leader and create initial entry */
     rr->state = REDIS_RAFT_UP;
-    raft_become_leader(rr->raft);
     raft_set_current_term(rr->raft, 1);
+    raft_become_leader(rr->raft);
 
     /* We need to create the first add node entry.  Because we don't have
      * callbacks set yet, we also need to manually push this in our log


### PR DESCRIPTION
Not a big problem but in log it shows "term 0" as the current term, it is slightly confusing : 

```
1246350:M 15 Sep 2021 07:28:24.088 * <redisraft> State change: Node is now a leader, term 0
```