### PR TITLE
Update rdbSave() prototype and require Redis build from unstable branch

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -45,7 +45,7 @@ jobs:
                   --test-count 20 \
                   --concurrency 4n \
                   --nemesis kill,pause,partition,member \
-                  --redis-version 6.2.2 \
+                  --redis-version 87789fae0 \
                   --raft-repo https://github.com/${{ env.REDISRAFT_REPO }} \
                   --raft-version ${{ env.REDISRAFT_VERSION }} | rg --passthrough '^0 failures'
     - name: Archive Jepsen results

--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ To build, simply run:
 
 ### Creating a RedisRaft Cluster
 
-Note: RedisRaft requires Redis 6.0 or above.
+RedisRaft requires the latest Redis build from 'unstable' branch. Build Redis first:
+    
+    git clone https://github.com/redis/redis  
+    cd redis
+    make 
+    make install
 
 To create a three-node cluster, start the first node:
 

--- a/snapshot.c
+++ b/snapshot.c
@@ -19,7 +19,7 @@
  */
 
 int rdbLoad(const char *filename, void *info, int flags);
-int rdbSave(const char *filename, void *info);
+int rdbSave(int flags, const char *filename, void *info);
 
 /* ------------------------------------ Snapshot metadata ------------------------------------ */
 
@@ -426,7 +426,7 @@ RRStatus initiateSnapshot(RedisRaftCtx *rr)
         snprintf(sr.rdb_filename, sizeof(sr.rdb_filename) - 1, "%s.tmp.%d",
             rr->config->rdb_filename, (int) getpid());
 
-        if (rdbSave(sr.rdb_filename, NULL) != 0) {
+        if (rdbSave(0, sr.rdb_filename, NULL) != 0) {
             snprintf(sr.err, sizeof(sr.err) - 1, "%s", "rdbSave() failed");
             goto exit;
         }


### PR DESCRIPTION
Updated rdbSave() protoype to reflect latest changes from Redis unstable branch. 

https://github.com/redis/redis/pull/9968 changes the rdbSave() prototype, we need to update in RedisRaft as well. After this commit, RedisRaft requires the latest Redis build from unstable branch.