### PR TITLE
Add CLUSTER NODES command support.

### DIFF
--- a/cluster.c
+++ b/cluster.c
@@ -972,7 +972,10 @@ static void addClusterNodesReply(RedisRaftCtx *rr, RaftReq *req)
         } else { /* the other shard groups we reply out of the shard group data */
             for (int j = 0; j < sg->nodes_num; j++) {
                 char *flags = "noflags";
-                char *master = "-";
+                /* SHARDGROUP GET only works on leader
+                 * SHARDGROUP GET lists nodes in order of idx, but 0 will always be self, i.e. leader
+                 */
+                char *master = j == 0 ? "master" : "slave";
                 int ping_sent = 0;
                 int pong_recv = 0;
                 int epoch = 0;

--- a/redisraft.h
+++ b/redisraft.h
@@ -619,6 +619,7 @@ void joinLinkFreeCallback(void *privdata);
 const char *getStateStr(RedisRaftCtx *rr);
 const char *raft_logtype_str(int type);
 void replyRaftError(RedisModuleCtx *ctx, int error);
+raft_node_t getLeaderNodeOrReply(RedisRaftCtx *rr, RaftReq *req);
 RRStatus checkLeader(RedisRaftCtx *rr, RaftReq *req, Node **ret_leader);
 RRStatus checkRaftNotLoading(RedisRaftCtx *rr, RaftReq *req);
 RRStatus checkRaftState(RedisRaftCtx *rr, RaftReq *req);

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -216,8 +216,12 @@ def test_shard_group_linking(cluster_factory):
     assert node1[8] == b"0-1"
     node3 = cluster_nodes[3].split(b' ')
     assert node3[2] == b"noflags"
-    assert node3[3] == b"-"
+    assert node3[3] == b"master"
     assert node3[8] == b"2-16383"
+    node4 = cluster_nodes[4].split(b' ')
+    assert node4[2] == b"noflags"
+    assert node4[3] == b"slave"
+    assert node4[8] == b"2-16383"
     assert cluster_nodes[6] == b"";  # empty entry after final "\r\n" from split
 
     # Terminate leader on cluster 2, wait for re-election and confirm

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -104,7 +104,6 @@ def test_shard_group_propagation(cluster):
     cluster_slots = cluster.node(3).client.execute_command('CLUSTER', 'SLOTS')
     assert len(cluster_slots) == 2
 
-
 def test_shard_group_snapshot_propagation(cluster):
     # Create a cluster with just a single slot
     cluster.create(1, raft_args={
@@ -202,6 +201,24 @@ def test_shard_group_linking(cluster_factory):
     assert cs[1][0] == 2
     assert cs[1][1] == 16383
     assert cs[1][2][1] == cluster2.leader_node().port  # first node is leader
+
+    # Verify CLUSTER NODES looks good
+    cluster_nodes_raw = cluster1.node(1).client.execute_command('CLUSTER', 'NODES')
+    cluster_nodes = cluster_nodes_raw.split(b"\r\n")
+    assert len(cluster_nodes) == 7  # blank entry at the end
+    node0 = cluster_nodes[0].split(b' ')
+    assert node0[2] == b"myself"
+    assert node0[3] == b"master"
+    assert node0[8] == b"0-1"
+    node1 = cluster_nodes[1].split(b' ')
+    assert node1[2] == b"noflags"
+    assert node1[3] == b"slave"
+    assert node1[8] == b"0-1"
+    node3 = cluster_nodes[3].split(b' ')
+    assert node3[2] == b"noflags"
+    assert node3[3] == b"-"
+    assert node3[8] == b"2-16383"
+    assert cluster_nodes[6] == b"";  # empty entry after final "\r\n" from split
 
     # Terminate leader on cluster 2, wait for re-election and confirm
     # propagation.


### PR DESCRIPTION
Intended mainly for clients that still use `CLUSTER NODES` and not `CLUSTER SLOTS`, and not so much for cluster administration which should rely on `RAFT.INFO`.

Many fields are not applicable for RedisRaft, but the output should be parser-compatible with Redis Cluster.