### PR TITLE
Extend raft.shardgroup replace to change hash slot owneship

### DIFF
--- a/cluster.c
+++ b/cluster.c
@@ -758,8 +758,19 @@ RRStatus ShardingInfoValidateShardGroup(RedisRaftCtx *rr, ShardGroup *new_sg)
 
         for (int i = new_sg->slot_ranges[h].start_slot; i <= new_sg->slot_ranges[h].end_slot; i++) {
             if (si->stable_slots_map[i] != 0) {
-                LOG_ERROR("Invalid shardgroup: hash slot already mapped: %u", i);
+                LOG_ERROR("Invalid shardgroup: hash slot already mapped as stable: %u", i);
                 return RR_ERROR;
+            }
+            if (new_sg->slot_ranges[h].type == SLOTRANGE_TYPE_MIGRATING) {
+                if (si->migrating_slots_map[i] != 0) {
+                    LOG_ERROR("Invalid shardgroup: hash slot already mapped as migrating: %u", i);
+                    return RR_ERROR;
+                }
+            } else if (new_sg->slot_ranges[h].type == SLOTRANGE_TYPE_IMPORTING) {
+                if (si->importing_slots_map[i] != 0) {
+                    LOG_ERROR("Invalid shardgroup: hash slot already mapped as importing: %u", i);
+                    return RR_ERROR;
+                }
             }
         }
     }

--- a/cluster.c
+++ b/cluster.c
@@ -621,7 +621,6 @@ void ShardingInfoRDBSave(RedisModuleIO *rdb)
         return;
     }
 
