### PR TITLE
enable acl support

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -129,7 +129,6 @@ RRStatus CommandSpecInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
             { "publish",                CMD_SPEC_DONT_INTERCEPT },
             { "pubsub",                 CMD_SPEC_DONT_INTERCEPT },
             { "slowlog",                CMD_SPEC_DONT_INTERCEPT },
-            { "acl",                    CMD_SPEC_DONT_INTERCEPT },
 
             /* RedisRaft Commands */
             { "raft",                         CMD_SPEC_DONT_INTERCEPT },

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -85,7 +85,9 @@ RRStatus ProxyCommand(RedisRaftCtx *rr, RaftReq *req, Node *leader)
     }
 
     req->r.redis.proxy_node = leader;
-    raft_entry_t *entry = RaftRedisCommandArraySerialize(&req->r.redis.cmds);
+    size_t len;
+    const char * username = RedisModule_StringPtrLen(req->r.redis.username, &len);
+    raft_entry_t *entry = RaftRedisCommandArraySerialize(username, len, &req->r.redis.cmds);
     int ret = redisAsyncCommand(rc, handleProxiedCommandResponse,
         req, "RAFT.ENTRY %b", entry->data, entry->data_len);
     raft_entry_release(entry);

--- a/src/raft.c
+++ b/src/raft.c
@@ -145,7 +145,7 @@ static void executeRaftRedisCommandArray(RedisModuleString * username, RaftRedis
             if (reply_ctx) {
                 handleRMCallError(reply_ctx, errno, cmd, cmd_len);
             }
-            return;
+            goto exit;
         }
     }
 
@@ -196,6 +196,9 @@ static void executeRaftRedisCommandArray(RedisModuleString * username, RaftRedis
             RedisModule_FreeCallReply(reply);
         }
     }
+
+exit:
+    RedisModule_FreeModuleUser(user);
 }
 
 /*

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -345,6 +345,8 @@ static int cmdRaft(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     }
 
     RaftReq *req = RaftReqInit(ctx, RR_REDISCOMMAND);
+    req->r.redis.username = RedisModule_GetCurrentUserName(ctx);
+
     RaftRedisCommand *cmd = RaftRedisCommandArrayExtend(&req->r.redis.cmds);
 
     cmd->argc = argc - 1;
@@ -380,7 +382,7 @@ static int cmdRaftEntry(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     const char *data = RedisModule_StringPtrLen(argv[1], &data_len);
 
     RaftReq *req = RaftReqInit(ctx, RR_REDISCOMMAND);
-    if (RaftRedisCommandArrayDeserialize(&req->r.redis.cmds, data, data_len) != RR_OK) {
+    if (RaftRedisCommandArrayDeserialize(&req->r.redis.username,&req->r.redis.cmds, data, data_len) != RR_OK) {
         RedisModule_ReplyWithError(ctx, "ERR invalid argument");
         RaftReqFree(req);
     } else {

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -579,6 +579,7 @@ typedef struct RaftReq {
         struct {
             Node *proxy_node;
             int hash_slot;
+            RedisModuleString * username;
             RaftRedisCommandArray cmds;
             msg_entry_response_t response;
         } redis;
@@ -720,9 +721,9 @@ void NodeAddPendingResponse(Node *node, bool proxy);
 void NodeDismissPendingResponse(Node *node);
 
 /* serialization.c */
-raft_entry_t *RaftRedisCommandArraySerialize(const RaftRedisCommandArray *source);
+raft_entry_t *RaftRedisCommandArraySerialize(const char *username, size_t username_len, const RaftRedisCommandArray *source);
 size_t RaftRedisCommandDeserialize(RaftRedisCommand *target, const void *buf, size_t buf_size);
