### PR TITLE
Move RAFT.NODE command handling into the command callback

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -48,7 +48,7 @@ static RedisModuleDict *multiClientState = NULL;
 
 /* ------------------------------------ Common helpers ------------------------------------ */
 
-static void shutdownAfterRemoval(RedisRaftCtx *rr)
+void shutdownAfterRemoval(RedisRaftCtx *rr)
 {
     LOG_INFO("*** NODE REMOVED, SHUTTING DOWN.");
 
@@ -62,7 +62,7 @@ static void shutdownAfterRemoval(RedisRaftCtx *rr)
     exit(0);
 }
 
-static RaftReq *entryDetachRaftReq(RedisRaftCtx *rr, raft_entry_t *entry)
+RaftReq *entryDetachRaftReq(RedisRaftCtx *rr, raft_entry_t *entry)
 {
     RaftReq* req = entry->user_data;
 
@@ -80,8 +80,7 @@ static RaftReq *entryDetachRaftReq(RedisRaftCtx *rr, raft_entry_t *entry)
 /* Set up a Raft log entry with an attached RaftReq. We use this when a user command provided
  * in a RaftReq should keep the client blocked until the log entry is committed and applied.
  */
-
-static void entryFreeAttachedRaftReq(raft_entry_t *ety)
+void entryFreeAttachedRaftReq(raft_entry_t *ety)
 {
     RaftReq *req = entryDetachRaftReq(&redis_raft, ety);
 
@@ -100,7 +99,7 @@ static void entryFreeAttachedRaftReq(raft_entry_t *ety)
  * When the entry will later reach the apply flow, the linkage to the RaftReq will
  * make it possible to generate the reply to the user.
  */
-static void entryAttachRaftReq(RedisRaftCtx *rr, raft_entry_t *entry, RaftReq *req)
+void entryAttachRaftReq(RedisRaftCtx *rr, raft_entry_t *entry, RaftReq *req)
 {
     entry->user_data = req;
     entry->free_func = entryFreeAttachedRaftReq;
@@ -532,12 +531,13 @@ static int raftApplyLog(raft_server_t *raft, void *user_data, raft_entry_t *entr
     switch (entry->type) {
         case RAFT_LOGTYPE_ADD_NONVOTING_NODE:
             req = entryDetachRaftReq(rr, entry);
+            cfg = (RaftCfgChange *) entry->data;
             if (!req) {
                 break;
             }
 
             RedisModule_ReplyWithArray(req->ctx, 2);
-            RedisModule_ReplyWithLongLong(req->ctx, req->r.cfgchange.id);
+            RedisModule_ReplyWithLongLong(req->ctx, cfg->id);
             RedisModule_ReplyWithSimpleString(req->ctx, rr->snapshot_info.dbid);
             RaftReqFree(req);
             break;
@@ -1018,7 +1018,7 @@ static int appendRaftCfgChangeEntry(RedisRaftCtx *rr, int type, int id, NodeAddr
     return 0;
 }
 
-static raft_node_id_t makeRandomNodeId(RedisRaftCtx *rr)
+raft_node_id_t makeRandomNodeId(RedisRaftCtx *rr)
 {
     unsigned int tmp;
     raft_node_id_t id;
@@ -1481,75 +1481,6 @@ void handleAppendEntries(RedisRaftCtx *rr, RaftReq *req)
     RedisModule_ReplyWithLongLong(req->ctx, response.success);
     RedisModule_ReplyWithLongLong(req->ctx, response.current_idx);
     RedisModule_ReplyWithLongLong(req->ctx, response.msg_id);
-
-exit:
-    RaftReqFree(req);
-}
-
-void handleCfgChange(RedisRaftCtx *rr, RaftReq *req)
-{
-    raft_entry_t *entry;
-    msg_entry_response_t response;
-    int e;
-
-    if (checkRaftState(rr, req->ctx) == RR_ERROR ||
-        checkLeader(rr, req->ctx, NULL) == RR_ERROR) {
-        goto exit;
-    }
-
-    short type;
-
-    switch (req->type) {
-        case RR_CFGCHANGE_ADDNODE:
-            if (hasNodeIdBeenUsed(rr, req->r.cfgchange.id)) {
-                RedisModule_ReplyWithError(req->ctx,
-                               "node id has already been used in this cluster");
-                goto exit;
-            }
-
-            type = RAFT_LOGTYPE_ADD_NONVOTING_NODE;
-            if (!req->r.cfgchange.id) {
-                req->r.cfgchange.id = makeRandomNodeId(rr);
-            }
-            break;
-        case RR_CFGCHANGE_REMOVENODE:
-            /* Validate it exists */
-            if (!raft_get_node(rr->raft, req->r.cfgchange.id)) {
-                RedisModule_ReplyWithError(req->ctx, "node id does not exist");
-                goto exit;
-            }
-
-            type = RAFT_LOGTYPE_REMOVE_NODE;
-            break;
-        default:
-            RedisModule_Assert(0);
-    }
-
-    entry = raft_entry_new(sizeof(req->r.cfgchange));
-    entry->id = rand();
-    entry->type = type;
-    memcpy(entry->data, &req->r.cfgchange, sizeof(req->r.cfgchange));
-    entryAttachRaftReq(rr, entry, req);
-
-    e = raft_recv_entry(rr->raft, entry, &response);
-    if (e != 0) {
-        entryDetachRaftReq(rr, entry);
-        raft_entry_release(entry);
-        replyRaftError(req->ctx, e);
-        goto exit;
-    }
-
-    raft_entry_release(entry);
-
-    if (req->type == RR_CFGCHANGE_REMOVENODE) {
-        /* Special case, we are the only node and our node has been removed */
-        if (req->r.cfgchange.id == raft_get_nodeid(rr->raft) &&
-            raft_get_num_voting_nodes(rr->raft) == 0) {
-            shutdownAfterRemoval(rr);
-        }
-    }
-
-    return;
 
 exit:
     RaftReqFree(req);

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -63,24 +63,23 @@ static RRStatus getNodeAddrFromArg(RedisModuleCtx *ctx, RedisModuleString *arg, 
  *   -MOVED <slot> <addr>:<port> ||
  *   +OK
  */
-
 static int cmdRaftNode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 {
+    RedisRaftCtx *rr = &redis_raft;
+
     if (argc < 2) {
         RedisModule_WrongArity(ctx);
         return REDISMODULE_OK;
     }
 
-    RedisRaftCtx *rr = &redis_raft;
-    RaftReq *req = NULL;
-    size_t cmd_len;
-
-    if (rr->state != REDIS_RAFT_UP) {
-        RedisModule_ReplyWithError(ctx, "NOCLUSTER No Raft Cluster");
+    if (checkRaftState(rr, ctx) == RR_ERROR ||
+        checkLeader(rr, ctx, NULL) == RR_ERROR) {
         return REDISMODULE_OK;
     }
 
+    size_t cmd_len;
     const char *cmd = RedisModule_StringPtrLen(argv[1], &cmd_len);
+
     if (!strncasecmp(cmd, "ADD", cmd_len)) {
         if (argc != 4) {
             RedisModule_WrongArity(ctx);
@@ -95,16 +94,45 @@ static int cmdRaftNode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
             return REDISMODULE_OK;
         }
 
+        if (hasNodeIdBeenUsed(rr, (raft_node_id_t) node_id)) {
+            RedisModule_ReplyWithError(ctx, "node id has already been used in this cluster");
+            return REDISMODULE_OK;
+        }
+
+        if (node_id == 0) {
+            node_id = makeRandomNodeId(rr);
+        }
+
+        RaftCfgChange cfg = {
+            .id = (raft_node_id_t) node_id
+        };
+
         /* Parse address */
-        NodeAddr node_addr = { 0 };
-        if (getNodeAddrFromArg(ctx, argv[3], &node_addr) == RR_ERROR) {
+        if (getNodeAddrFromArg(ctx, argv[3], &cfg.addr) == RR_ERROR) {
             /* Error already produced */
             return REDISMODULE_OK;
         }
 
-        req = RaftReqInit(ctx, RR_CFGCHANGE_ADDNODE);
-        req->r.cfgchange.id = node_id;
-        req->r.cfgchange.addr = node_addr;
+        msg_entry_response_t resp;
+        RaftReq *req = RaftReqInit(ctx, RR_CFGCHANGE_ADDNODE);
+
+        msg_entry_t *entry = raft_entry_new(sizeof(cfg));
+        entry->id = rand();
+        entry->type = RAFT_LOGTYPE_ADD_NONVOTING_NODE;
+        memcpy(entry->data, &cfg, sizeof(cfg));
+        entryAttachRaftReq(rr, entry, req);
+
+        int e = raft_recv_entry(rr->raft, entry, &resp);
+        if (e != 0) {
+            entryDetachRaftReq(rr, entry);
+            replyRaftError(req->ctx, e);
+            raft_entry_release(entry);
+            RaftReqFree(req);
+            return REDISMODULE_OK;
+        }
+
+        raft_entry_release(entry);
+
     } else if (!strncasecmp(cmd, "REMOVE", cmd_len)) {
         if (argc != 3) {
             RedisModule_WrongArity(ctx);
@@ -118,14 +146,45 @@ static int cmdRaftNode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
                 return REDISMODULE_OK;
         }
 
-        req = RaftReqInit(ctx, RR_CFGCHANGE_REMOVENODE);
-        req->r.cfgchange.id = node_id;
+        /* Validate it exists */
+        if (!raft_get_node(rr->raft, (raft_node_id_t) node_id)) {
+            RedisModule_ReplyWithError(ctx, "node id does not exist");
+            return REDISMODULE_OK;
+        }
+
+        RaftCfgChange cfg = {
+            .id = (raft_node_id_t) node_id
+        };
+
+        msg_entry_response_t resp;
+        RaftReq *req = RaftReqInit(ctx, RR_CFGCHANGE_REMOVENODE);
+
+        msg_entry_t *entry = raft_entry_new(sizeof(cfg));
+        entry->id = rand();
+        entry->type = RAFT_LOGTYPE_REMOVE_NODE;
+        memcpy(entry->data, &cfg, sizeof(cfg));
+        entryAttachRaftReq(rr, entry, req);
+
+        int e = raft_recv_entry(rr->raft, entry, &resp);
+        if (e != 0) {
+            entryDetachRaftReq(rr, entry);
+            replyRaftError(req->ctx, e);
+            raft_entry_release(entry);
+            RaftReqFree(req);
+            return REDISMODULE_OK;
+        }
+
+        raft_entry_release(entry);
+
+        /* Special case, we are the only node and our node has been removed */
+        if (cfg.id == raft_get_nodeid(rr->raft) &&
+            raft_get_num_voting_nodes(rr->raft) == 0) {
+            shutdownAfterRemoval(rr);
+        }
     } else {
         RedisModule_ReplyWithError(ctx, "RAFT.NODE supports ADD / REMOVE only");
-        return REDISMODULE_OK;
     }
 
-    handleCfgChange(rr, req);
     return REDISMODULE_OK;
 }
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -602,7 +602,6 @@ typedef struct RaftReq {
         struct {
             NodeAddrListElement *addr;
         } cluster_join;
-        RaftCfgChange cfgchange;
         struct {
             raft_node_id_t src_node_id;
             msg_appendentries_t msg;
@@ -777,6 +776,10 @@ void RaftReqFree(RaftReq *req);
 RaftReq *RaftReqInit(RedisModuleCtx *ctx, enum RaftReqType type);
 RaftReq *RaftDebugReqInit(RedisModuleCtx *ctx, enum RaftDebugReqType type);
 void addUsedNodeId(RedisRaftCtx *rr, raft_node_id_t node_id);
+raft_node_id_t makeRandomNodeId(RedisRaftCtx *rr);
+void entryAttachRaftReq(RedisRaftCtx *rr, raft_entry_t *entry, RaftReq *req);
+RaftReq *entryDetachRaftReq(RedisRaftCtx *rr, raft_entry_t *entry);
+void shutdownAfterRemoval(RedisRaftCtx *rr);
 bool hasNodeIdBeenUsed(RedisRaftCtx *rr, raft_node_id_t node_id);
 void handleClusterInit(RedisRaftCtx *rr, RaftReq *req);
 void handleRedisCommand(RedisRaftCtx *rr,RaftReq *req);
@@ -786,7 +789,6 @@ void handleShardGroupGet(RedisRaftCtx *rr, RaftReq *req);
 void handleDebug(RedisRaftCtx *rr, RaftReq *req);
 void handleNodeShutdown(RedisRaftCtx *rr, RaftReq *req);
 void handleClientDisconnect(RedisRaftCtx *rr, RaftReq *req);
-void handleCfgChange(RedisRaftCtx *rr, RaftReq *req);
 void handleTransferLeader(RedisRaftCtx *rr, RaftReq *req);
 void handleTimeoutNow(RedisRaftCtx *rr, RaftReq *req);
 void handleRequestVote(RedisRaftCtx *rr, RaftReq *req);


### PR DESCRIPTION
As part of refactoring, moved RAFT.NODE command handling into the command callback.