### PR TITLE
Don't advance commit index on a single node cluster

### DIFF
--- a/raft.c
+++ b/raft.c
@@ -818,16 +818,7 @@ RRStatus applyLoadedRaftLog(RedisRaftCtx *rr)
             rr->snapshot_info.last_applied_term);
     }
 
-    /* Special case: if no other nodes, set commit index to the latest
-     * entry in the log.
-     */
-    if (raft_get_num_voting_nodes(rr->raft) == 1 || raft_get_num_nodes(rr->raft) == 1) {
-        LOG_DEBUG("No other voting nodes, setting commit index to %ld",
-            raft_get_current_idx(rr->raft));
-        raft_set_commit_idx(rr->raft, raft_get_current_idx(rr->raft));
-    } else {
-        raft_set_commit_idx(rr->raft, rr->snapshot_info.last_applied_idx);
-    }
+    raft_set_commit_idx(rr->raft, rr->snapshot_info.last_applied_idx);
 
     memcpy(rr->snapshot_info.dbid, rr->log->dbid, RAFT_DBID_LEN);
     rr->snapshot_info.dbid[RAFT_DBID_LEN] = '\0';

--- a/tests/integration/test_snapshots.py
+++ b/tests/integration/test_snapshots.py
@@ -279,7 +279,7 @@ def test_loading_log_tail(cluster):
     assert r1.client.incr('testkey')
     assert r1.client.incr('testkey')
     assert r1.client.incr('testkey')
-    r1.client.save()
+    assert r1.client.execute_command('RAFT.DEBUG', 'COMPACT') == b'OK'
     assert r1.client.incr('testkey')
     assert r1.client.incr('testkey')
     assert r1.client.incr('testkey')


### PR DESCRIPTION
If the node is non-voting, it should not advance the commit index on a single node cluster according to Raft. It's better to leave this to raft library, commit index will be discovered later.