-    /* When saving, skip shardgroup #1 which is the local cluster */
     RedisModule_SaveUnsigned(rdb, si->shard_groups_num);
     if (si->shard_group_map != NULL) {
         RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(si->shard_group_map, "^", NULL, 0);

--- a/cluster.c
+++ b/cluster.c
@@ -1024,11 +1024,9 @@ RRStatus ShardGroupsParse(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
                 case SLOTRANGE_TYPE_STABLE:
                     for(unsigned int l=sr->start_slot; l <= sr->end_slot; l++) {
                         if (stable[l]) {
-                            printf("ERR Unable to validate shard groups: shard group already owns this slot\n");
                             RedisModule_ReplyWithError(ctx, "ERR Unable to validate shard groups: shard group already owns this slot");
                             goto fail;
                         } else if (importing[l] || migrating[l]) {
-                            printf("ERR Unable to validate shard groups: slot(%d) marked for resharding\n", l);
                             RedisModule_ReplyWithError(ctx, "ERR Unable to validate shard groups: slot marked for resharding");
                             goto fail;
                         }
@@ -1038,11 +1036,9 @@ RRStatus ShardGroupsParse(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
                 case SLOTRANGE_TYPE_IMPORTING:
                     for(unsigned int l=sr->start_slot; l <= sr->end_slot; l++) {
                         if (stable[l]) {
-                            printf("Unable to validate shard groups: shard group already owns this slot\n");
                             RedisModule_ReplyWithError(ctx, "ERR Unable to validate shard groups: shard group already owns this slot");
                             goto fail;
                         } else if (importing[l]) {
-                            printf("ERR Unable to validate shard groups: shard group already importing this slot\n");
                             RedisModule_ReplyWithError(ctx, "ERR Unable to validate shard groups: shard group already importing this slot");
                             goto fail;
                         }
@@ -1052,11 +1048,9 @@ RRStatus ShardGroupsParse(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
                 case SLOTRANGE_TYPE_MIGRATING:
                     for(unsigned int l=sr->start_slot; l <= sr->end_slot; l++) {
                         if (stable[l]) {
-                            printf("Unable to validate shard groups: shard group already owns this slot\n");
                             RedisModule_ReplyWithError(ctx, "ERR Unable to validate shard groups: shard group already owns this slot");
                             goto fail;
                         } else if (migrating[l]) {
-                            printf("Unable to validate shard groups: shard group already migrating this slot\n");
                             RedisModule_ReplyWithError(ctx, "ERR Unable to validate shard groups: shard group already migrating this slot");
                             goto fail;
                         }
@@ -1064,7 +1058,6 @@ RRStatus ShardGroupsParse(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
                     }
                     break;
                 default:
-                    printf("Unable to validate shard groups: unknown shard group type\n");
                     RedisModule_ReplyWithError(ctx, "ERR Unable to validate shard groups: unknown shard group type");
                     goto fail;
             }

--- a/cluster.c
+++ b/cluster.c
@@ -92,8 +92,10 @@ char *ShardGroupSerialize(ShardGroup *sg)
 /* Deserialize a ShardGroup from the specified buffer. The target ShardGroup is assumed
  * to be uninitialized, and the nodes array will be allocated on demand.
  */
-RRStatus ShardGroupDeserialize(const char *buf, size_t buf_len, ShardGroup *sg)
+ShardGroup * ShardGroupDeserialize(const char *buf, size_t buf_len)
 {
+    ShardGroup * sg = ShardGroupCreate();
+
     /* Make a mutable, null terminated copy */
     const char *s = buf;
     const char *end = buf + buf_len;
@@ -195,10 +197,11 @@ RRStatus ShardGroupDeserialize(const char *buf, size_t buf_len, ShardGroup *sg)
         s = nl + 1;
     }
 
-    return RR_OK;
+    return sg;
 
 error:
-    return RR_ERROR;
+    ShardGroupFree(sg);
+    return NULL;
 }
 
 /* Initialize a (previously allocated) shardgroup structure.

--- a/cluster.c
+++ b/cluster.c
@@ -759,17 +759,17 @@ RRStatus ShardingInfoValidateShardGroup(RedisRaftCtx *rr, ShardGroup *new_sg)
         }
 
         for (int i = new_sg->slot_ranges[h].start_slot; i <= new_sg->slot_ranges[h].end_slot; i++) {
-            if (si->stable_slots_map[i] != 0) {
+            if (si->stable_slots_map[i] != NULL) {
                 LOG_ERROR("Invalid shardgroup: hash slot already mapped as stable: %u", i);
                 return RR_ERROR;
             }
             if (new_sg->slot_ranges[h].type == SLOTRANGE_TYPE_MIGRATING) {
-                if (si->migrating_slots_map[i] != 0) {
+                if (si->migrating_slots_map[i] != NULL) {
                     LOG_ERROR("Invalid shardgroup: hash slot already mapped as migrating: %u", i);
                     return RR_ERROR;
                 }
             } else if (new_sg->slot_ranges[h].type == SLOTRANGE_TYPE_IMPORTING) {
-                if (si->importing_slots_map[i] != 0) {
+                if (si->importing_slots_map[i] != NULL) {
                     LOG_ERROR("Invalid shardgroup: hash slot already mapped as importing: %u", i);
                     return RR_ERROR;
                 }

--- a/cluster.c
+++ b/cluster.c
@@ -877,12 +877,13 @@ fail:
 }
 
 /* Parse a ShardGroup specification as passed directly to RAFT.SHARDGROUP ADD.
- * Shard group syntax is as follows:
+ * Shard group argv syntax is as follows:
  *
  *  [shardgroup id] [num_slots] [num_nodes] ([start slot] [end slot] [slot type])* ([node-uid node-addr:node-port])*
  *
- * If parsing errors are encountered, an error reply is generated on the supplied RedisModuleCtx and -1 is returned.
- * If it was processed successfully, the number of argv elements consumed is returned.
+ * If parsing errors are encountered, an error reply is generated on the supplied RedisModuleCtx and NULL is returned
+ * If it was processed successfully, a pointer to an allocated ShardGroup is returned and the number of consumed
+ * argv elements is set to the integer pointed to by num_argv_entries
  */
 
 ShardGroup *ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int base_argv_idx, int *num_argv_entries)

--- a/cluster.c
+++ b/cluster.c
@@ -879,7 +879,7 @@ fail:
 /* Parse a ShardGroup specification as passed directly to RAFT.SHARDGROUP ADD.
  * Shard group argv syntax is as follows:
  *
- *  [shardgroup id] [num_slots] [num_nodes] ([start slot] [end slot] [slot type])* ([node-uid node-addr:node-port])*
+ *  [shardgroup id] [num_slots] [num_nodes] ([start slot] [end slot] [slot type])* ([node-uid] [node-addr:node-port])*
  *
  * If parsing errors are encountered, an error reply is generated on the supplied RedisModuleCtx and NULL is returned
  * If it was processed successfully, a pointer to an allocated ShardGroup is returned and the number of consumed
@@ -980,6 +980,11 @@ error:
 }
 
 /* parses all the shardgroups in a replace call and validates them */
+/*
+ * It is able to validate them at this point, because the replace call has a view of the entire world
+ * and replaces the entire world.  Therefore, its not dependent on the state of the ShardGroups at any
+ * point in time.
+ */
 RRStatus ShardGroupsParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RaftReq *req)
 {
     long long val;

--- a/cluster.c
+++ b/cluster.c
@@ -787,6 +787,7 @@ RRStatus ShardingInfoValidateShardGroup(RedisRaftCtx *rr, ShardGroup *new_sg)
 RRStatus ShardingInfoUpdateShardGroup(RedisRaftCtx *rr, ShardGroup *new_sg)
 {
     RRStatus ret = RR_ERROR;
+
     if (!memcmp(rr->snapshot_info.dbid, new_sg->id, sizeof(new_sg->id))) {
         /* TODO: when we can update slots, that is the only thing that will be updated here */
     } else {

--- a/cluster.c
+++ b/cluster.c
@@ -198,7 +198,6 @@ RRStatus ShardGroupDeserialize(const char *buf, size_t buf_len, ShardGroup *sg)
     return RR_OK;
 
 error:
-    ShardGroupFree(sg);
     return RR_ERROR;
 }
 

--- a/cluster.c
+++ b/cluster.c
@@ -902,8 +902,7 @@ int ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, Sha
     }
     argidx++;
 
-    memcpy((*sg)
-    ->id, id, len);
+    memcpy((*sg)->id, id, len);
     (*sg)->id[RAFT_DBID_LEN] = '\0';
 
     if (RedisModule_StringToLongLong(argv[1], &num_slots) != REDISMODULE_OK) {

--- a/raft.c
+++ b/raft.c
@@ -1904,7 +1904,7 @@ static bool handleInterceptedCommands(RedisRaftCtx *rr, RaftReq *req)
  *
  * 1. Compute hash slot of all associated keys and validate there's no cross-slot
  *    violation.
- * 2. Update the request's hash_slot for future refrence.
+ * 2. Update the request's hash_slot for future reference.
  * 3. If the hash slot is associated with a foreign ShardGroup, perform a redirect.
  * 4. If the hash slot is not mapped, produce a CLUSTERDOWN error.
  */

--- a/raft.c
+++ b/raft.c
@@ -2386,10 +2386,7 @@ void replaceShardGroups(RedisRaftCtx *rr, raft_entry_t *entry)
         ShardGroup *data;
 
         while ((key = RedisModule_DictNextC(iter, &key_len, (void **) &data)) != NULL) {
-            /* local shardgroup will not have a filled in id */
-            if (*data->id != 0) {
-                ShardGroupFree(data);
-            }
+            ShardGroupFree(data);
         }
         RedisModule_DictIteratorStop(iter);
         RedisModule_FreeDict(rr->ctx, si->shard_group_map);

--- a/raft.c
+++ b/raft.c
@@ -1911,7 +1911,7 @@ static bool handleInterceptedCommands(RedisRaftCtx *rr, RaftReq *req)
 
 static RRStatus handleSharding(RedisRaftCtx *rr, RaftReq *req)
 {
-    if (computeHashSlot(rr, req) != RR_OK) {
+    if (computeHashSlotOrReplyError(rr, req) != RR_OK) {
         return RR_ERROR;
     }
 

--- a/raft.c
+++ b/raft.c
@@ -2333,6 +2333,7 @@ void applyShardGroupChange(RedisRaftCtx *rr, raft_entry_t *entry)
     RRStatus ret;
 
     if (ShardGroupDeserialize(entry->data, entry->data_len, sg) != RR_OK) {
+        ShardGroupFree(sg);
         LOG_ERROR("Failed to deserialize ADD_SHARDGROUP payload: [%.*s]",
                 entry->data_len, entry->data);
         return;
@@ -2417,6 +2418,7 @@ void replaceShardGroups(RedisRaftCtx *rr, raft_entry_t *entry)
 
         ShardGroup *sg = ShardGroupCreate();
         if (ShardGroupDeserialize(payload, payload_len, sg) != RR_OK) {
+            ShardGroupFree(sg);
             LOG_ERROR("Failed to deserialize shardgroup payload: [%.*s]", (int) payload_len, payload);
             return;
         }

--- a/raft.c
+++ b/raft.c
@@ -2346,7 +2346,6 @@ void applyShardGroupChange(RedisRaftCtx *rr, raft_entry_t *entry)
         case RAFT_LOGTYPE_UPDATE_SHARDGROUP:
             if ((ret = ShardingInfoUpdateShardGroup(rr, sg)) != RR_OK)
                 LOG_ERROR("Failed to update shardgroup");
-            ShardGroupFree(sg);
             break;
         default:
             PANIC("Unknown entry type %d", entry->type);

--- a/raft.c
+++ b/raft.c
@@ -2329,11 +2329,11 @@ void handleDebug(RedisRaftCtx *rr, RaftReq *req)
  */
 void applyShardGroupChange(RedisRaftCtx *rr, raft_entry_t *entry)
 {
-    ShardGroup * sg = ShardGroupCreate();
     RRStatus ret;
 
-    if (ShardGroupDeserialize(entry->data, entry->data_len, sg) != RR_OK) {
-        ShardGroupFree(sg);
+    ShardGroup * sg;
+
+    if ((sg = ShardGroupDeserialize(entry->data, entry->data_len)) == NULL) {
         LOG_ERROR("Failed to deserialize ADD_SHARDGROUP payload: [%.*s]",
                 entry->data_len, entry->data);
         return;
@@ -2416,9 +2416,8 @@ void replaceShardGroups(RedisRaftCtx *rr, raft_entry_t *entry)
         RedisModule_Assert(endptr == nl);
         payload = nl + 1;
 
-        ShardGroup *sg = ShardGroupCreate();
-        if (ShardGroupDeserialize(payload, payload_len, sg) != RR_OK) {
-            ShardGroupFree(sg);
+        ShardGroup *sg;
+        if ((sg = ShardGroupDeserialize(payload, payload_len)) == NULL) {
             LOG_ERROR("Failed to deserialize shardgroup payload: [%.*s]", (int) payload_len, payload);
             return;
         }

--- a/raft.c
+++ b/raft.c
@@ -2359,12 +2359,10 @@ void applyShardGroupChange(RedisRaftCtx *rr, raft_entry_t *entry)
     /* If we have an attached client, handle the reply */
     if (entry->user_data) {
         RaftReq *req = entry->user_data;
-
         if (ret == RR_OK) {
             RedisModule_ReplyWithSimpleString(req->ctx, "OK");
         } else {
-            /* Should never happen! */
-            RedisModule_ReplyWithError(req->ctx, "ERR failed to locally apply change, should never happen.");
+            RedisModule_ReplyWithError(req->ctx, "ERR Invalid ShardGroup Update");
         }
         RaftReqFree(req);
 

--- a/raft.c
+++ b/raft.c
@@ -1352,7 +1352,7 @@ void RaftReqFree(RaftReq *req)
             break;
         case RR_SHARDGROUPS_REPLACE:
             if (req->r.shardgroups_replace.shardgroups != NULL) {
-                for(int i = 0; i < req->r.shardgroups_replace.len; i++) {
+                for (unsigned int i = 0; i < req->r.shardgroups_replace.len; i++) {
                     ShardGroupFree(req->r.shardgroups_replace.shardgroups[i]);
                 }
                 RedisModule_Free(req->r.shardgroups_replace.shardgroups);
@@ -2393,7 +2393,7 @@ void replaceShardGroups(RedisRaftCtx *rr, raft_entry_t *entry)
     si->shard_groups_num = 0;
 
     si->shard_group_map = RedisModule_CreateDict(rr->ctx);
-    for(int i = 0; i <= REDIS_RAFT_HASH_MAX_SLOT; i++) {
+    for (int i = 0; i <= REDIS_RAFT_HASH_MAX_SLOT; i++) {
         si->stable_slots_map[i] = NULL;
         si->importing_slots_map[i] = NULL;
         si->migrating_slots_map[i] = NULL;

--- a/raft.c
+++ b/raft.c
@@ -1921,12 +1921,8 @@ static RRStatus handleSharding(RedisRaftCtx *rr, RaftReq *req)
     /* Make sure hash slot is mapped and handled locally. */
     ShardGroup *sg = rr->sharding_info->stable_slots_map[req->r.redis.hash_slot];
     if (!sg) {
-        /* TODO: will have to be smarter with actual migration happening */
-        sg = rr->sharding_info->migrating_slots_map[req->r.redis.hash_slot];
-        if (!sg) {
-            RedisModule_ReplyWithError(req->ctx, "CLUSTERDOWN Hash slot is not served");
-            return RR_ERROR;
-        }
+        RedisModule_ReplyWithError(req->ctx, "CLUSTERDOWN Hash slot is not served");
+        return RR_ERROR;
     }
 
     /* If accessing a foreign shardgroup, issue a redirect. We use round-robin

--- a/redisraft.c
+++ b/redisraft.c
@@ -651,11 +651,14 @@ static int cmdRaftShardGroup(RedisModuleCtx *ctx, RedisModuleString **argv, int 
         }
 
         req = RaftReqInit(ctx, RR_SHARDGROUP_ADD);
-        if (ShardGroupParse(ctx, &argv[2], argc - 2, &req->r.shardgroup_add, 2) < 0) {
+        int num_elems;
+        ShardGroup *sg;
+        if ((sg = ShardGroupParse(ctx, &argv[2], argc - 2, 2, &num_elems)) == NULL) {
             /* Error reply already produced by parseShardGroupFromArgs */
             RaftReqFree(req);
             return REDISMODULE_OK;
         }
+        req->r.shardgroup_add = sg;
 
         RaftReqSubmit(&redis_raft, req);
         return REDISMODULE_OK;

--- a/redisraft.c
+++ b/redisraft.c
@@ -651,7 +651,7 @@ static int cmdRaftShardGroup(RedisModuleCtx *ctx, RedisModuleString **argv, int 
         }
 
         req = RaftReqInit(ctx, RR_SHARDGROUP_ADD);
-        if (ShardGroupParse(ctx, &argv[2], argc - 2, &req->r.shardgroup_add) != RR_OK) {
+        if (ShardGroupParse(ctx, &argv[2], argc - 2, &req->r.shardgroup_add, 2) < 0) {
             /* Error reply already produced by parseShardGroupFromArgs */
             RaftReqFree(req);
             return REDISMODULE_OK;

--- a/redisraft.h
+++ b/redisraft.h
@@ -550,7 +550,7 @@ typedef struct RaftReq {
         struct {
             unsigned long long client_id;
         } client_disconnect;
-        struct ShardGroup shardgroup_add;
+        struct ShardGroup *shardgroup_add;
         struct {
             NodeAddr addr;
         } shardgroup_link;
@@ -805,7 +805,7 @@ ShardGroup *ShardGroupDeserialize(const char *buf, size_t buf_len);
 ShardGroup *ShardGroupCreate();
 void ShardGroupFree(ShardGroup *sg);
 void ShardGroupTerm(ShardGroup *sg);
-int ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, ShardGroup *sg, int base_argv_idx);
+int ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, ShardGroup **sg, int base_argv_idx);
 RRStatus ShardGroupsParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RaftReq *req);
 int compareShardGroups(ShardGroup *a, ShardGroup *b);
 ShardGroup *getShardGroupById(RedisRaftCtx *rr, char *id);

--- a/redisraft.h
+++ b/redisraft.h
@@ -801,8 +801,8 @@ const char *ConnGetStateStr(Connection *conn);
 
 /* cluster.c */
 char *ShardGroupSerialize(ShardGroup *sg);
-RRStatus ShardGroupDeserialize(const char *buf, size_t buf_len, ShardGroup *sg);
-ShardGroup* ShardGroupCreate();
+ShardGroup *ShardGroupDeserialize(const char *buf, size_t buf_len);
+ShardGroup *ShardGroupCreate();
 void ShardGroupFree(ShardGroup *sg);
 void ShardGroupTerm(ShardGroup *sg);
 int ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, ShardGroup *sg, int base_argv_idx);

--- a/redisraft.h
+++ b/redisraft.h
@@ -805,7 +805,7 @@ ShardGroup *ShardGroupDeserialize(const char *buf, size_t buf_len);
 ShardGroup *ShardGroupCreate();
 void ShardGroupFree(ShardGroup *sg);
 void ShardGroupTerm(ShardGroup *sg);
-int ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, ShardGroup **sg, int base_argv_idx);
+ShardGroup *ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int base_argv_idx, int *num_elems);
 RRStatus ShardGroupsParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RaftReq *req);
 int compareShardGroups(ShardGroup *a, ShardGroup *b);
 ShardGroup *getShardGroupById(RedisRaftCtx *rr, char *id);

--- a/redisraft.h
+++ b/redisraft.h
@@ -466,6 +466,7 @@ typedef struct ShardGroup {
     Connection *conn;                    /* Connection we use */
     long long last_updated;              /* Last time of successful update (mstime) */
     bool update_in_progress;             /* Are we currently updating? */
+    bool local;                          /* ShardGroup struct that corresponds to local cluster */
 } ShardGroup;
 
 #define RAFT_LOGTYPE_ADD_SHARDGROUP      (RAFT_LOGTYPE_NUM+1)
@@ -801,6 +802,7 @@ const char *ConnGetStateStr(Connection *conn);
 /* cluster.c */
 char *ShardGroupSerialize(ShardGroup *sg);
 RRStatus ShardGroupDeserialize(const char *buf, size_t buf_len, ShardGroup *sg);
+ShardGroup* ShardGroupCreate();
 void ShardGroupFree(ShardGroup *sg);
 void ShardGroupTerm(ShardGroup *sg);
 RRStatus ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, ShardGroup *sg);

--- a/redisraft.h
+++ b/redisraft.h
@@ -810,7 +810,7 @@ RRStatus ShardGroupsParse(RedisModuleCtx *ctx, RedisModuleString **argv, int arg
 int compareShardGroups(ShardGroup *a, ShardGroup *b);
 ShardGroup *getShardGroupById(RedisRaftCtx *rr, char *id);
 
-RRStatus computeHashSlot(RedisRaftCtx *rr, RaftReq *req);
+RRStatus computeHashSlotOrReplyError(RedisRaftCtx *rr, RaftReq *req);
 void handleClusterCommand(RedisRaftCtx *rr, RaftReq *req);
 void ShardingInfoInit(RedisRaftCtx *rr);
 void ShardingInfoReset(RedisRaftCtx *rr);

--- a/redisraft.h
+++ b/redisraft.h
@@ -560,7 +560,7 @@ typedef struct RaftReq {
         } node_shutdown;
         struct {
             ShardGroup **shardgroups;
-            long long len;
+            unsigned int len;
         } shardgroups_replace;
         raft_node_id_t node_to_transfer_leader;
         struct {

--- a/redisraft.h
+++ b/redisraft.h
@@ -805,7 +805,7 @@ RRStatus ShardGroupDeserialize(const char *buf, size_t buf_len, ShardGroup *sg);
 ShardGroup* ShardGroupCreate();
 void ShardGroupFree(ShardGroup *sg);
 void ShardGroupTerm(ShardGroup *sg);
-RRStatus ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, ShardGroup *sg);
+int ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, ShardGroup *sg, int base_argv_count);
 RRStatus ShardGroupsParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RaftReq *req);
 int compareShardGroups(ShardGroup *a, ShardGroup *b);
 ShardGroup *getShardGroupById(RedisRaftCtx *rr, char *id);

--- a/redisraft.h
+++ b/redisraft.h
@@ -805,7 +805,7 @@ RRStatus ShardGroupDeserialize(const char *buf, size_t buf_len, ShardGroup *sg);
 ShardGroup* ShardGroupCreate();
 void ShardGroupFree(ShardGroup *sg);
 void ShardGroupTerm(ShardGroup *sg);
-int ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, ShardGroup *sg, int base_argv_count);
+int ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, ShardGroup *sg, int base_argv_idx);
 RRStatus ShardGroupsParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, RaftReq *req);
 int compareShardGroups(ShardGroup *a, ShardGroup *b);
 ShardGroup *getShardGroupById(RedisRaftCtx *rr, char *id);

--- a/redisraft.h
+++ b/redisraft.h
@@ -485,7 +485,9 @@ typedef struct ShardingInfo {
      * since a zero value indicates the slot is unassigned. The index
      * should therefore be adjusted before refering the array.
      */
-    ShardGroup *hash_slots_map[REDIS_RAFT_HASH_SLOTS];
+    ShardGroup *stable_slots_map[REDIS_RAFT_HASH_SLOTS];
+    ShardGroup *importing_slots_map[REDIS_RAFT_HASH_SLOTS];
+    ShardGroup *migrating_slots_map[REDIS_RAFT_HASH_SLOTS];
 } ShardingInfo;
 
 /* Debug message structure, used for RAFT.DEBUG / RR_DEBUG
@@ -714,6 +716,7 @@ char *RedisInfoGetParam(RedisRaftCtx *rr, const char *section, const char *param
 RRStatus parseMemorySize(const char *value, unsigned long *result);
 RRStatus formatExactMemorySize(unsigned long value, char *buf, size_t buf_size);
 void handleRMCallError(RedisModuleCtx *reply_ctx, int ret_errno, const char *cmd, size_t cmdlen);
+void AddBasicLocalShardGroup(RedisRaftCtx *rr);
 
 /* log.c */
 RaftLog *RaftLogCreate(const char *filename, const char *dbid, raft_term_t snapshot_term, raft_index_t snapshot_index, raft_term_t current_term, raft_node_id_t last_vote, RedisRaftConfig *config);

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -10,7 +10,6 @@ import time
 from redis import ResponseError
 from pytest import raises
 from .sandbox import assert_after
-import pprint
 
 def test_cross_slot_violation(cluster):
     cluster.create(3, raft_args={'sharding': 'yes'})

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -48,7 +48,7 @@ def test_shard_group_sanity(cluster):
         'RAFT.SHARDGROUP', 'ADD',
         '12345678901234567890123456789012',
         '1', '1',
-        '1', '16383', '1',
+        '1', '16382', '1',
         '1234567890123456789012345678901234567890', '1.1.1.1:1111') == b'OK'
     with raises(ResponseError, match='MOVED [0-9]+ 1.1.1.1:111'):
         c.set('key', 'value')
@@ -62,14 +62,14 @@ def test_shard_group_sanity(cluster):
 
     cluster_slots = cluster.node(3).client.execute_command('CLUSTER', 'SLOTS')
 
-#    assert c.execute_command(
-#        'RAFT.SHARDGROUP', 'UPDATE',
-#        '12345678901234567890123456789012',
-#        '1', '1',
-#        '1', '16383', '1',
-#        '1234567890123456789012345678901234567890', '2.2.2.2:2222') == b'OK'
-#    with raises(ResponseError, match='MOVED [0-9]+ 2.2.2.2:2222'):
-#        c.set('key', 'value')
+    # Test by adding another fake shardgroup with same shardgroup id, should fail
+    with raises(ResponseError, match='Invalid ShardGroup Update'):
+        c.execute_command(
+            'RAFT.SHARDGROUP', 'ADD',
+            '12345678901234567890123456789012',
+            '1', '1',
+            '16383', '16383', '1',
+            '1234567890123456789012345678901234567890', '   1.1.1.1:1111')
 
 
 def test_shard_group_replace(cluster):

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -85,7 +85,7 @@ def test_shard_group_replace(cluster):
     assert c.execute_command(
         'RAFT.SHARDGROUP', 'REPLACE',
         '3',
-        '3',
+        '12345678901234567890123456789012',
         '1', '1',
         '6', '7', '1',
         '1234567890123456789012345678901234567890', '2.2.2.2:2222',

--- a/tests/test_serialization.c
+++ b/tests/test_serialization.c
@@ -184,10 +184,10 @@ static void test_deserialize_shardgroup(void **state)
             "12345678901234567890123456789012aabbccdd\n1.1.1.1:1111\n"
             "12345678901234567890123456789012aabbccee\n2.2.2.2:2222\n"
             "12345678901234567890123456789012aabbccff\n3.3.3.3:3333\n";
-    ShardGroup * sg = ShardGroupCreate();
 
     /* Happy path */
-    assert_int_equal(ShardGroupDeserialize(s1, strlen(s1), sg), RR_OK);
+    ShardGroup * sg = ShardGroupDeserialize(s1, strlen(s1));
+    assert_ptr_not_equal(sg, NULL);
     assert_string_equal(sg->id, "12345678901234567890123456789012");
     assert_int_equal(sg->slot_ranges_num, 1);
     assert_int_equal(sg->slot_ranges[0].start_slot, 1);
@@ -212,28 +212,20 @@ static void test_deserialize_shardgroup(void **state)
     /* Errors */
 
     /* Missing slot ranges */
-    sg = ShardGroupCreate();
     const char *s2 = "99\n1\n0\n";
-    assert_int_equal(ShardGroupDeserialize(s2, strlen(s2), sg), RR_ERROR);
-    ShardGroupFree(sg);
+    assert_ptr_equal(ShardGroupDeserialize(s2, strlen(s2)), NULL);
 
     /* Missing nodes */
-    sg = ShardGroupCreate();
     const char *s3 = "99\n0\n1\n";
-    assert_int_equal(ShardGroupDeserialize(s3, strlen(s3), sg), RR_ERROR);
-    ShardGroupFree(sg);
+    assert_ptr_equal(ShardGroupDeserialize(s3, strlen(s3)), NULL);
 
     /* Unterminated node line */
-    sg = ShardGroupCreate();
     const char *s4 = "99\n1\n3\nunterminated";
-    assert_int_equal(ShardGroupDeserialize(s4, strlen(s4), sg), RR_ERROR);
-    ShardGroupFree(sg);
+    assert_ptr_equal(ShardGroupDeserialize(s4, strlen(s4)), NULL);
 
     /* Overflow node id */
-    sg = ShardGroupCreate();
     const char *s5 = "99\n0\n1\n01234567890123456789012345678901234567890123456789:1.1.1.1:1111\n";
-    assert_int_equal(ShardGroupDeserialize(s5, strlen(s5), sg), RR_ERROR);
-    ShardGroupFree(sg);
+    assert_ptr_equal(ShardGroupDeserialize(s5, strlen(s5)), NULL);
 }
 
 const struct CMUnitTest serialization_tests[] = {

--- a/tests/test_serialization.c
+++ b/tests/test_serialization.c
@@ -184,48 +184,56 @@ static void test_deserialize_shardgroup(void **state)
             "12345678901234567890123456789012aabbccdd\n1.1.1.1:1111\n"
             "12345678901234567890123456789012aabbccee\n2.2.2.2:2222\n"
             "12345678901234567890123456789012aabbccff\n3.3.3.3:3333\n";
-    ShardGroup sg;
+    ShardGroup * sg = ShardGroupCreate();
 
     /* Happy path */
-    assert_int_equal(ShardGroupDeserialize(s1, strlen(s1), &sg), RR_OK);
-    assert_string_equal(sg.id, "12345678901234567890123456789012");
-    assert_int_equal(sg.slot_ranges_num, 1);
-    assert_int_equal(sg.slot_ranges[0].start_slot, 1);
-    assert_int_equal(sg.slot_ranges[0].end_slot, 1000);
-    assert_int_equal(sg.slot_ranges[0].type, SLOTRANGE_TYPE_STABLE);
-    assert_int_equal(sg.nodes_num, 3);
+    assert_int_equal(ShardGroupDeserialize(s1, strlen(s1), sg), RR_OK);
+    assert_string_equal(sg->id, "12345678901234567890123456789012");
+    assert_int_equal(sg->slot_ranges_num, 1);
+    assert_int_equal(sg->slot_ranges[0].start_slot, 1);
+    assert_int_equal(sg->slot_ranges[0].end_slot, 1000);
+    assert_int_equal(sg->slot_ranges[0].type, SLOTRANGE_TYPE_STABLE);
+    assert_int_equal(sg->nodes_num, 3);
 
-    assert_string_equal(sg.nodes[0].node_id, "12345678901234567890123456789012aabbccdd");
-    assert_string_equal(sg.nodes[0].addr.host, "1.1.1.1");
-    assert_int_equal(sg.nodes[0].addr.port, 1111);
+    assert_string_equal(sg->nodes[0].node_id, "12345678901234567890123456789012aabbccdd");
+    assert_string_equal(sg->nodes[0].addr.host, "1.1.1.1");
+    assert_int_equal(sg->nodes[0].addr.port, 1111);
 
-    assert_string_equal(sg.nodes[1].node_id, "12345678901234567890123456789012aabbccee");
-    assert_string_equal(sg.nodes[1].addr.host, "2.2.2.2");
-    assert_int_equal(sg.nodes[1].addr.port, 2222);
+    assert_string_equal(sg->nodes[1].node_id, "12345678901234567890123456789012aabbccee");
+    assert_string_equal(sg->nodes[1].addr.host, "2.2.2.2");
+    assert_int_equal(sg->nodes[1].addr.port, 2222);
 
-    assert_string_equal(sg.nodes[2].node_id, "12345678901234567890123456789012aabbccff");
-    assert_string_equal(sg.nodes[2].addr.host, "3.3.3.3");
-    assert_int_equal(sg.nodes[2].addr.port, 3333);
+    assert_string_equal(sg->nodes[2].node_id, "12345678901234567890123456789012aabbccff");
+    assert_string_equal(sg->nodes[2].addr.host, "3.3.3.3");
+    assert_int_equal(sg->nodes[2].addr.port, 3333);
 
-    test_free(sg.nodes);
-    test_free(sg.slot_ranges);
+    ShardGroupFree(sg);
+
     /* Errors */
 
     /* Missing slot ranges */
+    sg = ShardGroupCreate();
     const char *s2 = "99\n1\n0\n";
-    assert_int_equal(ShardGroupDeserialize(s2, strlen(s2), &sg), RR_ERROR);
+    assert_int_equal(ShardGroupDeserialize(s2, strlen(s2), sg), RR_ERROR);
+    ShardGroupFree(sg);
 
     /* Missing nodes */
+    sg = ShardGroupCreate();
     const char *s3 = "99\n0\n1\n";
-    assert_int_equal(ShardGroupDeserialize(s3, strlen(s3), &sg), RR_ERROR);
+    assert_int_equal(ShardGroupDeserialize(s3, strlen(s3), sg), RR_ERROR);
+    ShardGroupFree(sg);
 
     /* Unterminated node line */
+    sg = ShardGroupCreate();
     const char *s4 = "99\n1\n3\nunterminated";
-    assert_int_equal(ShardGroupDeserialize(s4, strlen(s4), &sg), RR_ERROR);
+    assert_int_equal(ShardGroupDeserialize(s4, strlen(s4), sg), RR_ERROR);
+    ShardGroupFree(sg);
 
     /* Overflow node id */
+    sg = ShardGroupCreate();
     const char *s5 = "99\n0\n1\n01234567890123456789012345678901234567890123456789:1.1.1.1:1111\n";
-    assert_int_equal(ShardGroupDeserialize(s5, strlen(s5), &sg), RR_ERROR);
+    assert_int_equal(ShardGroupDeserialize(s5, strlen(s5), sg), RR_ERROR);
+    ShardGroupFree(sg);
 }
 
 const struct CMUnitTest serialization_tests[] = {

--- a/util.c
+++ b/util.c
@@ -394,3 +394,52 @@ void handleRMCallError(RedisModuleCtx *ctx, int ret_errno, const char *cmd, size
     RedisModule_ReplyWithError(ctx, errmsg);
     RedisModule_Free(errmsg);
 }
+
+void FillShardSlots(RedisRaftCtx *rr, ShardGroup *sg)
+{
+    char *str = RedisModule_Strdup(rr->config->slot_config);
+
+    sg->slot_ranges_num = 1;
+    char *pos = str;
+    while ((pos = strchr(pos+1, ','))) {
+        sg->slot_ranges_num++;
+    }
+    sg->slot_ranges = RedisModule_Calloc(sg->slot_ranges_num, sizeof(ShardGroupSlotRange));
+
+    char *saveptr = NULL;
+    char *token = strtok_r(str, ",", &saveptr);
+    for (int i = 0; i < sg->slot_ranges_num; i++) {
+        unsigned long val;
+        if ((pos = strchr(token, ':'))) {
+            *pos = '\0';
+            val = strtoul(token, NULL, 10);
+            sg->slot_ranges[i].start_slot = val;
+            val = strtoul(pos+1, NULL, 10);
+            sg->slot_ranges[i].end_slot = val;
+        } else {
+            val = strtoul(token, NULL, 10);
+            sg->slot_ranges[i].start_slot = val;
+            sg->slot_ranges[i].end_slot = val;
+        }
+        sg->slot_ranges[i].type = SLOTRANGE_TYPE_STABLE;
+
+        token = strtok_r(NULL, ",", &saveptr);
+    }
+
+    RedisModule_Free(str);
+}
+
+void AddBasicLocalShardGroup(RedisRaftCtx *rr) {
+    ShardGroup sg = {
+            .slot_ranges_num = 0,
+            .slot_ranges = NULL,
+            .nodes_num = 0,
+            .nodes = NULL
+    };
+
+    FillShardSlots(rr, &sg);
+
+    RRStatus ret = ShardingInfoAddShardGroup(rr, &sg);
+    RedisModule_Assert(ret == RR_OK);
+    ShardGroupTerm(&sg);
+}

--- a/util.c
+++ b/util.c
@@ -395,6 +395,7 @@ void handleRMCallError(RedisModuleCtx *ctx, int ret_errno, const char *cmd, size
     RedisModule_Free(errmsg);
 }
 
+/* This function assumes that the rr->config->slot_config has already been validated as valid */
 void FillShardSlots(RedisRaftCtx *rr, ShardGroup *sg)
 {
     char *str = RedisModule_Strdup(rr->config->slot_config);

--- a/util.c
+++ b/util.c
@@ -430,16 +430,14 @@ void FillShardSlots(RedisRaftCtx *rr, ShardGroup *sg)
 }
 
 void AddBasicLocalShardGroup(RedisRaftCtx *rr) {
-    ShardGroup sg = {
-            .slot_ranges_num = 0,
-            .slot_ranges = NULL,
-            .nodes_num = 0,
-            .nodes = NULL
-    };
+    ShardGroup *sg = ShardGroupCreate();
+    sg->local = true;
 
-    FillShardSlots(rr, &sg);
+    memcpy(sg->id, rr->log->dbid, RAFT_DBID_LEN);
+    sg->id[RAFT_DBID_LEN] = 0;
 
-    RRStatus ret = ShardingInfoAddShardGroup(rr, &sg);
+    FillShardSlots(rr, sg);
+
+    RRStatus ret = ShardingInfoAddShardGroup(rr, sg);
     RedisModule_Assert(ret == RR_OK);
-    ShardGroupTerm(&sg);
 }


### PR DESCRIPTION
- shardgroup replace will validate options before submitting to log
	a given slot, can either only be specified as stable or as (migrating and/or importing)

- ShardingInfoReset() no longer adds local shardgroup to sharding info.
	- its added at
		- cluster init - with default cluster slots (AddBasicLocalShardGroup())
		- cluster join - with default cluster slots
		- reloading rdb file on restart (if exists, with saved slot ranges)
		- reloading without rdb file (before log playback) with default cluste slots

	- the way cluster slots is modified is via a shardgroup replace log entry
		- can be called after init
		- on join will get log entry and change
		- on replay of log will change

- in practice, the local shardgroup struct will also contain the nodes passed to it in the command, but those are given to it by the external orchestrator, so aren't the real source of truth.  the real source of truth for its nodes is itself, so for cluster slots/nodes commands, it ignores those entries and uses its own view of its world.

lots of small changes
- in rdb snapshot serialize out local shardgroup
- rename/creation of new hash slot mappings
	for stable (rename), importing/exportng

todo: currently, as an artifact of older code, we treat the local shardgroup's id as an emptry string (as it's struct was allocated before dbid was specified).  In new model, that doesn't have to be the case.

the primary advantage of keeping it the way it is, is that it makes it easy to find the local shardgroup (*sg->id == 0).  However, it is a bit ugly and perhaps better to just memcmp() it in the future.