### PR TITLE
Fixed index file bug which becomes visible in BSDs

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,7 +8,7 @@ on:
       skipjobs:
         description: 'jobs to skip (delete the ones you want to keep, do not leave empty)'
         required: false
-        default: 'address,undefined'
+        default: 'address,undefined,macos'
       use_repo:
         description: 'repo owner and name'
         required: false
@@ -87,6 +87,46 @@ jobs:
           path: 'redis'
       - name: Build Redis
         run: cd redis && make SANITIZER=undefined
+      - name: Setup Python for testing
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
+      - name: Install Python dependencies
+        run:
+          python -m pip install -r tests/integration/requirements.txt
+      - name: Run tests
+        run:
+          PYTEST_OPTS="--redis-executable=redis/src/redis-server -v" make tests
+
+  test-macos:
+    runs-on: macos-latest
+    if: |
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'redislabs/redisraft')) && !contains(github.event.inputs.skipjobs, 'macos')
+    timeout-minutes: 14400
+    steps:
+      - name: prep
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "GITHUB_REPOSITORY=${{github.event.inputs.use_repo}}" >> $GITHUB_ENV
+          echo "GITHUB_HEAD_REF=${{github.event.inputs.use_git_ref}}" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{ env.GITHUB_REPOSITORY }}
+          ref: ${{ env.GITHUB_HEAD_REF }}
+      - name: Install build dependencies
+        run: brew install autoconf automake
+      - name: Build
+        run: make -j 4
+      - name: Checkout Redis
+        uses: actions/checkout@v2
+        with:
+          repository: 'redis/redis'
+          ref: 'unstable'
+          path: 'redis'
+      - name: Build Redis
+        run: cd redis && make -j 4
       - name: Setup Python for testing
         uses: actions/setup-python@v1
         with:

--- a/tests/integration/test_membership.py
+++ b/tests/integration/test_membership.py
@@ -199,12 +199,11 @@ def test_node_history_with_same_address(cluster):
     for _ in range(5):
         for port in ports:
             n = cluster.add_node(port=port)
-            cluster.leader_node().wait_for_num_nodes(2)
+            cluster.leader_node().wait_for_num_voting_nodes(2)
             cluster.leader_node().wait_for_log_committed()
             cluster.leader_node().wait_for_log_applied()
-            n.wait_for_node_voting()
             cluster.remove_node(n.id)
-            cluster.leader_node().wait_for_num_nodes(1)
+            cluster.leader_node().wait_for_num_voting_nodes(1)
             cluster.leader_node().wait_for_log_applied()
 
     # Add enough data in the log to satisfy timing

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -61,6 +61,9 @@ def test_node_joins_and_gets_data(cluster):
     r2 = cluster.add_node()
     r2.wait_for_election()
     assert r2.raft_info().get('leader_id') == 1
+    commit_idx = cluster.leader_node().commit_index()
+    r2.wait_for_commit_index(commit_idx, gt_ok=True)
+    r2.wait_for_log_applied()
     assert r2.raft_debug_exec('get', 'key') == b'value'
 
     # Also validate -MOVED as expected


### PR DESCRIPTION
Fixed index file bug and added MacOS to daily CI. 
Also, in tests, fixed a few issues that rely on timing to stabilize them in MacOS build.

The problem is while using FILE API, switching between fread to fwrite or vice versa 
requires calling file positioning functions, e.g fseek() according to C standard.
Example : 
```c
fwrite("abc", 4, 1, file); // Written 3 bytes, offset is 3. 
fseek(file, 0, SEEK_END);  // Set position to zero.
fread(buf, 1, 1, file);    // Read 1 byte, is position 1 ? 
fwrite(buf, "aa", 2, 1);   // <---- Undefined behavior, needs data positioning functions to be called before
```

The problem is implementations might be holding different position variables for read and write. 
Looks like this is not the case for glibc and there is no issue in Linux. 
On BSDs and MacOS, this issue is reproducible.

Related section from C standard : 


> When a file is opened with update mode ( '+' as the second or third character in the mode argument),
both input and output may be performed on the associated stream. However, the application shall 
ensure that output is not directly followed by input without an intervening call to fflush() or to a file
positioning function ( fseek(), fsetpos(), or rewind()), and input is not directly followed by output without 
an intervening call to a file positioning function, unless the input operation encounters end-of-file.

In RedisRaft, issue becomes visible when we read an index just to delete an entry and 
later when we try to write again for a new entry index. `test_log_delete` covers this case,
 not adding another test.

Introduced by https://github.com/RedisLabs/redisraft/pull/208