-RRStatus RaftRedisCommandArrayDeserialize(RaftRedisCommandArray *target, const void *buf, size_t buf_size);
+RRStatus RaftRedisCommandArrayDeserialize(RedisModuleString **username, RaftRedisCommandArray *target, const void *buf, size_t buf_size);
 void RaftRedisCommandArrayFree(RaftRedisCommandArray *array);
 void RaftRedisCommandFree(RaftRedisCommand *r);
 RaftRedisCommand *RaftRedisCommandArrayExtend(RaftRedisCommandArray *target);

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -647,6 +647,7 @@ typedef struct SnapshotResult {
 typedef struct {
     char *name;                 /* Command name */
     unsigned int flags;         /* Command flags, see CMD_SPEC_* */
+    RedisModuleDict *commands;  /* SubCommandSpec for sub commands */
 } CommandSpec;
 
 #define CMD_SPEC_READONLY       (1<<1)      /* Command is a read-only command */
@@ -655,6 +656,7 @@ typedef struct {
 #define CMD_SPEC_DONT_INTERCEPT (1<<4)      /* Command should not be intercepted to RAFT */
 #define CMD_SPEC_SORT_REPLY     (1<<5)      /* Command output should be sorted within a lua script */
 #define CMD_SPEC_RANDOM         (1<<6)      /* Commands that are always random */
+#define CMD_SPEC_SUBCOMMAND     (1<<7)      /* Commands that have subcommands to be handled */
 
 /* Command filtering re-entrancy counter handling.
  *
@@ -878,7 +880,7 @@ void handleClusterJoin(RedisRaftCtx *rr, RaftReq *req);
 /* commands.c */
 RRStatus CommandSpecInit(RedisModuleCtx *ctx, RedisRaftConfig *config);
 unsigned int CommandSpecGetAggregateFlags(RaftRedisCommandArray *array, unsigned int default_flags);
-const CommandSpec *CommandSpecGet(const RedisModuleString *cmd);
+const CommandSpec *CommandSpecGet(const RedisModuleString *cmd, const RedisModuleString *subcommand);
 
 /* sort.c */
 void handleSort(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);

--- a/src/serialization.c
+++ b/src/serialization.c
@@ -273,7 +273,7 @@ RRStatus RaftRedisCommandArrayDeserialize(RedisModuleString **username, RaftRedi
         return RR_ERROR;
     }
     p += n; buf_size -= n;
-    *username = RedisModule_CreateString(redis_raft.ctx, p, username_len);
+    *username = RedisModule_CreateString(NULL, p, username_len);
     p += (username_len + 1); buf_size -= (username_len + 1);
 
     /* Read multibulk count */

--- a/src/sort.c
+++ b/src/sort.c
@@ -117,7 +117,9 @@ early_exit:
 /* Calls Redis commands whose results can be sorted without semantically breaking them */
 void handleSort(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 {
-    const CommandSpec *cs = CommandSpecGet(argv[0]);
+    RedisModuleString *cmd = argv[0];
+    RedisModuleString *subcommand = argc > 1 ? argv[1] : NULL;
+    const CommandSpec *cs = CommandSpecGet(cmd, subcommand);
     if (!cs || !(cs->flags & CMD_SPEC_SORT_REPLY)) {
         RedisModule_ReplyWithError(ctx, "ERR not a sortable command");
         return;

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -9,7 +9,7 @@ import socket
 
 import pytest as pytest
 import time
-from redis import ResponseError
+from redis import ResponseError, Redis
 from pytest import raises, skip
 from .sandbox import RedisRaft, RedisRaftFailedToStart
 
@@ -381,9 +381,9 @@ def test_rolled_back_read_only_multi_reply(cluster):
 def test_acl(cluster):
     cluster.create(3)
 
-    client1 = redis.Redis(host='localhost', port=cluster.node(1).port, username="test", password="test")
-    client2 = redis.Redis(host='localhost', port=cluster.node(2).port, username="test", password="test")
-    client3 = redis.Redis(host='localhost', port=cluster.node(3).port, username="test", password="test")
+    client1 = Redis(host='localhost', port=cluster.node(1).port, username="test", password="test")
+    client2 = Redis(host='localhost', port=cluster.node(2).port, username="test", password="test")
+    client3 = Redis(host='localhost', port=cluster.node(3).port, username="test", password="test")
 
     with raises(ResponseError, match='WRONGPASS invalid username-password pair or user is disabled'):
         client1.set('key', 'value')

--- a/tests/test_serialization.c
+++ b/tests/test_serialization.c
@@ -55,7 +55,7 @@ static void test_serialize_redis_command(void **state)
 
 static void test_deserialize_redis_command(void **state)
 {
-    const char *serialized = "*4\ntest\n*3\n$3\nSET\n$3\nkey\n$5\nvalue\n";
+    const char *serialized = "*3\n$3\nSET\n$3\nkey\n$5\nvalue\n";
     int serialized_len = strlen(serialized);
 
     RaftRedisCommand target = { 0 };
@@ -71,16 +71,15 @@ static void test_deserialize_redis_command_array(void **state)
 
     RaftRedisCommandArray cmd_array = { 0 };
     RedisModuleString * username;
-    RedisModuleString * test = RedisModule_CreateString(NULL, "test", 4);
     cmd_array.len = 5; /* free would be called to reset it */
     assert_int_equal(RaftRedisCommandArrayDeserialize(&username, &cmd_array, serialized, serialized_len), RR_OK);
     assert_int_equal(cmd_array.len, 3);
     assert_non_null(username);
-    assert_int_equal(RedisModule_StringCompare(test, username), 0);
-
+    size_t len;
+    const char * tmp = RedisModule_StringPtrLen(username, &len);
+    strcmp("test", tmp);
     RaftRedisCommandArrayFree(&cmd_array);
     RedisModule_FreeString(NULL, username);
-    RedisModule_FreeString(NULL, test);
 }
 
 static void test_deserialize_corrupted_data(void **state)


### PR DESCRIPTION
check ACLs using redis module api before we execute redis commmand
allow acl setuser to be serialized to all nodes via raft log