### PR TITLE
Prevent crash if leader is asked to send snapshot to itself

### DIFF
--- a/raft.c
+++ b/raft.c
@@ -2010,6 +2010,11 @@ static void handleDebugSendSnapshot(RedisRaftCtx *rr, RaftReq *req)
         goto exit;
     }
 
+    if (req->r.debug.d.nodecfg.id == raft_get_nodeid(rr->raft)) {
+        RedisModule_ReplyWithError(req->ctx, "ERR leader cannot send snapshot to itself");
+        goto exit;
+    }
+
     if (raftSendSnapshot(rr->raft, rr, node) != 0) {
         RedisModule_ReplyWithError(req->ctx, "ERR failed to send snapshot");
         goto exit;


### PR DESCRIPTION
Passing leader's own id as "sendsnapshot" target leads to crash. Extra check prevents that. 