### PR TITLE
enable RAFT.CLUSTER INIT to define the local cluster id string

### DIFF
--- a/raft.c
+++ b/raft.c
@@ -1074,10 +1074,21 @@ RRStatus initRaftLog(RedisModuleCtx *ctx, RedisRaftCtx *rr)
     return RR_OK;
 }
 
-RRStatus initCluster(RedisModuleCtx *ctx, RedisRaftCtx *rr, RedisRaftConfig *config)
+RRStatus initCluster(RedisModuleCtx *ctx, RedisRaftCtx *rr, RedisRaftConfig *config, RedisModuleString *id)
 {
     /* Initialize dbid */
-    RedisModule_GetRandomHexChars(rr->snapshot_info.dbid, RAFT_DBID_LEN);
+    if (id == NULL) {
+        RedisModule_GetRandomHexChars(rr->snapshot_info.dbid, RAFT_DBID_LEN);
+    } else {
+        const char *id_str;
+        size_t len;
+        id_str = RedisModule_StringPtrLen(id, &len);
+        if (len != RAFT_DBID_LEN) {
+            RedisModule_Log(ctx, REDIS_WARNING, "cluster id must be %d characters", RAFT_DBID_LEN);
+            return RR_ERROR;
+        }
+        memcpy(rr->snapshot_info.dbid, id_str, RAFT_DBID_LEN);
+    }
     rr->snapshot_info.dbid[RAFT_DBID_LEN] = '\0';
 
     /* This is the first node, so there are no used node ids yet */
@@ -1305,6 +1316,11 @@ void RaftReqFree(RaftReq *req)
     TRACE("RaftReqFree: req=%p, req->ctx=%p, req->client=%p", req, req->ctx, req->client);
 
     switch (req->type) {
+        case RR_CLUSTER_INIT:
+            if (req->r.cluster_init.id) {
+                RedisModule_FreeString(req->ctx, req->r.cluster_init.id);
+                req->r.cluster_init.id = NULL;
+            }
         case RR_APPENDENTRIES:
             /* Note: we only free the array of entries but not actual entries, as they
              * are owned by the log and should be freed when the log entry is freed.
@@ -2176,7 +2192,7 @@ static void handleClusterInit(RedisRaftCtx *rr, RaftReq *req)
         goto exit;
     }
 
-    if (initCluster(req->ctx, rr, rr->config) == RR_ERROR) {
+    if (initCluster(req->ctx, rr, rr->config, req->r.cluster_init.id) == RR_ERROR) {
         RedisModule_ReplyWithError(req->ctx, "ERR Failed to initialize, check logs");
         goto exit;
     }

--- a/redisraft.c
+++ b/redisraft.c
@@ -524,8 +524,9 @@ error:
     return REDISMODULE_OK;
 }
 
-/* RAFT.CLUSTER INIT
+/* RAFT.CLUSTER INIT <id>
  *   Initializes a new Raft cluster.
+ *   <id> is an optional 32 character string, if set, cluster will use it for the id
  * Reply:
  *   +OK [dbid]
  *
@@ -549,11 +550,14 @@ static int cmdRaftCluster(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
     size_t cmd_len;
     const char *cmd = RedisModule_StringPtrLen(argv[1], &cmd_len);
     if (!strncasecmp(cmd, "INIT", cmd_len)) {
-        if (argc != 2) {
+        if (argc < 2 || argc > 3) {
             RedisModule_WrongArity(ctx);
             return REDISMODULE_OK;
         }
         req = RaftReqInit(ctx, RR_CLUSTER_INIT);
+        if (argc == 3) {
+            req->r.cluster_init.id = RedisModule_CreateStringFromString(ctx, argv[2]);
+        }
     } else if (!strncasecmp(cmd, "JOIN", cmd_len)) {
         if (argc < 3) {
             RedisModule_WrongArity(ctx);

--- a/redisraft.c
+++ b/redisraft.c
@@ -550,14 +550,26 @@ static int cmdRaftCluster(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
     size_t cmd_len;
     const char *cmd = RedisModule_StringPtrLen(argv[1], &cmd_len);
     if (!strncasecmp(cmd, "INIT", cmd_len)) {
-        if (argc < 2 || argc > 3) {
+        if (argc != 2 && argc != 3) {
             RedisModule_WrongArity(ctx);
             return REDISMODULE_OK;
         }
-        req = RaftReqInit(ctx, RR_CLUSTER_INIT);
-        if (argc == 3) {
-            req->r.cluster_init.id = RedisModule_CreateStringFromString(ctx, argv[2]);
+
+        char cluster_id[RAFT_DBID_LEN];
+        if (argc == 2) {
+            RedisModule_GetRandomHexChars(cluster_id, RAFT_DBID_LEN);
+        } else {
+            size_t len;
+            const char *reqId = RedisModule_StringPtrLen(argv[2], &len);
+            if (len != RAFT_DBID_LEN) {
+                RedisModule_ReplyWithError(ctx, "ERR cluster id must be 32 characters");
+                return REDISMODULE_OK;
+            }
+            memcpy(cluster_id, reqId, RAFT_DBID_LEN);
         }
+
+        req = RaftReqInit(ctx, RR_CLUSTER_INIT);
+        memcpy(req->r.cluster_init.id, cluster_id, RAFT_DBID_LEN);
     } else if (!strncasecmp(cmd, "JOIN", cmd_len)) {
         if (argc < 3) {
             RedisModule_WrongArity(ctx);

--- a/redisraft.h
+++ b/redisraft.h
@@ -558,6 +558,9 @@ typedef struct RaftReq {
             long long len;
         } shardgroups_replace;
         raft_node_id_t node_to_transfer_leader;
+        struct {
+            RedisModuleString *id;
+        } cluster_init;
     } r;
 } RaftReq;
 

--- a/redisraft.h
+++ b/redisraft.h
@@ -559,7 +559,7 @@ typedef struct RaftReq {
         } shardgroups_replace;
         raft_node_id_t node_to_transfer_leader;
         struct {
-            RedisModuleString *id;
+            char id[RAFT_DBID_LEN];
         } cluster_init;
     } r;
 } RaftReq;

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -132,10 +132,15 @@ class RedisRaft(object):
                         raise err
                 time.sleep(0.1)
 
-    def init(self):
+    def init(self, cluster_id=None):
         self.cleanup()
         self.start()
-        dbid = self.cluster('init')
+
+        if cluster_id is None:
+            dbid = self.cluster('init')
+        else:
+            dbid = self.cluster('init', cluster_id)
+
         LOG.info('Cluster created: %s', dbid)
         return self
 
@@ -432,7 +437,7 @@ class Cluster(object):
     def node_addresses(self):
         return [n.address for n in self.nodes.values()]
 
-    def create(self, node_count, raft_args=None, prepopulate_log=0):
+    def create(self, node_count, raft_args=None, cluster_id=None, prepopulate_log=0):
         if raft_args is None:
             raft_args = {}
         self.raft_args = raft_args.copy()
@@ -445,7 +450,7 @@ class Cluster(object):
         self.next_id = node_count + 1
         for _id, node in self.nodes.items():
             if _id == 1:
-                node.init()
+                node.init(cluster_id=cluster_id)
             else:
                 logging.info("{} joining".format(_id))
                 node.join(['localhost:{}'.format(self.base_port + 1)])

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -19,6 +19,12 @@ def test_info(cluster):
     assert data["cluster_enabled"] == 1
 
 
+def test_set_cluster_id(cluster):
+    id = "12345678901234567890123456789012"
+    cluster.create(3, cluster_id=id)
+    data = cluster.leader_node().client.execute_command('info')
+    assert data["dbid"] == id
+
 def test_fail_cluster_enabled(cluster):
     with raises(RedisRaftFailedToStart):
         r1 = cluster.add_node(redis_args=["--cluster_enabled", "yes"])

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -22,8 +22,8 @@ def test_info(cluster):
 def test_set_cluster_id(cluster):
     id = "12345678901234567890123456789012"
     cluster.create(3, cluster_id=id)
-    data = cluster.leader_node().client.execute_command('info')
-    assert data["dbid"] == id
+    assert str(cluster.leader_node().raft_info()["dbid"]) == id
+
 
 def test_fail_cluster_enabled(cluster):
     with raises(RedisRaftFailedToStart):

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -25,6 +25,18 @@ def test_set_cluster_id(cluster):
     assert str(cluster.leader_node().raft_info()["dbid"]) == id
 
 
+def test_set_cluster_id_too_short(cluster):
+    id = "123456789012345678901234567890"
+    with raises(ResponseError, match='cluster id must be 32 characters'):
+        cluster.create(3, cluster_id=id)
+
+
+def test_set_cluster_id_too_long(cluster):
+    id = "1234567890123456789012345678901234"
+    with raises(ResponseError, match='cluster id must be 32 characters'):
+        cluster.create(3, cluster_id=id)
+
+
 def test_fail_cluster_enabled(cluster):
     with raises(RedisRaftFailedToStart):
         r1 = cluster.add_node(redis_args=["--cluster_enabled", "yes"])


### PR DESCRIPTION
it is enforced to be 32 characters