### PR TITLE
Intercept "info" to spoof cluster_enabled and prevent starting with cluster_enabled flag

### DIFF
--- a/cluster.c
+++ b/cluster.c
@@ -1069,11 +1069,6 @@ void handleClusterCommand(RedisRaftCtx *rr, RaftReq *req)
         goto exit;
     }
 
-    if (!redis_raft.sharding_info) {
-        RedisModule_ReplyWithError(req->ctx, "ERR This instance has cluster support disabled");
-        goto exit;
-    }
-
     size_t cmd_len;
     const char *cmd_str = RedisModule_StringPtrLen(cmd->argv[1], &cmd_len);
 

--- a/commands.c
+++ b/commands.c
@@ -107,7 +107,6 @@ RRStatus CommandSpecInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
             { "save",                   CMD_SPEC_DONT_INTERCEPT },
             { "bgsave",                 CMD_SPEC_DONT_INTERCEPT },
             { "module",                 CMD_SPEC_DONT_INTERCEPT },
-            { "info",                   CMD_SPEC_DONT_INTERCEPT },
             { "client",                 CMD_SPEC_DONT_INTERCEPT },
             { "config",                 CMD_SPEC_DONT_INTERCEPT },
             { "monitor",                CMD_SPEC_DONT_INTERCEPT },

