### PR TITLE
Refactor helper functions to use RedisModuleCtx directly

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1337,15 +1337,15 @@ static void addClusterNodeReplyFromNode(RedisRaftCtx *rr,
  * 2. All configured shardgroups with their slot ranges and nodes.
  */
 
-static void addClusterNodesReply(RedisRaftCtx *rr, RaftReq *req)
+static void addClusterNodesReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
 {
-    raft_node_t *leader_node = getLeaderNodeOrReply(rr, req);
+    raft_node_t *leader_node = getLeaderNodeOrReply(rr, ctx);
     if (!leader_node) {
         return;
     }
     ShardingInfo *si = rr->sharding_info;
 
-    RedisModuleString *ret = RedisModule_CreateString(req->ctx, "", 0);
+    RedisModuleString *ret = RedisModule_CreateString(ctx, "", 0);
 
     if (si->shard_group_map != NULL) {
         size_t key_len;
@@ -1353,7 +1353,7 @@ static void addClusterNodesReply(RedisRaftCtx *rr, RaftReq *req)
 
         RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(si->shard_group_map, "^", NULL, 0);
         while (RedisModule_DictNextC(iter, &key_len, (void **) &sg) != NULL) {
-            RedisModuleString *slots = generateSlots(req->ctx, sg);
+            RedisModuleString *slots = generateSlots(ctx, sg);
 
             if (sg->local) {
                 for (int j = 0; j < raft_get_num_nodes(rr->raft); j++) {
@@ -1379,14 +1379,14 @@ static void addClusterNodesReply(RedisRaftCtx *rr, RaftReq *req)
                                             pong_recv, epoch, link_state, slots);
                 }
             }
-            RedisModule_FreeString(req->ctx, slots);
+            RedisModule_FreeString(ctx, slots);
         }
 
         RedisModule_DictIteratorStop(iter);
     }
 
-    RedisModule_ReplyWithString(req->ctx, ret);
-    RedisModule_FreeString(req->ctx, ret);
+    RedisModule_ReplyWithString(ctx, ret);
+    RedisModule_FreeString(ctx, ret);
 }
 
 /* Produce a CLUSTER SLOTS compatible reply, including:
@@ -1395,16 +1395,16 @@ static void addClusterNodesReply(RedisRaftCtx *rr, RaftReq *req)
  * 2. All configured shardgroups with their slot ranges and nodes.
  */
 
-static void addClusterSlotsReply(RedisRaftCtx *rr, RaftReq *req)
+static void addClusterSlotsReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
 {
-    raft_node_t *leader_node = getLeaderNodeOrReply(rr, req);
+    raft_node_t *leader_node = getLeaderNodeOrReply(rr, ctx);
     if (!leader_node) {
         return;
     }
 
     ShardingInfo *si = rr->sharding_info;
     if (!si->shard_group_map) {
-        RedisModule_ReplyWithArray(req->ctx, 0);
+        RedisModule_ReplyWithArray(ctx, 0);
         return;
     }
 
@@ -1418,18 +1418,18 @@ static void addClusterSlotsReply(RedisRaftCtx *rr, RaftReq *req)
         num_slots += sg->slot_ranges_num;
     }
     RedisModule_DictIteratorStop(iter);
-    RedisModule_ReplyWithArray(req->ctx, num_slots);
+    RedisModule_ReplyWithArray(ctx, num_slots);
 
     /* Return array elements */
     iter = RedisModule_DictIteratorStartC(si->shard_group_map, "^", NULL, 0);
     while (RedisModule_DictNextC(iter, &key_len, (void **) &sg) != NULL) {
         for (unsigned int i = 0; i < sg->slot_ranges_num; i++) {
-            RedisModule_ReplyWithArray(req->ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
+            RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 
             int slot_len = 0;
 
-            RedisModule_ReplyWithLongLong(req->ctx, sg->slot_ranges[i].start_slot); /* Start slot */
-            RedisModule_ReplyWithLongLong(req->ctx, sg->slot_ranges[i].end_slot);   /* End slot */
+            RedisModule_ReplyWithLongLong(ctx, sg->slot_ranges[i].start_slot); /* Start slot */
+            RedisModule_ReplyWithLongLong(ctx, sg->slot_ranges[i].end_slot);   /* End slot */
             slot_len += 2;
 
             /* Dump Raft nodes now. Leader (master) first, followed by others */
@@ -1439,7 +1439,7 @@ static void addClusterSlotsReply(RedisRaftCtx *rr, RaftReq *req)
                  * come from the ShardGroup.
                  */
 
-                slot_len += addClusterSlotNodeReply(rr, req->ctx, leader_node);
+                slot_len += addClusterSlotNodeReply(rr, ctx, leader_node);
                 for (int j = 0; j < raft_get_num_nodes(rr->raft); j++) {
                     raft_node_t *raft_node = raft_get_node_from_idx(rr->raft, j);
                     if (raft_node_get_id(raft_node) == raft_get_leader_id(rr->raft) ||
@@ -1447,7 +1447,7 @@ static void addClusterSlotsReply(RedisRaftCtx *rr, RaftReq *req)
                         continue;
                     }
 
-                    slot_len += addClusterSlotNodeReply(rr, req->ctx, raft_node);
+                    slot_len += addClusterSlotNodeReply(rr, ctx, raft_node);
                 }
             } else {
                 /* Remote cluster: we simply dump what the ShardGroup configuration
@@ -1455,11 +1455,11 @@ static void addClusterSlotsReply(RedisRaftCtx *rr, RaftReq *req)
                  */
 
                 for (unsigned int j = 0; j < sg->nodes_num; j++) {
-                    slot_len += addClusterSlotShardGroupNodeReply(rr, req->ctx, &sg->nodes[j]);
+                    slot_len += addClusterSlotShardGroupNodeReply(rr, ctx, &sg->nodes[j]);
                 }
             }
 
-            RedisModule_ReplySetArrayLength(req->ctx, slot_len);
+            RedisModule_ReplySetArrayLength(ctx, slot_len);
         }
     }
 
