### PR TITLE
Enable __attribute__((__common__)) for clang

### DIFF
--- a/redismodule.h
+++ b/redismodule.h
@@ -418,7 +418,7 @@ typedef long long mstime_t;
 #endif
 
 #ifndef REDISMODULE_ATTR_COMMON
-#    if defined(__GNUC__) && !defined(__clang__)
+#    if defined(__GNUC__)
 #        define REDISMODULE_ATTR_COMMON __attribute__((__common__))
 #    else
 #        define REDISMODULE_ATTR_COMMON

--- a/redismodule.h
+++ b/redismodule.h
@@ -418,7 +418,7 @@ typedef long long mstime_t;
 #endif
 
 #ifndef REDISMODULE_ATTR_COMMON
-#    if defined(__GNUC__) && !defined(__cplusplus)
+#    if defined(__GNUC__) && !(defined(__clang) && defined(__cplusplus))
 #        define REDISMODULE_ATTR_COMMON __attribute__((__common__))
 #    else
 #        define REDISMODULE_ATTR_COMMON

--- a/redismodule.h
+++ b/redismodule.h
@@ -418,7 +418,7 @@ typedef long long mstime_t;
 #endif
 
 #ifndef REDISMODULE_ATTR_COMMON
-#    if defined(__GNUC__)
+#    if defined(__GNUC__) && !defined(__cplusplus)
 #        define REDISMODULE_ATTR_COMMON __attribute__((__common__))
 #    else
 #        define REDISMODULE_ATTR_COMMON

--- a/redismodule.h
+++ b/redismodule.h
@@ -418,7 +418,7 @@ typedef long long mstime_t;
 #endif
 
 #ifndef REDISMODULE_ATTR_COMMON
-#    if defined(__GNUC__) && !(defined(__clang) && defined(__cplusplus))
+#    if defined(__GNUC__) && !(defined(__clang__) && defined(__cplusplus))
 #        define REDISMODULE_ATTR_COMMON __attribute__((__common__))
 #    else
 #        define REDISMODULE_ATTR_COMMON


### PR DESCRIPTION
fixes #152 

@yossigo  I saw your comment (https://github.com/redis/redis/pull/6900#issuecomment-673674681) 

I'm trying clang here : https://godbolt.org/z/6EKz69q4K. Older versions don't complain about the attribute. Do you remember what was the issue with clang? 