### PR TITLE
Fix redirection to foreign leader.

### DIFF
--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -52,6 +52,12 @@ def test_shard_group_sanity(cluster):
     with raises(ResponseError, match='MOVED [0-9]+ 1.1.1.1:111'):
         c.set('key', 'value')
 
+    # Follower redirect straight to remote shardgroup to
+    # avoid another redirect hop.
+    cluster.wait_for_unanimity()
+    cluster.node(2).wait_for_log_applied()  # to get shardgroup
+    with raises(ResponseError, match='MOVED [0-9]+ 1.1.1.1:111'):
+        cluster.node(2).client.set('key', 'value')
 
 def test_shard_group_validation(cluster):
     cluster.create(3, raft_args={


### PR DESCRIPTION
Before this commit, when sharding was enabled a follower would redirect
clients accessing foreign keys to the current cluster's leader and not
the target cluster's one. This would result with an unnecessary extra
redirect hop.