### PR TITLE
Enable slot-config to be set with raft.config set before init/join

### DIFF
--- a/config.c
+++ b/config.c
@@ -272,19 +272,19 @@ invalid_value:
 
 void handleConfigSet(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 {
-    if (argc != 4) {
+    if (argc != 2) {
         RedisModule_WrongArity(ctx);
         return;
     }
 
     size_t key_len;
-    const char *key = RedisModule_StringPtrLen(argv[2], &key_len);
+    const char *key = RedisModule_StringPtrLen(argv[0], &key_len);
     char keybuf[key_len + 1];
     memcpy(keybuf, key, key_len);
     keybuf[key_len] = '\0';
 
     size_t value_len;
-    const char *value = RedisModule_StringPtrLen(argv[3], &value_len);
+    const char *value = RedisModule_StringPtrLen(argv[1], &value_len);
     char valuebuf[value_len + 1];
     memcpy(valuebuf, value, value_len);
     valuebuf[value_len] = '\0';
@@ -330,14 +330,14 @@ static void replyConfigBool(RedisModuleCtx *ctx, const char *name, bool val)
 
 void handleConfigGet(RedisModuleCtx *ctx, RedisRaftConfig *config, RedisModuleString **argv, int argc)
 {
-    if (argc != 3) {
+    if (argc != 1) {
         RedisModule_WrongArity(ctx);
         return;
     }
 
     int len = 0;
     size_t pattern_len;
-    const char *pattern = RedisModule_StringPtrLen(argv[2], &pattern_len);
+    const char *pattern = RedisModule_StringPtrLen(argv[0], &pattern_len);
 
     RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
     if (stringmatch(pattern, CONF_ID, 1)) {

--- a/redisraft.h
+++ b/redisraft.h
@@ -334,7 +334,7 @@ typedef struct RedisRaftConfig {
     bool raft_log_fsync;
     /* Cluster mode */
     bool sharding;                      /* Are we running in a sharding configuration? */
-    char *slot_config;                  /* Defining multiple slot ranges (# or #:#) that are delimited by ',' */
+    const char *slot_config;                  /* Defining multiple slot ranges (# or #:#) that are delimited by ',' */
     int shardgroup_update_interval;     /* Milliseconds between shardgroup updates */
     char *ignored_commands;             /* Comma delimited list of commands that should not be intercepted */
     int external_sharding;              /* use external sharding orchestrator only */

--- a/redisraft.h
+++ b/redisraft.h
@@ -334,7 +334,7 @@ typedef struct RedisRaftConfig {
     bool raft_log_fsync;
     /* Cluster mode */
     bool sharding;                      /* Are we running in a sharding configuration? */
-    const char *slot_config;                  /* Defining multiple slot ranges (# or #:#) that are delimited by ',' */
+    const char *slot_config;            /* Defining multiple slot ranges (# or #:#) that are delimited by ',' */
     int shardgroup_update_interval;     /* Milliseconds between shardgroup updates */
     char *ignored_commands;             /* Comma delimited list of commands that should not be intercepted */
     int external_sharding;              /* use external sharding orchestrator only */

--- a/redisraft.h
+++ b/redisraft.h
@@ -390,6 +390,8 @@ enum RaftReqType {
     RR_NODE_SHUTDOWN,
     RR_TRANSFER_LEADER,
     RR_TIMEOUT_NOW,
+    RR_CONFIG_SET,
+    RR_CONFIG_GET,
 };
 
 extern const char *RaftReqTypeStr[];
@@ -561,6 +563,10 @@ typedef struct RaftReq {
         struct {
             char id[RAFT_DBID_LEN];
         } cluster_init;
+        struct {
+            RedisModuleString **argv;
+            int argc;
+        } config;
     } r;
 } RaftReq;
 


### PR DESCRIPTION
This is to enable orchestrators to configure redisraft nodes not just via the command line.