### PR TITLE
fail join and set state to unitialized if run out of nodes to join

### DIFF
--- a/common.c
+++ b/common.c
@@ -246,6 +246,7 @@ void joinLinkIdleCallback(Connection *conn)
 
 exit_fail:
     ConnAsyncTerminate(conn);
+    rr->state = REDIS_RAFT_UNINITIALIZED;
 
     snprintf(err_msg, sizeof(err_msg), "ERR failed to %s cluster, please check logs", state->type);
     RedisModule_ReplyWithError(state->req->ctx, err_msg);

--- a/common.c
+++ b/common.c
@@ -233,7 +233,13 @@ void joinLinkIdleCallback(Connection *conn)
         state->addr_iter = state->addr_iter->next;
     }
     if (!state->addr_iter) {
-        state->addr_iter = state->addr;
+        if (!state->started) {
+            state->started = true;
+            state->addr_iter = state->addr;
+        } else {
+            LOG_ERROR("exhausted all possible hosts to connect to");
+            goto exit_fail;
+        }
     }
 
     LOG_VERBOSE("%s cluster, connecting to %s:%u", state->type, state->addr_iter->addr.host, state->addr_iter->addr.port);

--- a/redisraft.h
+++ b/redisraft.h
@@ -645,6 +645,7 @@ typedef struct JoinLinkState {
     RaftReq *req;                       /* Original RaftReq, so we can return a reply */
     bool failed;                        /* unrecoverable failure */
     char *type;                         /* error message to print if exhaust time */
+    bool started;                       /* we have started connecting */
     ConnectionCallbackFunc connect_callback;
 } JoinLinkState;
 


### PR DESCRIPTION
Before, once we start a join, the state stays in joining and keeps on retrying nodes that have failed

This means, that one can't issue another join, as the state is no longer uninitialized

this changes both things.

1) once we iterate through all given/discovered nodes, fail back to user with error message
2) when we fail back to user, reset state to unitialized

fixes #187