### PR TITLE
add a slot-config of "" (empty string) to indicate no slots are owned

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1237,6 +1237,10 @@ RedisModuleString *generateSlots(RedisModuleCtx *ctx, ShardGroup *sg)
 {
     RedisModuleString *ret;
 
+    if (sg->slot_ranges_num == 0) {
+        return RedisModule_CreateString(ctx, "", 0);
+    }
+
     if (sg->slot_ranges[0].start_slot != sg->slot_ranges[0].end_slot) {
         ret = RedisModule_CreateStringPrintf(ctx, "%d-%d", sg->slot_ranges[0].start_slot, sg->slot_ranges[0].end_slot);
     } else {

--- a/src/config.c
+++ b/src/config.c
@@ -95,14 +95,14 @@ int validSlotConfig(char *slot_config) {
     char *tmp = RedisModule_Strdup(slot_config);
     char *pos = tmp;
     char *endptr;
-    int val_l, val_h;
+    long val_l, val_h;
     if ((pos = strchr(tmp, ':'))) {
         *pos = '\0';
-        val_l = strtoul(tmp, &endptr, 10);
+        val_l = strtol(tmp, &endptr, 10);
         if (*endptr != 0) {
             goto exit;
         }
-        val_h = strtoul(pos+1, &endptr, 10);
+        val_h = strtol(pos+1, &endptr, 10);
         if (*endptr != 0) {
             goto exit;
         }
@@ -110,7 +110,7 @@ int validSlotConfig(char *slot_config) {
             goto exit;
         }
     } else {
-        val_l = val_h = strtoul(tmp, &endptr, 10);
+        val_l = strtol(tmp, &endptr, 10);
         if (*endptr != 0 || !HashSlotValid(val_l)) {
             goto exit;
         }

--- a/src/config.c
+++ b/src/config.c
@@ -91,6 +91,10 @@ static const char *getLoglevelName(int level)
 }
 
 int validSlotConfig(char *slot_config) {
+    if (*slot_config == 0) {
+        return 1;
+    }
+
     int ret = 0;
     char *tmp = RedisModule_Strdup(slot_config);
     char *pos = tmp;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -373,14 +373,15 @@ extern raft_log_impl_t RaftLogImpl;
 #define REDIS_RAFT_DEFAULT_SHARDGROUP_UPDATE_INTERVAL 5000
 #define REDIS_RAFT_DEFAULT_MAX_APPENDENTRIES          4
 
-static inline bool HashSlotValid(int slot)
+static inline bool HashSlotValid(long slot)
 {
-    return (slot >= REDIS_RAFT_HASH_MIN_SLOT && slot <= REDIS_RAFT_HASH_MAX_SLOT);
+    return (slot == -1 || (slot >= REDIS_RAFT_HASH_MIN_SLOT && slot <= REDIS_RAFT_HASH_MAX_SLOT));
 }
 
-static inline bool HashSlotRangeValid(int start_slot, int end_slot)
+static inline bool HashSlotRangeValid(long start_slot, long end_slot)
 {
-    return (HashSlotValid(start_slot) && HashSlotValid(end_slot) &&
+    return (start_slot != -1 && end_slot != -1 &&
+            HashSlotValid(start_slot) && HashSlotValid(end_slot) &&
             start_slot <= end_slot);
 }
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -375,13 +375,12 @@ extern raft_log_impl_t RaftLogImpl;
 
 static inline bool HashSlotValid(long slot)
 {
-    return (slot == -1 || (slot >= REDIS_RAFT_HASH_MIN_SLOT && slot <= REDIS_RAFT_HASH_MAX_SLOT));
+    return (slot >= REDIS_RAFT_HASH_MIN_SLOT && slot <= REDIS_RAFT_HASH_MAX_SLOT);
 }
 
 static inline bool HashSlotRangeValid(long start_slot, long end_slot)
 {
-    return (start_slot != -1 && end_slot != -1 &&
-            HashSlotValid(start_slot) && HashSlotValid(end_slot) &&
+    return (HashSlotValid(start_slot) && HashSlotValid(end_slot) &&
             start_slot <= end_slot);
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -398,6 +398,10 @@ ShardGroup * CreateAndFillShard(RedisRaftCtx *rr)
 {
     ShardGroup *sg = ShardGroupCreate();
 
+    if (!strcmp(rr->config->slot_config, "-1")) {
+        goto exit;
+    }
+
     char *str = RedisModule_Strdup(rr->config->slot_config);
     sg->slot_ranges_num = 1;
     char *pos = str;
@@ -428,6 +432,7 @@ ShardGroup * CreateAndFillShard(RedisRaftCtx *rr)
 
     RedisModule_Free(str);
 
+exit:
     return sg;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -398,7 +398,7 @@ ShardGroup * CreateAndFillShard(RedisRaftCtx *rr)
 {
     ShardGroup *sg = ShardGroupCreate();
 
-    if (!strcmp(rr->config->slot_config, "-1")) {
+    if (!strcmp(rr->config->slot_config, "")) {
         goto exit;
     }
 

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -384,10 +384,11 @@ def test_shard_group_refresh(cluster_factory):
     assert_after(check_slots, 10)
 
 
+
 def test_shard_group_no_slots(cluster):
     cluster.create(3, raft_args={
         'sharding': 'yes',
-        'slot-config': '-1'
+        'slot-config': ''
     })
 
     c = cluster.node(1).client

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -382,3 +382,17 @@ def test_shard_group_refresh(cluster_factory):
                 assert slots[i][2][1] != 5001, slots
 
     assert_after(check_slots, 10)
+
+
+def test_shard_group_no_slots(cluster):
+    cluster.create(3, raft_args={
+        'sharding': 'yes',
+        'slot-config': '-1'
+    })
+
+    c = cluster.node(1).client
+    results = c.execute_command('CLUSTER', 'NODES').split(b"\r\n")
+
+    splits = results[0].split(b" ")
+    assert len(splits) == 9
+    assert splits[8] == b""


### PR DESCRIPTION
Allow one to specify `slot-config ""` on the command line to indicate that no slots are owned.