### PR TITLE
Clear inactive flag of a node while loading snapshot

### DIFF
--- a/snapshot.c
+++ b/snapshot.c
@@ -329,6 +329,9 @@ static int updateNodeFromSnapshot(RedisRaftCtx *rr, raft_node_t *node, SnapshotC
 {
     int ret = 0;
 
+    /* Clear inactive flag, a node in the snapshot cannot be inactive */
+    raft_node_set_active(node, 1);
+
     if (cfg->voting != raft_node_is_voting(node)) {
         raft_node_set_voting(node, cfg->voting);
         raft_node_set_voting_committed(node, cfg->voting);


### PR DESCRIPTION
1 - Leader appends its own removal entry, marks itself inactive. 
2 - Before replicating the entry, node becomes follower.
3 - New leader sends snapshot to this node.
4 - Node wipes out existing log entries including its removal entry but it is still inactive as it didn't rollback entries.
5 - Snapshot does not clear inactive flag for the "own node". Node stays in an awkward situation, inactive forever. 

This situation triggers an assert on Jepsen tests later on. 

Solution : Nodes in a snapshot cannot be inactive, so it's safe to set own node as active. Other nodes will be active by default as we create them while loading snapshot.