### PR TITLE
Make save and bgsave unsupported

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -77,6 +77,8 @@ RRStatus CommandSpecInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
             { "debug",                  CMD_SPEC_UNSUPPORTED },
             { "watch",                  CMD_SPEC_UNSUPPORTED },
             { "unwatch",                CMD_SPEC_UNSUPPORTED },
+            { "save",                   CMD_SPEC_UNSUPPORTED },
+            { "bgsave",                 CMD_SPEC_UNSUPPORTED },
             /* Blocking commands not supported */
             { "brpop",                  CMD_SPEC_UNSUPPORTED },
             { "brpoplpush",             CMD_SPEC_UNSUPPORTED },
@@ -106,8 +108,6 @@ RRStatus CommandSpecInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
             { "auth",                   CMD_SPEC_DONT_INTERCEPT },
             { "ping",                   CMD_SPEC_DONT_INTERCEPT },
             { "hello",                  CMD_SPEC_DONT_INTERCEPT },
-            { "save",                   CMD_SPEC_DONT_INTERCEPT },
-            { "bgsave",                 CMD_SPEC_DONT_INTERCEPT },
             { "module",                 CMD_SPEC_DONT_INTERCEPT },
             { "client",                 CMD_SPEC_DONT_INTERCEPT },
             { "config",                 CMD_SPEC_DONT_INTERCEPT },

--- a/tests/integration/test_snapshots.py
+++ b/tests/integration/test_snapshots.py
@@ -279,7 +279,7 @@ def test_loading_log_tail(cluster):
     assert r1.client.incr('testkey')
     assert r1.client.incr('testkey')
     assert r1.client.incr('testkey')
-    r1.client.save()
+    assert r1.client.execute_command('RAFT.DEBUG', 'COMPACT') == b'OK'
     assert r1.client.incr('testkey')
     assert r1.client.incr('testkey')
     assert r1.client.incr('testkey')


### PR DESCRIPTION
Rdb save should be handled by RedisRaft as we need generate and store raft config for the last applied entry. 