### PR TITLE
Update fsync max latency on async fsync() callback

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -2493,6 +2493,7 @@ void handleFsyncCompleted(void *result)
 
     rr->log->fsync_count++;
     rr->log->fsync_total += rs->time;
+    rr->log->fsync_max = MAX(rs->time, rr->log->fsync_max);
 
     int e = raft_flush(rr->raft, rs->fsync_index);
     if (e == RAFT_ERR_SHUTDOWN) {


### PR DESCRIPTION
Max latency update was missing if fsync() is called in fsync thread