### PR TITLE
Make pollSnapshotStatus() return negative if snapshot failed

### DIFF
--- a/raft.c
+++ b/raft.c
@@ -2142,9 +2142,11 @@ static void handleInfo(RedisRaftCtx *rr, RaftReq *req)
     s = catsnprintf(s, &slen,
             "\r\n# Snapshot\r\n"
             "snapshot_in_progress:%s\r\n"
-            "snapshots_loaded:%lu\r\n",
+            "snapshots_loaded:%lu\r\n"
+            "snapshots_created:%lu\r\n",
             rr->snapshot_in_progress ? "yes" : "no",
-            rr->snapshots_loaded);
+            rr->snapshots_loaded,
+            rr->snapshots_created);
 
     s = catsnprintf(s, &slen,
             "\r\n# Clients\r\n"

--- a/redisraft.c
+++ b/redisraft.c
@@ -718,6 +718,7 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     cmd[cmdlen] = '\0';
 
     if (!strncasecmp(cmd, "compact", cmdlen)) {
+        long long fail = 0;
         long long delay = 0;
         if (argc == 3) {
             if (RedisModule_StringToLongLong(argv[2], &delay) != REDISMODULE_OK) {
@@ -725,9 +726,16 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
                 return REDISMODULE_OK;
             }
         }
+        if (argc == 4) {
+            if (RedisModule_StringToLongLong(argv[3], &fail) != REDISMODULE_OK) {
+                RedisModule_ReplyWithError(ctx, "ERR invalid compact fail value");
+                return REDISMODULE_OK;
+            }
+        }
 
         RaftReq *req = RaftDebugReqInit(ctx, RR_DEBUG_COMPACT);
-        req->r.debug.d.compact.delay = delay;
+        req->r.debug.d.compact.delay = (int) delay;
+        req->r.debug.d.compact.fail = (int) fail;
         RaftReqSubmit(&redis_raft, req);
     } else if (!strncasecmp(cmd, "nodecfg", cmdlen)) {
         if (argc != 4) {

--- a/redisraft.h
+++ b/redisraft.h
@@ -277,6 +277,7 @@ typedef struct RedisRaftCtx {
     unsigned long long proxy_failed_responses;   /* Number of failed proxy responses, i.e. did not complete */
     unsigned long proxy_outstanding_reqs;        /* Number of proxied requests pending */
     unsigned long snapshots_loaded;              /* Number of snapshots loaded */
+    unsigned long snapshots_created;             /* Number of snapshots created */
     char *resp_call_fmt;                         /* Format string to use in RedisModule_Call(), Redis version-specific */
 } RedisRaftCtx;
 
@@ -500,6 +501,7 @@ typedef struct RaftDebugReq {
     union {
         struct {
             int delay;
+            int fail;
         } compact;
         struct {
             raft_node_id_t id;

--- a/snapshot.c
+++ b/snapshot.c
@@ -428,6 +428,8 @@ RRStatus initiateSnapshot(RedisRaftCtx *rr)
             }
 
             if (rr->debug_req->r.debug.d.compact.fail) {
+                strncpy(sr.err, "debug rdbSave() failed", sizeof(sr.err));
+                sr.err[sizeof(sr.err) - 1] = '\0';
                 goto exit;
             }
         }

--- a/snapshot.c
+++ b/snapshot.c
@@ -317,11 +317,13 @@ int pollSnapshotStatus(RedisRaftCtx *rr, SnapshotResult *sr)
 
     if (sr->magic != SNAPSHOT_RESULT_MAGIC) {
         LOG_ERROR("Corrupted snapshot result (magic=%08x)", sr->magic);
+        ret = -1;
         goto exit;
     }
 
     if (!sr->success) {
         LOG_ERROR("Snapshot failed: %s", sr->err);
+        ret = -1;
         goto exit;
     }
 

--- a/tests/integration/test_snapshots.py
+++ b/tests/integration/test_snapshots.py
@@ -8,6 +8,8 @@ RedisRaft is licensed under the Redis Source Available License (RSAL).
 
 import shutil
 import os
+from redis import ResponseError
+from pytest import raises
 from .raftlog import RaftLog, LogEntry
 
 
@@ -393,3 +395,29 @@ def test_log_reset_on_snapshot_load(cluster):
 
     assert cluster.execute('INCR', 'last-key')
     cluster.wait_for_unanimity()
+
+def test_snapshot_failure(cluster):
+    """
+    Ability to properly handle snapshot failure
+    """
+
+    r1 = cluster.add_node()
+    r1.client.incr('testkey')
+    r1.client.incr('testkey')
+    r1.client.incr('testkey')
+    r1.client.incr('testkey')
+    assert r1.client.get('testkey') == b'4'
+
+    assert r1.raft_info()['snapshots_created'] == 0
+    with raises(ResponseError):
+        r1.client.execute_command('RAFT.DEBUG', 'COMPACT', '0', '1')
+
+    assert r1.raft_info()['snapshots_created'] == 0
+    assert r1.client.execute_command('RAFT.DEBUG', 'COMPACT', '0', '0') == b'OK'
+    assert r1.raft_info()['snapshots_created'] == 1
+
+    r1.client.incr('testkey')
+    r1.client.incr('testkey')
+    r1.client.incr('testkey')
+    r1.client.incr('testkey')
+    assert r1.client.get('testkey') == b'8'


### PR DESCRIPTION
- pollSnapshotStatus() must return -1 if snapshot fork reports a failure.
- Added test for it.