### PR TITLE
Move leader transfer command handling into the command callback

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -48,8 +48,14 @@ void replyRaftError(RedisModuleCtx *ctx, int error)
         case RAFT_ERR_NOMEM:
             RedisModule_ReplyWithError(ctx, "OOM Raft out of memory");
             break;
+        case RAFT_ERR_LEADER_TRANSFER_IN_PROGRESS:
+            RedisModule_ReplyWithError(ctx, "ERR transfer already in progress");
+            break;
+        case RAFT_ERR_INVALID_NODEID:
+            RedisModule_ReplyWithError(ctx, "ERR invalid node id");
+            break;
         default:
-            snprintf(buf, sizeof(buf) - 1, "ERR Raft error %d", error);
+            snprintf(buf, sizeof(buf), "ERR Raft error %d", error);
             RedisModule_ReplyWithError(ctx, buf);
             break;
     }

--- a/src/raft.c
+++ b/src/raft.c
@@ -33,8 +33,7 @@ const char *RaftReqTypeStr[] = {
     "RR_SHARDGROUP_UPDATE",
     "RR_SHARDGROUP_GET",
     "RR_SHARDGROUP_LINK",
-    "RR_TRANSFER_LEADER",
-    "RR_TIMEOUT_NOW",
+    "RR_TRANSFER_LEADER"
 };
 
 /* Forward declarations */
@@ -1380,54 +1379,6 @@ void handleTransferLeaderComplete(raft_server_t *raft, raft_transfer_state_e sta
 
     RaftReqFree(redis_raft.transfer_req);
     redis_raft.transfer_req = NULL;
-}
-
-void handleTransferLeader(RedisRaftCtx *rr, RaftReq *req)
-{
-    int err;
-
-    if (checkRaftState(rr, req->ctx) == RR_ERROR) {
-        goto exit;
-    }
-
-    if ((err = raft_transfer_leader(rr->raft, req->r.node_to_transfer_leader, 0)) != 0) {
-        char e[128];
-        switch (err) {
-            case RAFT_ERR_NOT_LEADER:
-                RedisModule_ReplyWithError(req->ctx, "ERR not leader");
-                break;
-            case RAFT_ERR_LEADER_TRANSFER_IN_PROGRESS:
-                RedisModule_ReplyWithError(req->ctx, "ERR transfer already in progress");
-                break;
-            case RAFT_ERR_INVALID_NODEID:
-                snprintf(e, 128, "ERR invalid node id: %d", req->r.node_to_transfer_leader);
-                RedisModule_ReplyWithError(req->ctx, e);
-                break;
-            default:
-                snprintf(e, 128, "ERR unknown error transferring leader: %d", err);
-                RedisModule_ReplyWithError(req->ctx, e);
-                break;
-        }
-        goto exit;
-    }
-    redis_raft.transfer_req = req;
-    return;
-
-exit:
-    RaftReqFree(req);
-}
-
-void handleTimeoutNow(RedisRaftCtx *rr, RaftReq *req)
-{
-    if (checkRaftState(rr, req->ctx) == RR_ERROR) {
-        goto exit;
-    }
-
-    raft_set_timeout_now(rr->raft);
-    RedisModule_ReplyWithSimpleString(req->ctx, "OK");
-
-exit:
-    RaftReqFree(req);
 }
 
 void handleRequestVote(RedisRaftCtx *rr, RaftReq *req)

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -139,7 +139,6 @@ static int cmdRaftNode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
  */
 static int cmdRaftTransferLeader(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 {
-    char buf[128];
     RedisRaftCtx *rr = &redis_raft;
 
     if (argc != 2) {
@@ -164,22 +163,7 @@ static int cmdRaftTransferLeader(RedisModuleCtx *ctx, RedisModuleString **argv, 
 
     int err = raft_transfer_leader(rr->raft, target_node_id, 0);
     if (err != 0) {
-        switch (err) {
-            case RAFT_ERR_NOT_LEADER:
-                RedisModule_ReplyWithError(ctx, "ERR not leader");
-                break;
-            case RAFT_ERR_LEADER_TRANSFER_IN_PROGRESS:
-                RedisModule_ReplyWithError(ctx, "ERR transfer already in progress");
-                break;
-            case RAFT_ERR_INVALID_NODEID:
-                snprintf(buf, sizeof(buf), "ERR invalid node id: %d", target_node_id);
-                RedisModule_ReplyWithError(ctx, buf);
-                break;
-            default:
-                snprintf(buf, sizeof(buf), "ERR unknown error transferring leader: %d", err);
-                RedisModule_ReplyWithError(ctx, buf);
-                break;
-        }
+        replyRaftError(ctx, err);
         return REDISMODULE_OK;
     }
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -466,7 +466,6 @@ enum RaftReqType {
     RR_SHARDGROUP_LINK,
     RR_NODE_SHUTDOWN,
     RR_TRANSFER_LEADER,
-    RR_TIMEOUT_NOW,
     RR_CONFIG,
 };
 
@@ -787,8 +786,6 @@ void handleDebug(RedisRaftCtx *rr, RaftReq *req);
 void handleNodeShutdown(RedisRaftCtx *rr, RaftReq *req);
 void handleClientDisconnect(RedisRaftCtx *rr, RaftReq *req);
 void handleCfgChange(RedisRaftCtx *rr, RaftReq *req);
-void handleTransferLeader(RedisRaftCtx *rr, RaftReq *req);
-void handleTimeoutNow(RedisRaftCtx *rr, RaftReq *req);
 void handleRequestVote(RedisRaftCtx *rr, RaftReq *req);
 void handleShardGroupsReplace(RedisRaftCtx *rr, RaftReq *req);
 void handleConfig(RedisRaftCtx *rr, RaftReq *req);


### PR DESCRIPTION
As part of refactoring, moved leader transfer command handling into the command callback.