### PR TITLE
add internode auth to redisraft

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -298,7 +298,7 @@ static RRStatus processConfigParam(const char *keyword, const char *value, Redis
         }
         target->cluster_password = RedisModule_Strdup(value);
     } else if (!strcmp(keyword, CONF_CLUSTER_USER)) {
-        if (target->cluster_password) {
+        if (target->cluster_user) {
             RedisModule_Free(target->cluster_user);
         }
         target->cluster_user = RedisModule_Strdup(value);
@@ -499,7 +499,7 @@ void handleConfigGet(RedisModuleCtx *ctx, RedisRaftConfig *config, RedisModuleSt
         len++;
         replyConfigStr(ctx, CONF_CLUSTER_USER, config->cluster_user);
     }
-    if (stringmatch(pattern, CONF_CLUSTER_USER, 1)) {
+    if (stringmatch(pattern, CONF_CLUSTER_PASSWORD, 1)) {
         len++;
         replyConfigStr(ctx, CONF_CLUSTER_PASSWORD, "***");
     }
@@ -605,6 +605,8 @@ void ConfigInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
     config->tls_ca_cert = getRedisConfig(ctx, "tls-ca-cert-file");
     config->tls_key = getRedisConfig(ctx, "tls-key-file");
     config->tls_cert = getRedisConfig(ctx, "tls-cert-file");
+    config->cluster_user = RedisModule_Strdup("default");
+    config->cluster_password = RedisModule_Strdup("");
 }
 
 

--- a/src/config.c
+++ b/src/config.c
@@ -50,6 +50,8 @@ static const char *CONF_TLS_ENABLED = "tls-enabled";
 static const char *CONF_TLS_CA_CERT = "tls-ca-cert";
 static const char *CONF_TLS_CERT = "tls-cert";
 static const char *CONF_TLS_KEY = "tls-key";
+static const char *CONF_CLUSTER_USER = "cluster-user";
+static const char *CONF_CLUSTER_PASSWORD = "cluster-password";
 
 static RRStatus parseBool(const char *value, bool *result)
 {
@@ -290,6 +292,16 @@ static RRStatus processConfigParam(const char *keyword, const char *value, Redis
             RedisModule_Free(target->tls_key);
         }
         target->tls_key = RedisModule_Strdup(value);
+    } else if (!strcmp(keyword, CONF_CLUSTER_PASSWORD)) {
+        if (target->cluster_password) {
+            RedisModule_Free(target->cluster_password);
+        }
+        target->cluster_password = RedisModule_Strdup(value);
+    } else if (!strcmp(keyword, CONF_CLUSTER_USER)) {
+        if (target->cluster_password) {
+            RedisModule_Free(target->cluster_user);
+        }
+        target->cluster_user = RedisModule_Strdup(value);
     } else {
         snprintf(errbuf, errbuflen-1, "invalid parameter '%s'", keyword);
         return RR_ERROR;
@@ -483,7 +495,14 @@ void handleConfigGet(RedisModuleCtx *ctx, RedisRaftConfig *config, RedisModuleSt
         len++;
         replyConfigStr(ctx, CONF_TLS_KEY, config->tls_key);
     }
-
+    if (stringmatch(pattern, CONF_CLUSTER_USER, 1)) {
+        len++;
+        replyConfigStr(ctx, CONF_CLUSTER_USER, config->cluster_user);
+    }
+    if (stringmatch(pattern, CONF_CLUSTER_USER, 1)) {
+        len++;
+        replyConfigStr(ctx, CONF_CLUSTER_PASSWORD, "***");
+    }
     RedisModule_ReplySetArrayLength(ctx, len * 2);
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -499,10 +499,6 @@ void handleConfigGet(RedisModuleCtx *ctx, RedisRaftConfig *config, RedisModuleSt
         len++;
         replyConfigStr(ctx, CONF_CLUSTER_USER, config->cluster_user);
     }
-    if (stringmatch(pattern, CONF_CLUSTER_PASSWORD, 1)) {
-        len++;
-        replyConfigStr(ctx, CONF_CLUSTER_PASSWORD, "***");
-    }
     RedisModule_ReplySetArrayLength(ctx, len * 2);
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -295,13 +295,19 @@ static RRStatus processConfigParam(const char *keyword, const char *value, Redis
     } else if (!strcmp(keyword, CONF_CLUSTER_PASSWORD)) {
         if (target->cluster_password) {
             RedisModule_Free(target->cluster_password);
+            target->cluster_password = NULL;
         }
-        target->cluster_password = RedisModule_Strdup(value);
+        if (strlen(value) > 0) {
+            target->cluster_password = RedisModule_Strdup(value);
+        }
     } else if (!strcmp(keyword, CONF_CLUSTER_USER)) {
         if (target->cluster_user) {
             RedisModule_Free(target->cluster_user);
+            target->cluster_user = NULL;
         }
-        target->cluster_user = RedisModule_Strdup(value);
+        if (strlen(value) > 0) {
+            target->cluster_user = RedisModule_Strdup(value);
+        }
     } else {
         snprintf(errbuf, errbuflen-1, "invalid parameter '%s'", keyword);
         return RR_ERROR;
@@ -497,7 +503,7 @@ void handleConfigGet(RedisModuleCtx *ctx, RedisRaftConfig *config, RedisModuleSt
     }
     if (stringmatch(pattern, CONF_CLUSTER_USER, 1)) {
         len++;
-        replyConfigStr(ctx, CONF_CLUSTER_USER, config->cluster_user);
+        replyConfigStr(ctx, CONF_CLUSTER_USER, config->cluster_user ? config->cluster_user : "");
     }
     RedisModule_ReplySetArrayLength(ctx, len * 2);
 }
@@ -602,7 +608,7 @@ void ConfigInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
     config->tls_key = getRedisConfig(ctx, "tls-key-file");
     config->tls_cert = getRedisConfig(ctx, "tls-cert-file");
     config->cluster_user = RedisModule_Strdup("default");
-    config->cluster_password = RedisModule_Strdup("");
+    config->cluster_password = NULL;
 }
 
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -403,7 +403,7 @@ void ConnMarkDisconnected(Connection *conn)
 
 bool ConnIsIdle(Connection *conn)
 {
-    return (conn->state == CONN_DISCONNECTED || conn->state == CONN_CONNECT_ERROR || (conn->flags | CONN_TERMINATING));
+    return (conn->state == CONN_DISCONNECTED || conn->state == CONN_CONNECT_ERROR || (conn->flags & CONN_TERMINATING));
 }
 
 bool ConnIsConnected(Connection *conn)

--- a/src/connection.c
+++ b/src/connection.c
@@ -185,10 +185,11 @@ static void handleAuth(redisAsyncContext *c, void *r, void *privdata)
         redisAsyncDisconnect(ConnGetRedisCtx(conn));
         ConnMarkDisconnected(conn);
     } else {
-        return connectionSuccess(conn);
+        connectionSuccess(conn);
+        return;
     }
 
-    return connectionFailure(conn);
+    connectionFailure(conn);
 }
 
 /* Connection with authentication
@@ -197,7 +198,6 @@ static void handleAuth(redisAsyncContext *c, void *r, void *privdata)
  * If connection status is not ok, will immediately transition connection to CONN_CONNECT_ERROR
  * User callback is called in all cases except when the connection has already been terminated externally
  */
