### PR TITLE
Add ignore-commands config option to Redis Raft

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -165,10 +165,6 @@ RRStatus CommandSpecInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
                 RedisModule_Free(temp);
                 return RR_ERROR;
             }
-
-            CommandSpec *cs = RedisModule_DictGetC(commandSpecDict, tok, strlen(tok), NULL);
-            printf("val = %d\n", cs->flags);
-
             tok = strtok(NULL, ",");
         }
         RedisModule_Free(temp);

--- a/config.c
+++ b/config.c
@@ -34,6 +34,7 @@ static const char *CONF_SHARDING = "sharding";
 static const char *CONF_SHARDING_START_HSLOT = "sharding-start-hslot";
 static const char *CONF_SHARDING_END_HSLOT = "sharding-end-hslot";
 static const char *CONF_SHARDGROUP_UPDATE_INTERVAL = "shardgroup-update-interval";
+static const char *CONF_IGNORED_COMMANDS = "ignored-commands";
 
 static RRStatus parseBool(const char *value, bool *result)
 {
@@ -207,6 +208,11 @@ static RRStatus processConfigParam(const char *keyword, const char *value,
         if (*errptr != '\0' || val < 0)
             goto invalid_value;
         target->shardgroup_update_interval = (int) val;
+    } else if (!strcmp(keyword, CONF_IGNORED_COMMANDS)) {
+        if (target->ignored_commands) {
+            RedisModule_Free(target->ignored_commands);
+        }
+        target->ignored_commands = RedisModule_Strdup(value);
     } else {
         snprintf(errbuf, errbuflen-1, "invalid parameter '%s'", keyword);
         return RR_ERROR;
@@ -374,6 +380,10 @@ void handleConfigGet(RedisModuleCtx *ctx, RedisRaftConfig *config, RedisModuleSt
     if (stringmatch(pattern, CONF_SHARDGROUP_UPDATE_INTERVAL, 1)) {
         len++;
         replyConfigInt(ctx, CONF_SHARDGROUP_UPDATE_INTERVAL, config->shardgroup_update_interval);
+    }
+    if (stringmatch(pattern, CONF_IGNORED_COMMANDS, 1)) {
+        len++;
+        replyConfigStr(ctx, CONF_IGNORED_COMMANDS, config->ignored_commands);
     }
     RedisModule_ReplySetArrayLength(ctx, len * 2);
 }

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -372,3 +372,13 @@ The interval (in milliseconds) between attempts to refresh shardgroup configurat
 of foreign shardgroup clusters.
 
 *Default: 5000*
+
+### `ignored-commands`
+
+A comma sepeated list of additional commands that RedisRaft should not intercept and append to the Raft log before executing.
+
+Im general this is useful when used with other modules that don't wnat some or all of their commands handled via raft.
+
+*Example*: ignore,mycommand
+
+By default, this configuration option will be mepty and no additional commands will be ignored beyond those RedisRaft is hard coded to ignore.

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -379,6 +379,6 @@ A comma sepeated list of additional commands that RedisRaft should not intercept
 
 Im general this is useful when used with other modules that don't wnat some or all of their commands handled via raft.
 
-*Example*: ignore,mycommand
+*Example*: command1,command2
 
 By default, this configuration option will be mepty and no additional commands will be ignored beyond those RedisRaft is hard coded to ignore.

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -375,10 +375,10 @@ of foreign shardgroup clusters.
 
 ### `ignored-commands`
 
-A comma sepeated list of additional commands that RedisRaft should not intercept and append to the Raft log before executing.
+A comma seperated list of additional commands that RedisRaft should not intercept, and therefore not append to the Raft log before executing.
 
-Im general this is useful when used with other modules that don't wnat some or all of their commands handled via raft.
+In general this is useful when used with other modules that don't want some or all of their commands handled via raft.
 
 *Example*: command1,command2
 
-By default, this configuration option will be mepty and no additional commands will be ignored beyond those RedisRaft is hard coded to ignore.
+By default, this configuration option will be empty and no additional commands will be ignored beyond those RedisRaft is hard coded to ignore.

--- a/redisraft.c
+++ b/redisraft.c
@@ -943,7 +943,7 @@ __attribute__((__unused__)) int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisMod
         return REDISMODULE_ERR;
     }
 
-    if (CommandSpecInit(ctx) == RR_ERROR) {
+    if (CommandSpecInit(ctx, &config) == RR_ERROR) {
         RedisModule_Log(ctx, REDIS_WARNING, "Failed to initialize internal command table");
         return REDISMODULE_ERR;
     }

--- a/redisraft.h
+++ b/redisraft.h
@@ -337,7 +337,7 @@ typedef struct RedisRaftConfig {
     int sharding_start_hslot;           /* First cluster hash slot */
     int sharding_end_hslot;             /* Last cluster hash slot */
     int shardgroup_update_interval;     /* Milliseconds between shardgroup updates */
-    char *ignored_commands;             /* comma delimited list of strings to ignore */
+    char *ignored_commands;             /* Comma delimited list of commands that should not be intercepted */
 } RedisRaftConfig;
 
 typedef struct PendingResponse {

--- a/redisraft.h
+++ b/redisraft.h
@@ -337,6 +337,7 @@ typedef struct RedisRaftConfig {
     int sharding_start_hslot;           /* First cluster hash slot */
     int sharding_end_hslot;             /* Last cluster hash slot */
     int shardgroup_update_interval;     /* Milliseconds between shardgroup updates */
+    char *ignored_commands;             /* comma delimited list of strings to ignore */
 } RedisRaftConfig;
 
 typedef struct PendingResponse {
@@ -778,7 +779,7 @@ void HandleClusterJoinCompleted(RedisRaftCtx *rr, RaftReq *pReq);
 void handleClusterJoin(RedisRaftCtx *rr, RaftReq *req);
 
 /* commands.c */
-RRStatus CommandSpecInit(RedisModuleCtx *ctx);
+RRStatus CommandSpecInit(RedisModuleCtx *ctx, RedisRaftConfig *config);
 unsigned int CommandSpecGetAggregateFlags(RaftRedisCommandArray *array, unsigned int default_flags);
 const CommandSpec *CommandSpecGet(const RedisModuleString *cmd);
 

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -86,9 +86,9 @@ def test_ignored_commands(cluster):
     cluster.node(1).start()
 
     # ignored commands should give a non existent command redis error
-    with raises(ResponseError, match='unknown command `ignored`, with args beginning with: `test`, `command`, '):
+    with raises(ResponseError, match="unknown command"):
         cluster.node(1).client.execute_command("ignored", "test", "command")
-    with raises(ResponseError, match='unknown command `mycommand`, with args beginning with: `to`, `ignore`, '):
+    with raises(ResponseError, match="unknown command"):
         cluster.node(1).client.execute_command("mycommand", "to", "ignore")
 
     # while not ignored commands should give an uninitialized cluster error


### PR DESCRIPTION
this adds the ignore-commands configuraiton option on the command line that takes a comma delimited list of command that Redis Raft should ignore.

ex: "ignore-commands ignore,me"

included is an integration test that compares an ignored command issued against an unitialized cluster vs a non ignored command