### PR TITLE
Enable core dumps on Jepsen runs.

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -29,6 +29,8 @@ jobs:
         echo "REDISRAFT_VERSION=${{ github.event.inputs.version || env.REDISRAFT_VERSION }}" >> $GITHUB_ENV
     - name: Install ripgrep
       run: sudo apt-get install ripgrep
+    - name: Configure core_pattern
+      run: echo "core.%p" | tee /proc/sys/kernel/core_pattern
     - name: Build containers
       run: cd jepsen/docker && ./genkeys.sh && docker-compose build
     - name: Start containers


### PR DESCRIPTION
This configures the kernel to generate local core dumps, instead of
piping them through apport which is the default.

Debian stretch seems to have an unlimited core file size by default, so
crashes in Redis should generate a core dump.

And the latest version of the RedisRaft jepsen is now set to locate core
files and pack them along wiht log files.