### PR TITLE
Use config fsync option always

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -2523,7 +2523,7 @@ void handleBeforeSleep(RedisRaftCtx *rr)
     if (next > 0) {
         fflush(rr->log->file);
 
-        if (rr->log->fsync) {
+        if (rr->config->raft_log_fsync) {
             /* Trigger async fsync() for the current index */
             fsyncThreadAddTask(&rr->fsyncThread, fileno(rr->log->file), next);
         } else {

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -659,7 +659,6 @@ typedef struct RaftLog {
     uint32_t            version;                /* Log file format version */
     char                dbid[RAFT_DBID_LEN+1];  /* DB unique ID */
     raft_node_id_t      node_id;                /* Node ID */
-    bool                fsync;                  /* Should fsync every append? */
     unsigned long int   num_entries;            /* Entries in log */
     raft_term_t         snapshot_last_term;     /* Last term included in snapshot */
     raft_index_t        snapshot_last_idx;      /* Last index included in snapshot */
@@ -821,7 +820,7 @@ void RaftLogClose(RaftLog *log);
 RRStatus RaftLogAppend(RaftLog *log, raft_entry_t *entry);
 int RaftLogLoadEntries(RaftLog *log, int (*callback)(void *, raft_entry_t *, raft_index_t), void *callback_arg);
 RRStatus RaftLogWriteEntry(RaftLog *log, raft_entry_t *entry);
-RRStatus RaftLogSync(RaftLog *log);
+RRStatus RaftLogSync(RaftLog *log, bool sync);
 raft_entry_t *RaftLogGet(RaftLog *log, raft_index_t idx);
 RRStatus RaftLogDelete(RaftLog *log, raft_index_t from_idx, func_entry_notify_f cb, void *cb_arg);
 RRStatus RaftLogReset(RaftLog *log, raft_index_t index, raft_term_t term);

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -411,7 +411,7 @@ RRStatus initiateSnapshot(RedisRaftCtx *rr)
     if (rr->log) {
         fsyncThreadWaitUntilCompleted(&rr->fsyncThread);
 
-        if (RaftLogSync(rr->log) != RR_OK) {
+        if (RaftLogSync(rr->log, true) != RR_OK) {
             PANIC("RaftLogSync() failed.");
         }
     }

--- a/tests/test_log.c
+++ b/tests/test_log.c
@@ -195,8 +195,6 @@ static void test_log_fuzzer(void **state)
     RaftLog *log = (RaftLog *) *state;
     int idx = 0, i;
 
-    log->fsync = false;
-
     for (i = 0; i < 10000; i++) {
         int new_entries = random() % 10;
         int j;


### PR DESCRIPTION
RaftLog is now using RedisRaftCtx config which is reconfigurable from the command line. Enables to switch fsync option without restart.