### PR TITLE
Run Jepsen tests with Redis unstable

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -45,7 +45,7 @@ jobs:
                   --test-count 20 \
                   --concurrency 4n \
                   --nemesis kill,pause,partition,member \
-                  --redis-version 87789fae0 \
+                  --redis-version unstable \
                   --raft-repo https://github.com/${{ env.REDISRAFT_REPO }} \
                   --raft-version ${{ env.REDISRAFT_VERSION }} | rg --passthrough '^0 failures'
     - name: Archive Jepsen results


### PR DESCRIPTION
Fixes Jepsen test failure due to module API mismatch.