### PR TITLE
fix raftNodeHasSufficientLogs assert

### DIFF
--- a/raft.c
+++ b/raft.c
@@ -636,11 +636,9 @@ static int raftNodeHasSufficientLogs(raft_server_t *raft, void *user_data, raft_
     cfgchange->addr = node->addr;
 
     int e = raft_recv_entry(raft, entry, &response);
-    assert(e == 0);
-
     raft_entry_release(entry);
 
-    return 0;
+    return e;
 }
 
 void raftNotifyMembershipEvent(raft_server_t *raft, void *user_data, raft_node_t *raft_node,


### PR DESCRIPTION
raft_recv_entry (for config changes, which this does) can fail.  this assumed it couldn't.

the caller of this callback already expected it could fail.