### PR TITLE
Enable RedisRaft to support older versions of Redis

### DIFF
--- a/config.c
+++ b/config.c
@@ -400,6 +400,13 @@ void ConfigInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
     config->sharding_start_hslot = REDIS_RAFT_HASH_MIN_SLOT;
     config->sharding_end_hslot = REDIS_RAFT_HASH_MAX_SLOT;
     config->shardgroup_update_interval = REDIS_RAFT_DEFAULT_SHARDGROUP_UPDATE_INTERVAL;
+
+    /* for backwards compatibility with older redis version that don't support "0v"m */
+    if (RedisModule_GetContextFlagsAll() & REDISMODULE_CTX_FLAGS_RESP3) {
+        config->resp_call_fmt = "0v";
+    } else {
+        config->resp_call_fmt = "v";
+    }
 }
 
 static RRStatus setRedisConfig(RedisModuleCtx *ctx, const char *param, const char *value)

--- a/config.c
+++ b/config.c
@@ -400,13 +400,6 @@ void ConfigInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
     config->sharding_start_hslot = REDIS_RAFT_HASH_MIN_SLOT;
     config->sharding_end_hslot = REDIS_RAFT_HASH_MAX_SLOT;
     config->shardgroup_update_interval = REDIS_RAFT_DEFAULT_SHARDGROUP_UPDATE_INTERVAL;
-
-    /* for backwards compatibility with older redis version that don't support "0v"m */
-    if (RedisModule_GetContextFlagsAll() & REDISMODULE_CTX_FLAGS_RESP3) {
-        config->resp_call_fmt = "0v";
-    } else {
-        config->resp_call_fmt = "v";
-    }
 }
 
 static RRStatus setRedisConfig(RedisModuleCtx *ctx, const char *param, const char *value)

--- a/raft.c
+++ b/raft.c
@@ -148,8 +148,15 @@ static void executeRaftRedisCommandArray(RaftRedisCommandArray *array,
         }
 
         enterRedisModuleCall();
+        /* for backwards compatability with older redis version that don't support "0v"m */
+        char * fmt;
+        if (RedisModule_GetContextFlagsAll() & REDISMODULE_CTX_FLAGS_RESP3) {
+            fmt = "0v";
+        } else {
+            fmt = "v";
+        }
         RedisModuleCallReply *reply = RedisModule_Call(
-                ctx, cmd, "0v", &c->argv[1], c->argc - 1);
+                ctx, cmd, fmt, &c->argv[1], c->argc - 1);
         int ret_errno = errno;
         exitRedisModuleCall();
 

--- a/raft.c
+++ b/raft.c
@@ -149,7 +149,7 @@ static void executeRaftRedisCommandArray(RaftRedisCommandArray *array,
 
         enterRedisModuleCall();
         RedisModuleCallReply *reply = RedisModule_Call(
-                ctx, cmd, redis_raft.config->resp_call_fmt, &c->argv[1], c->argc - 1);
+                ctx, cmd, redis_raft.resp_call_fmt, &c->argv[1], c->argc - 1);
         int ret_errno = errno;
         exitRedisModuleCall();
 
@@ -1237,6 +1237,13 @@ RRStatus RedisRaftInit(RedisModuleCtx *ctx, RedisRaftCtx *rr, RedisRaftConfig *c
 
     rr->ctx = RedisModule_GetDetachedThreadSafeContext(ctx);
     rr->config = config;
+
+    /* for backwards compatibility with older redis version that don't support "0v"m */
+    if (RedisModule_GetContextFlagsAll() & REDISMODULE_CTX_FLAGS_RESP3) {
+        rr->resp_call_fmt = "0v";
+    } else {
+        rr->resp_call_fmt = "v";
+    }
 
     /* Client state for MULTI support */
     multiClientState = RedisModule_CreateDict(ctx);

--- a/raft.c
+++ b/raft.c
@@ -148,15 +148,8 @@ static void executeRaftRedisCommandArray(RaftRedisCommandArray *array,
         }
 
         enterRedisModuleCall();
-        /* for backwards compatability with older redis version that don't support "0v"m */
-        char * fmt;
-        if (RedisModule_GetContextFlagsAll() & REDISMODULE_CTX_FLAGS_RESP3) {
-            fmt = "0v";
-        } else {
-            fmt = "v";
-        }
         RedisModuleCallReply *reply = RedisModule_Call(
-                ctx, cmd, fmt, &c->argv[1], c->argc - 1);
+                ctx, cmd, redis_raft.config->resp_call_fmt, &c->argv[1], c->argc - 1);
         int ret_errno = errno;
         exitRedisModuleCall();
 

--- a/redisraft.h
+++ b/redisraft.h
@@ -277,8 +277,7 @@ typedef struct RedisRaftCtx {
     unsigned long long proxy_failed_responses;   /* Number of failed proxy responses, i.e. did not complete */
     unsigned long proxy_outstanding_reqs;        /* Number of proxied requests pending */
     unsigned long snapshots_loaded;              /* Number of snapshots loaded */
-
-    char * resp_call_fmt;               /* format string to use in RedisModule_Call() */
+    char *resp_call_fmt;                         /* Format string to use in RedisModule_Call(), Redis version-specific */
 } RedisRaftCtx;
 
 extern RedisRaftCtx redis_raft;

--- a/redisraft.h
+++ b/redisraft.h
@@ -336,6 +336,8 @@ typedef struct RedisRaftConfig {
     int sharding_start_hslot;           /* First cluster hash slot */
     int sharding_end_hslot;             /* Last cluster hash slot */
     int shardgroup_update_interval;     /* Milliseconds between shardgroup updates */
+
+    char * resp_call_fmt;               /* format string to use in RedisModule_Call() */
 } RedisRaftConfig;
 
 typedef struct PendingResponse {

--- a/redisraft.h
+++ b/redisraft.h
@@ -277,6 +277,8 @@ typedef struct RedisRaftCtx {
     unsigned long long proxy_failed_responses;   /* Number of failed proxy responses, i.e. did not complete */
     unsigned long proxy_outstanding_reqs;        /* Number of proxied requests pending */
     unsigned long snapshots_loaded;              /* Number of snapshots loaded */
+
+    char * resp_call_fmt;               /* format string to use in RedisModule_Call() */
 } RedisRaftCtx;
 
 extern RedisRaftCtx redis_raft;
@@ -336,8 +338,6 @@ typedef struct RedisRaftConfig {
     int sharding_start_hslot;           /* First cluster hash slot */
     int sharding_end_hslot;             /* Last cluster hash slot */
     int shardgroup_update_interval;     /* Milliseconds between shardgroup updates */
-
-    char * resp_call_fmt;               /* format string to use in RedisModule_Call() */
 } RedisRaftConfig;
 
 typedef struct PendingResponse {


### PR DESCRIPTION
Older versions don't support the `0` format modifier in `RM_Call()`, which is used to automatically match the call's protocol level to the current client's select version.

This commit auto-detects the version of Redis and will a compatible format. As a result, older versions will not have proper RESP3 support.