@@ -1488,10 +1488,10 @@ void handleClusterCommand(RedisRaftCtx *rr, RaftReq *req)
     const char *cmd_str = RedisModule_StringPtrLen(cmd->argv[1], &cmd_len);
 
     if (cmd_len == 5 && !strncasecmp(cmd_str, "SLOTS", 5) && cmd->argc == 2) {
-        addClusterSlotsReply(rr, req);
+        addClusterSlotsReply(rr, req->ctx);
         goto exit;
     } else if (cmd_len == 5 && !strncasecmp(cmd_str, "NODES", 5) && cmd->argc == 2) {
-        addClusterNodesReply(rr, req);
+        addClusterNodesReply(rr, req->ctx);
         goto exit;
     } else {
         RedisModule_ReplyWithError(req->ctx,
@@ -1605,8 +1605,8 @@ static void linkSendRequest(Connection *conn)
 void handleShardGroupLink(RedisRaftCtx *rr, RaftReq *req)
 {
     /* Must be done on a leader */
-    if (checkRaftState(rr, req) == RR_ERROR ||
-        checkLeader(rr, req, NULL) == RR_ERROR) {
+    if (checkRaftState(rr, req->ctx) == RR_ERROR ||
+        checkLeader(rr, req->ctx, NULL) == RR_ERROR) {
         goto exit_fail;
     }
 

--- a/src/join.c
+++ b/src/join.c
@@ -100,7 +100,7 @@ static void sendNodeAddRequest(Connection *conn)
 
 void handleClusterJoin(RedisRaftCtx *rr, RaftReq *req)
 {
-    if (checkRaftNotLoading(rr, req) == RR_ERROR) {
+    if (checkRaftNotLoading(rr, req->ctx) == RR_ERROR) {
         goto exit_fail;
     }
 

--- a/src/raft.c
+++ b/src/raft.c
@@ -1386,7 +1386,7 @@ void handleTransferLeader(RedisRaftCtx *rr, RaftReq *req)
 {
     int err;
 
-    if (checkRaftState(rr, req) == RR_ERROR) {
+    if (checkRaftState(rr, req->ctx) == RR_ERROR) {
         goto exit;
     }
 
@@ -1419,7 +1419,7 @@ exit:
 
 void handleTimeoutNow(RedisRaftCtx *rr, RaftReq *req)
 {
-    if (checkRaftState(rr, req) == RR_ERROR) {
+    if (checkRaftState(rr, req->ctx) == RR_ERROR) {
         goto exit;
     }
 
@@ -1434,7 +1434,7 @@ void handleRequestVote(RedisRaftCtx *rr, RaftReq *req)
 {
     msg_requestvote_response_t response;
 
-    if (checkRaftState(rr, req) == RR_ERROR) {
+    if (checkRaftState(rr, req->ctx) == RR_ERROR) {
         goto exit;
     }
 
@@ -1462,7 +1462,7 @@ void handleAppendEntries(RedisRaftCtx *rr, RaftReq *req)
     msg_appendentries_response_t response;
     int err;
 
-    if (checkRaftState(rr, req) == RR_ERROR) {
+    if (checkRaftState(rr, req->ctx) == RR_ERROR) {
         goto exit;
     }
 
@@ -1492,8 +1492,8 @@ void handleCfgChange(RedisRaftCtx *rr, RaftReq *req)
     msg_entry_response_t response;
     int e;
 
-    if (checkRaftState(rr, req) == RR_ERROR ||
-        checkLeader(rr, req, NULL) == RR_ERROR) {
+    if (checkRaftState(rr, req->ctx) == RR_ERROR ||
+        checkLeader(rr, req->ctx, NULL) == RR_ERROR) {
         goto exit;
     }
 
@@ -1856,7 +1856,7 @@ void handleRedisCommand(RedisRaftCtx *rr,RaftReq *req)
     /* Check that we're part of a boostrapped cluster and not in the middle of joining
      * or loading data.
      */
-    if (checkRaftState(rr, req) == RR_ERROR) {
+    if (checkRaftState(rr, req->ctx) == RR_ERROR) {
         goto exit;
     }
 
@@ -1876,7 +1876,7 @@ void handleRedisCommand(RedisRaftCtx *rr,RaftReq *req)
     }
 
     /* Confirm that we're the leader and handle redirect or proxying if not. */
-    if (checkLeader(rr, req, rr->config->follower_proxy ? &leader_proxy : NULL) == RR_ERROR) {
+    if (checkLeader(rr, req->ctx, rr->config->follower_proxy ? &leader_proxy : NULL) == RR_ERROR) {
         goto exit;
     }
 
@@ -2063,7 +2063,7 @@ void handleInfo(RedisRaftCtx *rr, RaftReq *req)
 
 void handleClusterInit(RedisRaftCtx *rr, RaftReq *req)
 {
-    if (checkRaftNotLoading(rr, req) == RR_ERROR) {
+    if (checkRaftNotLoading(rr, req->ctx) == RR_ERROR) {
         goto exit;
     }
 
@@ -2334,8 +2334,8 @@ void replaceShardGroups(RedisRaftCtx *rr, raft_entry_t *entry)
 void handleShardGroupAdd(RedisRaftCtx *rr, RaftReq *req)
 {
     /* Must be done on a leader */
-    if (checkRaftState(rr, req) == RR_ERROR ||
-        checkLeader(rr, req, NULL) == RR_ERROR) {
+    if (checkRaftState(rr, req->ctx) == RR_ERROR ||
+        checkLeader(rr, req->ctx, NULL) == RR_ERROR) {
         goto exit;
     }
 
@@ -2358,8 +2358,8 @@ exit:
 void handleShardGroupsReplace(RedisRaftCtx *rr, RaftReq *req)
 {
     /* Must be done on a leader */
-    if (checkRaftState(rr, req) == RR_ERROR ||
-        checkLeader(rr, req, NULL) == RR_ERROR) {
+    if (checkRaftState(rr, req->ctx) == RR_ERROR ||
+        checkLeader(rr, req->ctx, NULL) == RR_ERROR) {
         goto exit;
     }
 
@@ -2384,8 +2384,8 @@ exit:
 void handleShardGroupGet(RedisRaftCtx *rr, RaftReq *req)
 {
     /* Must be done on a leader */
-    if (checkRaftState(rr, req) == RR_ERROR ||
-        checkLeader(rr, req, NULL) == RR_ERROR) {
+    if (checkRaftState(rr, req->ctx) == RR_ERROR ||
+        checkLeader(rr, req->ctx, NULL) == RR_ERROR) {
         goto exit;
     }
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -742,10 +742,10 @@ void joinLinkIdleCallback(Connection *conn);
 void joinLinkFreeCallback(void *privdata);
 const char *getStateStr(RedisRaftCtx *rr);
 void replyRaftError(RedisModuleCtx *ctx, int error);
-raft_node_t getLeaderNodeOrReply(RedisRaftCtx *rr, RaftReq *req);
-RRStatus checkLeader(RedisRaftCtx *rr, RaftReq *req, Node **ret_leader);
-RRStatus checkRaftNotLoading(RedisRaftCtx *rr, RaftReq *req);
-RRStatus checkRaftState(RedisRaftCtx *rr, RaftReq *req);
+raft_node_t *getLeaderNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx);
+RRStatus checkLeader(RedisRaftCtx *rr, RedisModuleCtx *ctx, Node **ret_leader);
+RRStatus checkRaftNotLoading(RedisRaftCtx *rr, RedisModuleCtx *ctx);
+RRStatus checkRaftState(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 void replyRedirect(RedisModuleCtx *ctx, int slot, NodeAddr *addr);
 bool parseMovedReply(const char *str, NodeAddr *addr);
 

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -594,7 +594,7 @@ int raftLoadSnapshot(raft_server_t* raft, void *user_data, raft_index_t index, r
 
 void handleSnapshot(RedisRaftCtx *rr, RaftReq *req)
 {
-    if (checkRaftState(rr, req) == RR_ERROR) {
+    if (checkRaftState(rr, req->ctx) == RR_ERROR) {
         goto exit;
     }
 


### PR DESCRIPTION
Made these functions not to rely on RaftReq existence.