-
 static void handleConnectedWithAuth(Connection *conn, int status)
 {
     if (status == REDIS_OK) {
@@ -227,12 +227,12 @@ fail:
  * Depending on status, state transitions to CONN_CONNECTED or CONN_CONNECT_ERROR.
  * User callback is called in all cases except when the connection has already been terminated externally
  */
-
-static void handleConnectedWithoutAuth(Connection *conn, int status) {
+static void handleConnectedWithoutAuth(Connection *conn, int status) 
+{
     if (status == REDIS_OK) {
-        return connectionSuccess(conn);
+        connectionSuccess(conn);
     } else {
-        return connectionFailure(conn);
+        connectionFailure(conn);
     }
 }
 
@@ -242,10 +242,9 @@ static void handleConnectedWithoutAuth(Connection *conn, int status) {
  * from handleResolved(), with state CONN_CONNECTING.
  *
  */
-
 static void handleConnected(const redisAsyncContext *c, int status)
 {
-    Connection *conn = (Connection *) c->data;
+    Connection *conn = c->data;
     CONN_TRACE(conn, "handleConnected: status=%d", status);
 
     if (conn->rr->config->cluster_user) {

--- a/src/connection.c
+++ b/src/connection.c
@@ -247,7 +247,7 @@ static void handleConnected(const redisAsyncContext *c, int status)
     Connection *conn = c->data;
     CONN_TRACE(conn, "handleConnected: status=%d", status);
 
-    if (conn->rr->config->cluster_user) {
+    if (conn->rr->config->cluster_user && conn->rr->config->cluster_password) {
         handleConnectedWithAuth(conn, status);
     } else {
         handleConnectedWithoutAuth(conn, status);

--- a/src/connection.c
+++ b/src/connection.c
@@ -203,7 +203,7 @@ static void handleConnectedWithAuth(Connection *conn, int status)
     if (status == REDIS_OK) {
         /* don't try to authenticate if terminating */
         if (conn->flags & CONN_TERMINATING) {
-            return connectionSuccess(conn);
+            return;
         }
 
         if (redisAsyncCommand(ConnGetRedisCtx(conn), handleAuth, conn,
@@ -403,7 +403,7 @@ void ConnMarkDisconnected(Connection *conn)
 
 bool ConnIsIdle(Connection *conn)
 {
-    return (conn->state == CONN_DISCONNECTED || conn->state == CONN_CONNECT_ERROR);
+    return (conn->state == CONN_DISCONNECTED || conn->state == CONN_CONNECT_ERROR || (conn->flags | CONN_TERMINATING));
 }
 
 bool ConnIsConnected(Connection *conn)

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -415,6 +415,8 @@ typedef struct RedisRaftConfig {
     char *tls_ca_cert;
     char *tls_cert;
     char *tls_key;
+    char *cluster_user;                 /* acl user to use for internode communication */
+    char *cluster_password;             /* password used for internode communication */
 } RedisRaftConfig;
 
 typedef struct PendingResponse {

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -25,6 +25,13 @@ def test_set_cluster_id(cluster):
     assert str(cluster.leader_node().raft_info()["dbid"]) == id
 
 
+def test_set_cluster_password(cluster):
+    password = "foobar"
+    id = "12345678901234567890123456789012"
+    cluster.create(3, password=password, cluster_id=id)
+    assert str(cluster.leader_node().raft_info()["dbid"]) == id
+
+
 def test_set_cluster_id_too_short(cluster):
     id = "123456789012345678901234567890"
     with raises(ResponseError, match='cluster id must be 32 characters'):


### PR DESCRIPTION
currently, there is no authentication that is done between RedisRaft clusters

this adds the ability to define which acl user and what password should be used, as has redis authenticate them

the default user (if not specified) is default, and the default password is empty.

when used, on must ensure that redis itself is configured to accept such user/password authenticaiton.
If using the default user of default, one can just pass a --requirepass to redis, if one is changing the user, one must setup the acl user correctly in redis conf/acl files

Fixes #238 