--- a/raft.c
+++ b/raft.c
@@ -1823,13 +1823,13 @@ static bool handleMultiExec(RedisRaftCtx *rr, RaftReq *req)
 void handleInfoCommand(RedisRaftCtx *rr, RaftReq *req) {
     RaftRedisCommand *cmd = req->r.redis.cmds.commands[0];
 
-    const char * section = "all";
+    const char *section = "all";
 
     if (cmd->argc > 2) {
         /* Note: we can't use RM_WrongArity here because our req->ctx is a thread-safe context
          * with a synthetic client that no longer has the original argv.
          */
-        RedisModule_ReplyWithError(req->ctx, "ERR wrong number of arguments for 'cluster' command");
+        RedisModule_ReplyWithError(req->ctx, "ERR wrong number of arguments for 'info' command");
         goto exit;
     }
     if (cmd->argc == 2) {
@@ -1841,12 +1841,14 @@ void handleInfoCommand(RedisRaftCtx *rr, RaftReq *req) {
     const char *info = RedisModule_CallReplyProto(reply, &info_len);
 
     char * pos = strstr(info, "cluster_enabled:0");
-    pos += 16;
-    *pos = '1';
+    if (pos) {
+        pos += 16;
+        *pos = '1';
+    }
 
     RedisModule_ReplyWithStringBuffer(req->ctx, info, info_len);
 
-    exit:
+exit:
     RaftReqFree(req);
 }
 

--- a/raft.c
+++ b/raft.c
@@ -1842,7 +1842,7 @@ void handleInfoCommand(RedisRaftCtx *rr, RaftReq *req) {
 
     char * pos = strstr(info, "cluster_enabled:0");
     if (pos) {
-        pos += 16;
+        pos += strlen("cluster_enabled:");
         *pos = '1';
     }
 

--- a/raft.c
+++ b/raft.c
@@ -1263,9 +1263,7 @@ RRStatus RedisRaftInit(RedisModuleCtx *ctx, RedisRaftCtx *rr, RedisRaftConfig *c
     }
 
     /* Cluster configuration */
-    if (rr->config->sharding) {
-        ShardingInfoInit(rr);
-    }
+    ShardingInfoInit(rr);
 
     /* Raft log exists -> go into RAFT_LOADING state:
      *
@@ -1840,7 +1838,7 @@ void handleInfoCommand(RedisRaftCtx *rr, RaftReq *req) {
     size_t info_len;
     const char *info = RedisModule_CallReplyProto(reply, &info_len);
 
-    char * pos = strstr(info, "cluster_enabled:0");
+    char *pos = strstr(info, "cluster_enabled:0");
     if (pos) {
         pos += strlen("cluster_enabled:");
         *pos = '1';

--- a/redisraft.c
+++ b/redisraft.c
@@ -917,10 +917,9 @@ __attribute__((__unused__)) int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisMod
 
     /* Sanity check that not running with cluster_enabled */
     RedisModuleServerInfoData *info = RedisModule_GetServerInfo(ctx, "cluster");
-    const char * val = RedisModule_ServerInfoGetFieldC(info, "cluster_enabled");
-    int cluster_enabled = strncmp("1", val, 1);
+    int cluster_enabled = (int) RedisModule_ServerInfoGetFieldSigned(info, "cluster_enabled", NULL);
     RedisModule_FreeServerInfo(ctx, info);
-    if (!cluster_enabled) {
+    if (cluster_enabled) {
         RedisModule_Log(ctx, REDIS_NOTICE, "Redis Raft requires Redis not be started with cluster_enabled!");
         return REDISMODULE_ERR;
     }

--- a/redisraft.c
+++ b/redisraft.c
@@ -915,6 +915,16 @@ __attribute__((__unused__)) int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisMod
         return REDISMODULE_ERR;
     }
 
+    /* Sanity check that not running with cluster_enabled */
+    RedisModuleServerInfoData *info = RedisModule_GetServerInfo(ctx, "cluster");
+    const char * val = RedisModule_ServerInfoGetFieldC(info, "cluster_enabled");
+    int cluster_enabled = strncmp("1", val, 1);
+    RedisModule_FreeServerInfo(ctx, info);
+    if (!cluster_enabled) {
+        RedisModule_Log(ctx, REDIS_NOTICE, "Redis Raft requires Redis not be started with cluster_enabled!");
+        return REDISMODULE_ERR;
+    }
+
     /* Create a logging context */
     redis_raft_log_ctx = RedisModule_GetDetachedThreadSafeContext(ctx);
 

--- a/redisraft.c
+++ b/redisraft.c
@@ -606,6 +606,11 @@ static int cmdRaftShardGroup(RedisModuleCtx *ctx, RedisModuleString **argv, int 
         return REDISMODULE_OK;
     }
 
+    if (!redis_raft.config->sharding) {
+        RedisModule_ReplyWithError(ctx, "ERR: RedisRaft sharding not enabled");
+        return REDISMODULE_OK;
+    }
+
     size_t cmd_len;
     const char *cmd = RedisModule_StringPtrLen(argv[1], &cmd_len);
 

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -48,7 +48,7 @@ class PipeLogger(threading.Thread):
 
 
 class RedisRaft(object):
-    def __init__(self, _id, port, config, raft_args=None,
+    def __init__(self, _id, port, config, redis_args=None, raft_args=None,
                  use_id_arg=True, cluster_id=0):
         if raft_args is None:
             raft_args = {}
@@ -74,6 +74,7 @@ class RedisRaft(object):
                       '--bind', '0.0.0.0',
                       '--dir', self.serverdir,
                       '--dbfilename', self._dbfilename]
+        self.args += redis_args if redis_args else []
         self.args += ['--loadmodule', os.path.abspath(config.raftmodule)]
         if use_id_arg:
             raft_args['id'] = str(_id)
@@ -463,7 +464,7 @@ class Cluster(object):
 
     def add_node(self, raft_args=None, port=None, cluster_setup=True,
                  node_id=None, use_cluster_args=False, single_run=False,
-                 join_addr_list=None, **kwargs):
+                 join_addr_list=None, redis_args=None, **kwargs):
         _raft_args = raft_args
         if use_cluster_args:
             _raft_args = self.raft_args
@@ -473,7 +474,7 @@ class Cluster(object):
             port = self.base_port + _id
         node = None
         try:
-            node = RedisRaft(_id, port, self.config, raft_args=_raft_args,
+            node = RedisRaft(_id, port, self.config, redis_args, raft_args=_raft_args,
                 **kwargs)
             if cluster_setup:
                 if self.nodes:

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -10,7 +10,18 @@ import socket
 import time
 from redis import ResponseError
 from pytest import raises, skip
-from .sandbox import RedisRaft
+from .sandbox import RedisRaft, RedisRaftFailedToStart
+
+
+def test_info(cluster):
+    r1 = cluster.add_node()
+    data = r1.client.execute_command('info')
+    assert data["cluster_enabled"] == 1
+
+
+def test_fail_cluster_enabled(cluster):
+    with raises(RedisRaftFailedToStart):
+        r1 = cluster.add_node(redis_args=["--cluster_enabled", "yes"])
 
 
 def test_add_node_as_a_single_leader(cluster):


### PR DESCRIPTION
As Redis Raft does the clustering itself, it can't be run the cluster_enabled yes, but clients expect to see the flag set, so have to spoof it.