### PR TITLE
Add Jepsen repo configuration to Jepsen test suite

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -7,10 +7,16 @@ on:
     inputs:
       repository:
         description: 'Repository, e.g redislabs/redisraft'
-        required: true
+        default: 'redisLabs/redisraft'
+        required: false
       version:
-        description: 'Commit hash, e.g 98d8f29'
-        required: true
+        description: 'Commit hash or branch name for Redisraft repo'
+        default: 'master'
+        required: false
+      jepsen-repo:
+        description: 'Jepsen repository, e.g jepsen-io/redis'
+        default:  'jepsen-io/redis'
+        required: false
 
 jobs:
   jepsen:
@@ -24,15 +30,17 @@ jobs:
       env:
         REDISRAFT_REPO: 'redislabs/redisraft'
         REDISRAFT_VERSION: ${{ github.sha }}
+        JEPSEN_REPO: 'jepsen-io/redis'
       run: |
         echo "REDISRAFT_REPO=${{ github.event.inputs.repository || env.REDISRAFT_REPO }}" >> $GITHUB_ENV
         echo "REDISRAFT_VERSION=${{ github.event.inputs.version || env.REDISRAFT_VERSION }}" >> $GITHUB_ENV
+        echo "JEPSEN_REPO=${{ github.event.inputs.jepsen-repo || env.JEPSEN_REPO }}" >> $GITHUB_ENV
     - name: Install ripgrep
       run: sudo apt-get install ripgrep
     - name: Configure core_pattern
       run: echo "core.%p" | sudo tee /proc/sys/kernel/core_pattern
     - name: Build containers
-      run: cd jepsen/docker && ./genkeys.sh && docker-compose build
+      run: cd jepsen/docker && ./genkeys.sh && docker-compose build --build-arg JEPSEN_REPO=${{ env.JEPSEN_REPO }}
     - name: Start containers
       run: cd jepsen/docker && docker-compose up -d
     - name: Run test

--- a/jepsen/docker/control/Dockerfile
+++ b/jepsen/docker/control/Dockerfile
@@ -19,8 +19,8 @@ RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
     chmod +x /usr/bin/lein && \
     lein self-install
 
-ARG JEPSEN_REPO=https://github.com/jepsen-io/redis
-RUN git clone $JEPSEN_REPO /jepsen && \
+ARG JEPSEN_REPO=jepsen-io/redis
+RUN git clone https://github.com/${JEPSEN_REPO} /jepsen && \
     cd /jepsen && \
     lein install
 


### PR DESCRIPTION
User specified repository can be used in Jepsen tests, useful for trying fixes. 