### PR TITLE
Updated CI platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        platform: [ubuntu-latest, ubuntu-16.04]
+        platform: [ubuntu-latest, ubuntu-18.04]
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
CI for 16.04 hangs. Apparently, 16.04 does not exist anymore. 

https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/