### PR TITLE
Make removed node shutdown even it's the only node in the cluster

### DIFF
--- a/raft.c
+++ b/raft.c
@@ -1626,6 +1626,8 @@ static void handleCfgChange(RedisRaftCtx *rr, RaftReq *req)
             RedisModule_ReplyWithSimpleString(req->ctx, rr->snapshot_info.dbid);
             break;
         case RR_CFGCHANGE_REMOVENODE:
+            /* Block until removed, so don't reply here. */
+
             /* Special case, we are the only node and our node has been removed */
             if (req->r.cfgchange.id == raft_get_nodeid(rr->raft) &&
                 raft_get_num_voting_nodes(rr->raft) == 0) {

--- a/raft.c
+++ b/raft.c
@@ -912,6 +912,20 @@ static void handleLoadingState(RedisRaftCtx *rr)
     }
 }
 
+static void shutdownAfterRemoval(RedisRaftCtx *rr)
+{
+    LOG_INFO("*** NODE REMOVED, SHUTTING DOWN.");
+
+    if (rr->config->raft_log_filename) {
+        RaftLogArchiveFiles(rr);
+    }
+    if (rr->config->rdb_filename) {
+        archiveSnapshot(rr);
+    }
+
+    exit(0);
+}
+
 static void callRaftPeriodic(uv_timer_t *handle)
 {
     RedisRaftCtx *rr = (RedisRaftCtx *) uv_handle_get_data((uv_handle_t *) handle);
@@ -953,13 +967,7 @@ static void callRaftPeriodic(uv_timer_t *handle)
     }
 
     if (ret == RAFT_ERR_SHUTDOWN) {
-        LOG_INFO("*** NODE REMOVED, SHUTTING DOWN.");
-
-        if (rr->config->raft_log_filename)
-            RaftLogArchiveFiles(rr);
-        if (rr->config->rdb_filename)
-            archiveSnapshot(rr);
-        exit(0);
+        shutdownAfterRemoval(rr);
     }
 
     assert(ret == 0);
@@ -1618,7 +1626,13 @@ static void handleCfgChange(RedisRaftCtx *rr, RaftReq *req)
             RedisModule_ReplyWithSimpleString(req->ctx, rr->snapshot_info.dbid);
             break;
         case RR_CFGCHANGE_REMOVENODE:
-            // block until removed, so don't reply here
+            /* Special case, we are the only node and our node has been removed */
+            if (req->r.cfgchange.id == raft_get_nodeid(rr->raft) &&
+                raft_get_num_voting_nodes(rr->raft) == 0) {
+                RedisModule_ReplyWithSimpleString(req->ctx, "OK");
+                RaftReqFree(req);
+                shutdownAfterRemoval(rr);
+            }
             return;
         default:
 	    assert(0);
@@ -2388,18 +2402,8 @@ static void handleNodeShutdown(RedisRaftCtx *rr, RaftReq *req)
         return;
     }
 
-    LOG_INFO("*** NODE REMOVED, SHUTTING DOWN.");
-
-    if (rr->config->raft_log_filename) {
-        RaftLogArchiveFiles(rr);
-    }
-
-    if (rr->config->rdb_filename) {
-        archiveSnapshot(rr);
-    }
-
     RaftReqFree(req);
-    exit(0);
+    shutdownAfterRemoval(rr);
 }
 
 static RaftReqHandler RaftReqHandlers[] = {

--- a/tests/integration/test_membership.py
+++ b/tests/integration/test_membership.py
@@ -128,16 +128,19 @@ def test_full_cluster_remove(cluster):
         expected_nodes -= 1
         leader.wait_for_num_nodes(expected_nodes)
 
+    # remove the leader node finally
+    leader.client.execute_command('RAFT.NODE', 'REMOVE', leader.id)
+
     # make sure other nodes are down
-    for node_id in (2, 3, 4, 5):
+    for node_id in (1, 2, 3, 4, 5):
         assert cluster.node(node_id).verify_down()
 
     # and make sure they start up in uninitialized state
-    for node_id in (2, 3, 4, 5):
+    for node_id in (1, 2, 3, 4, 5):
         cluster.node(node_id).terminate()
         cluster.node(node_id).start()
 
-    for node_id in (2, 3, 4, 5):
+    for node_id in (1, 2, 3, 4, 5):
         assert cluster.node(node_id).raft_info()['state'] == 'uninitialized'
 
 


### PR DESCRIPTION
Make removed node shutdown even it's the only node in the cluster

In a single node cluster, remove operation of the last node will only be appended to the log and it will not be applied. As configuration changes are effective immediately after appending to the log, the last node can do a special check and decide to shutdown in this case.