### PR TITLE
Address TLS usability issues

### DIFF
--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -16,7 +16,7 @@ In addition, one has to pass the `tls-enabled yes` option to the redisraft modul
 
 ## Configuring RedisRaft TLS support
 
-RedisRaft can be configured by reusing the Redis server's TLS configuration, or by configuring the RedisRaft module directly. In general, we expect people will configure the Redis server. 
+RedisRaft is configured by reusing the Redis server's TLS configuration. 
 
 ### Configuring RedisRaft via Redis.
 
@@ -29,7 +29,3 @@ RedisRaft can be configured by reusing the Redis server's TLS configuration, or 
 | tls-client-cert-file     | File Containing the PEM encoded public signed CERT (overrides tls-cert-file)                              |                                                                                                          |
 | tls-key-file-pass        | String containing password to decrypt the private key, if encrypted                                       |
 | tls-client-key-file-pass | String containing password to decrypt the private key if using client key field                           | 
-
-### Configuring RedisRaft
-
-RedisRaft can also be configured via module configuration using the same Redis configuration key names if one wants to keep it separate from Redis.  One thing to note, if one configures RedisRaft via the module configuration, one should ensure that one configures all required fields via the module configuration options.

--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -16,17 +16,17 @@ In addition, one has to pass the `tls-enabled yes` option to the redisraft modul
 
 ## Configuring RedisRaft TLS support
 
-RedisRaft can be configured by reusing the Redis server's TLS configuration, or by configuring the RedisRaft module directly.  In general, we expect people will configure the Redis server. 
+RedisRaft can be configured by reusing the Redis server's TLS configuration, or by configuring the RedisRaft module directly. In general, we expect people will configure the Redis server. 
 
 ### Configuring RedisRaft via Redis.
 
 | Config Key Name          | Meaning                                                                                                   |
 |--------------------------|-----------------------------------------------------------------------------------------------------------|
-| tls-ca-cert-file         | File Containing the CA Sertificate                                                                        |
+| tls-ca-cert-file         | File Containing the CA Certificate                                                                        |
 | tls-key-file             | File Containing the PEM encoded private key file                                                          |
-| tls-client-key-file      | File Containing the PEM encoded private key file for client connecitons (overrides value of tls-key-file) |
-| tls-cert-file            | File Containg the PEM encoded public signed CERT                                                          |
-| tla-client-cert-file     | File Containg the PEM encoded public signed CERT (overrides tla-cert-file)                                |                                                                                                          |
+| tls-client-key-file      | File Containing the PEM encoded private key file for client connections (overrides value of tls-key-file) |
+| tls-cert-file            | File Containing the PEM encoded public signed CERT                                                        |
+| tls-client-cert-file     | File Containing the PEM encoded public signed CERT (overrides tls-cert-file)                              |                                                                                                          |
 | tls-key-file-pass        | String containing password to decrypt the private key, if encrypted                                       |
 | tls-client-key-file-pass | String containing password to decrypt the private key if using client key field                           | 
 
@@ -34,9 +34,9 @@ RedisRaft can be configured by reusing the Redis server's TLS configuration, or 
 
 | Redis Module Config Key Name | Maps to Redis Configuration |
 |------------------------------|-----------------------------|
-| tls-ca-cert                  | tla-ca-cert-file            |
+| tls-ca-cert                  | tls-ca-cert-file            |
 | tls-key                      | tls-key-file                |
-| tls-cert                     | tla-cert-file               |
-| tla-key-pass                 | tile-key-file-pass          |
+| tls-cert                     | tls-cert-file               |
+| tls-key-pass                 | tls-key-file-pass           |
 
 One thing to note, if one configures RedisRaft via the module configuration, one should ensure that one configures all required fields via the module configuration options.

--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -1,5 +1,4 @@
-RedisRaft TLS Support
-=====================
+# RedisRaft TLS Support
 
 RedisRaft's TLS support mirrors Redis's native TLS support.  
 
@@ -15,10 +14,29 @@ In addition, one has to pass the `tls-enabled yes` option to the redisraft modul
 --loadmodule ./redisraft.so <other options> tls-enabled yes
 ```
 
-RedisRaft is smart enough to figure out which files to use for the local cert/key/ca by querying the underlying Redis server.  However, if a user wants to use different files for the client aspects vs server aspects, one can specify RedisRaft module options as well
+## Configuring RedisRaft TLS support
 
-```asm
-tls-ca-cert
-tls-cert
-tls-key
-```
+RedisRaft can be configured by reusing the Redis server's TLS configuration, or by configuring the RedisRaft module directly.  In general, we expect people will configure the Redis server. 
+
+### Configuring RedisRaft via Redis.
+
+| Config Key Name          | Meaning                                                                                                   |
+|--------------------------|-----------------------------------------------------------------------------------------------------------|
+| tls-ca-cert-file         | File Containing the CA Sertificate                                                                        |
+| tls-key-file             | File Containing the PEM encoded private key file                                                          |
+| tls-client-key-file      | File Containing the PEM encoded private key file for client connecitons (overrides value of tls-key-file) |
+| tls-cert-file            | File Containg the PEM encoded public signed CERT                                                          |
+| tla-client-cert-file     | File Containg the PEM encoded public signed CERT (overrides tla-cert-file)                                |                                                                                                          |
+| tls-key-file-pass        | String containing password to decrypt the private key, if encrypted                                       |
+| tls-client-key-file-pass | String containing password to decrypt the private key if using client key field                           | 
+
+### Configuring RedisRaft
+
+| Redis Module Config Key Name | Maps to Redis Configuration |
+|------------------------------|-----------------------------|
+| tls-ca-cert                  | tla-ca-cert-file            |
+| tls-key                      | tls-key-file                |
+| tls-cert                     | tla-cert-file               |
+| tla-key-pass                 | tile-key-file-pass          |
+
+One thing to note, if one configures RedisRaft via the module configuration, one should ensure that one configures all required fields via the module configuration options.

--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -32,11 +32,4 @@ RedisRaft can be configured by reusing the Redis server's TLS configuration, or 
 
 ### Configuring RedisRaft
 
-| Redis Module Config Key Name | Maps to Redis Configuration |
-|------------------------------|-----------------------------|
-| tls-ca-cert                  | tls-ca-cert-file            |
-| tls-key                      | tls-key-file                |
-| tls-cert                     | tls-cert-file               |
-| tls-key-pass                 | tls-key-file-pass           |
-
-One thing to note, if one configures RedisRaft via the module configuration, one should ensure that one configures all required fields via the module configuration options.
+RedisRaft can also be configured via module configuration using the same Redis configuration key names if one wants to keep it separate from Redis.  One thing to note, if one configures RedisRaft via the module configuration, one should ensure that one configures all required fields via the module configuration options.

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1540,7 +1540,12 @@ static void linkHandleResponse(redisAsyncContext *c, void *r, void *privdata)
     JoinLinkState *state = ConnGetPrivateData(conn);
 
     if (!reply) {
+#ifndef HAVE_TLS
         LOG_WARNING("RAFT.SHARDGROUP GET failed: connection dropped.");
+#else
+        unsigned long e = ERR_peek_last_error();
+        LOG_WARNING("RAFT.SHARDGROUP GET failed: connection dropped: %s", ERR_reason_error_string(e));
+#endif
     } else if (reply->type == REDIS_REPLY_ERROR) {
         /* -MOVED? */
         if (strlen(reply->str) > 6 && !strncmp(reply->str, "MOVED ", 6)) {

--- a/src/config.c
+++ b/src/config.c
@@ -51,7 +51,7 @@ static const char *CONF_TLS_ENABLED = "tls-enabled";
 static const char *CONF_TLS_CA_CERT = "tls-ca-cert";
 static const char *CONF_TLS_CERT = "tls-cert";
 static const char *CONF_TLS_KEY = "tls-key";
-static const char *CONF_TLS_KEY_FILE_PASS = "tls-key-file-pass";
+static const char *CONF_TLS_KEY_PASS = "tls-key-pass";
 static const char *CONF_CLUSTER_USER = "cluster-user";
 static const char *CONF_CLUSTER_PASSWORD = "cluster-password";
 
@@ -428,12 +428,12 @@ static RRStatus processConfigParam(const char *keyword, const char *value, Redis
             RedisModule_Free(target->tls_key);
         }
         target->tls_key = RedisModule_Strdup(value);
-    } else if (!strcmp(keyword, CONF_TLS_KEY_FILE_PASS)) {
+    } else if (!strcmp(keyword, CONF_TLS_KEY_PASS)) {
         target->tls_manual = true;
-        if (target->tls_key_file_pass) {
-            RedisModule_Free(target->tls_key_file_pass);
+        if (target->tls_key_pass) {
+            RedisModule_Free(target->tls_key_pass);
         }
-        target->tls_key_file_pass = RedisModule_Strdup(value);
+        target->tls_key_pass = RedisModule_Strdup(value);
     } else if (!strcmp(keyword, CONF_CLUSTER_PASSWORD)) {
         if (target->cluster_password) {
             RedisModule_Free(target->cluster_password);
@@ -663,11 +663,11 @@ void updateTLSConfig(RedisModuleCtx *ctx, RedisRaftConfig *config) {
         RedisModule_Free(config->tls_key);
         config->tls_key = key;
     }
-    config->tls_key_file_pass = getRedisConfig(ctx, "tls-key-file-pass");
+    config->tls_key_pass = getRedisConfig(ctx, "tls-key-file-pass");
     char *pass = getRedisConfig(ctx, "tls-client-key-file-pass");
     if (pass) {
-        RedisModule_Free(config->tls_key_file_pass);
-        config->tls_key_file_pass = pass;
+        RedisModule_Free(config->tls_key_pass);
+        config->tls_key_pass = pass;
     }
     config->tls_cert = getRedisConfig(ctx, "tls-cert-file");
     char *cert = getRedisConfig(ctx, "tls-client-cert-file");

--- a/src/config.c
+++ b/src/config.c
@@ -48,6 +48,7 @@ static const char *CONF_IGNORED_COMMANDS = "ignored-commands";
 static const char *CONF_EXTERNAL_SHARDING = "external-sharding";
 static const char *CONF_MAX_APPEND_REQ_IN_FLIGHT = "max-append-req-in-flight";
 static const char *CONF_TLS_ENABLED = "tls-enabled";
+static const char *CONF_TLS_TRACE = "tls-trace";
 static const char *CONF_TLS_CA_CERT = "tls-ca-cert";
 static const char *CONF_TLS_CERT = "tls-cert";
 static const char *CONF_TLS_KEY = "tls-key";
@@ -410,6 +411,11 @@ static RRStatus processConfigParam(const char *keyword, const char *value, Redis
         if (parseBool(value, &val) != RR_OK)
             goto invalid_value;
         target->tls_enabled = val;
+    } else if (!strcmp(keyword, CONF_TLS_TRACE)) {
+        bool val;
+        if (parseBool(value, &val) != RR_OK)
+            goto invalid_value;
+        target->tls_trace = val;
     } else if (!strcmp(keyword, CONF_TLS_CA_CERT)) {
         target->tls_manual = true;
         if (target->tls_ca_cert) {
@@ -660,20 +666,32 @@ void updateTLSConfig(RedisModuleCtx *ctx, RedisRaftConfig *config) {
     config->tls_key = getRedisConfig(ctx, "tls-key-file");
     char *key = getRedisConfig(ctx, "tls-client-key-file");
     if (key) {
-        RedisModule_Free(config->tls_key);
-        config->tls_key = key;
+        if (strcmp("", key)) {
+            RedisModule_Free(config->tls_key);
+            config->tls_key = key;
+        } else {
+            RedisModule_Free(key);
+        }
     }
     config->tls_key_pass = getRedisConfig(ctx, "tls-key-file-pass");
     char *pass = getRedisConfig(ctx, "tls-client-key-file-pass");
     if (pass) {
-        RedisModule_Free(config->tls_key_pass);
-        config->tls_key_pass = pass;
+        if (strcmp("", pass)) {
+            RedisModule_Free(config->tls_key_pass);
+            config->tls_key_pass = pass;
+        } else {
+            RedisModule_Free(pass);
+        }
     }
     config->tls_cert = getRedisConfig(ctx, "tls-cert-file");
     char *cert = getRedisConfig(ctx, "tls-client-cert-file");
     if (cert) {
-        RedisModule_Free(config->tls_cert);
-        config->tls_cert = cert;
+        if (strcmp("", cert)) {
+            RedisModule_Free(config->tls_cert);
+            config->tls_cert = cert;
+        } else {
+            RedisModule_Free(cert);
+        }
     }
 
 }

--- a/src/config.c
+++ b/src/config.c
@@ -48,7 +48,6 @@ static const char *CONF_IGNORED_COMMANDS = "ignored-commands";
 static const char *CONF_EXTERNAL_SHARDING = "external-sharding";
 static const char *CONF_MAX_APPEND_REQ_IN_FLIGHT = "max-append-req-in-flight";
 static const char *CONF_TLS_ENABLED = "tls-enabled";
-static const char *CONF_TLS_TRACE = "tls-trace";
 static const char *CONF_TLS_CA_CERT = "tls-ca-cert";
 static const char *CONF_TLS_CERT = "tls-cert";
 static const char *CONF_TLS_KEY = "tls-key";
@@ -411,11 +410,6 @@ static RRStatus processConfigParam(const char *keyword, const char *value, Redis
         if (parseBool(value, &val) != RR_OK)
             goto invalid_value;
         target->tls_enabled = val;
-    } else if (!strcmp(keyword, CONF_TLS_TRACE)) {
-        bool val;
-        if (parseBool(value, &val) != RR_OK)
-            goto invalid_value;
-        target->tls_trace = val;
     } else if (!strcmp(keyword, CONF_TLS_CA_CERT)) {
         target->tls_manual = true;
         if (target->tls_ca_cert) {
@@ -661,8 +655,15 @@ void ConfigGet(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, 
     RedisModule_ReplySetArrayLength(ctx, len * 2);
 }
 
-void updateTLSConfig(RedisModuleCtx *ctx, RedisRaftConfig *config) {
+void updateTLSConfig(RedisModuleCtx *ctx, RedisRaftConfig *config)
+{
+    if (config->tls_ca_cert) {
+        RedisModule_Free(config->tls_ca_cert);
+    }
     config->tls_ca_cert = getRedisConfig(ctx, "tls-ca-cert-file");
+    if (config->tls_key) {
+        RedisModule_Free(config->tls_key);
+    }
     config->tls_key = getRedisConfig(ctx, "tls-key-file");
     char *key = getRedisConfig(ctx, "tls-client-key-file");
     if (key) {
@@ -672,6 +673,9 @@ void updateTLSConfig(RedisModuleCtx *ctx, RedisRaftConfig *config) {
         } else {
             RedisModule_Free(key);
         }
+    }
+    if (config->tls_key_pass) {
+        RedisModule_Free(config->tls_key_pass);
     }
     config->tls_key_pass = getRedisConfig(ctx, "tls-key-file-pass");
     char *pass = getRedisConfig(ctx, "tls-client-key-file-pass");
@@ -683,6 +687,9 @@ void updateTLSConfig(RedisModuleCtx *ctx, RedisRaftConfig *config) {
             RedisModule_Free(pass);
         }
     }
+    if (config->tls_cert) {
+        RedisModule_Free(config->tls_cert);
+    }
     config->tls_cert = getRedisConfig(ctx, "tls-cert-file");
     char *cert = getRedisConfig(ctx, "tls-client-cert-file");
     if (cert) {
@@ -693,7 +700,6 @@ void updateTLSConfig(RedisModuleCtx *ctx, RedisRaftConfig *config) {
             RedisModule_Free(cert);
         }
     }
-
 }
 
 void ConfigInit(RedisModuleCtx *ctx, RedisRaftConfig *config)

--- a/src/config.c
+++ b/src/config.c
@@ -48,10 +48,6 @@ static const char *CONF_IGNORED_COMMANDS = "ignored-commands";
 static const char *CONF_EXTERNAL_SHARDING = "external-sharding";
 static const char *CONF_MAX_APPEND_REQ_IN_FLIGHT = "max-append-req-in-flight";
 static const char *CONF_TLS_ENABLED = "tls-enabled";
-static const char *CONF_TLS_CA_CERT = "tls-ca-cert-file";
-static const char *CONF_TLS_CERT = "tls-cert-file";
-static const char *CONF_TLS_KEY = "tls-key-file";
-static const char *CONF_TLS_KEY_PASS = "tls-key-file-pass";
 static const char *CONF_CLUSTER_USER = "cluster-user";
 static const char *CONF_CLUSTER_PASSWORD = "cluster-password";
 
@@ -410,30 +406,6 @@ static RRStatus processConfigParam(const char *keyword, const char *value, Redis
         if (parseBool(value, &val) != RR_OK)
             goto invalid_value;
         target->tls_enabled = val;
-    } else if (!strcmp(keyword, CONF_TLS_CA_CERT)) {
-        target->tls_manual = true;
-        if (target->tls_ca_cert) {
-            RedisModule_Free(target->tls_ca_cert);
-        }
-        target->tls_ca_cert = RedisModule_Strdup(value);
-    } else if (!strcmp(keyword, CONF_TLS_CERT)) {
-        target->tls_manual = true;
-        if (target->tls_cert) {
-            RedisModule_Free(target->tls_cert);
-        }
-        target->tls_cert = RedisModule_Strdup(value);
-    } else if (!strcmp(keyword, CONF_TLS_KEY)) {
-        target->tls_manual = true;
-        if (target->tls_key) {
-            RedisModule_Free(target->tls_key);
-        }
-        target->tls_key = RedisModule_Strdup(value);
-    } else if (!strcmp(keyword, CONF_TLS_KEY_PASS)) {
-        target->tls_manual = true;
-        if (target->tls_key_pass) {
-            RedisModule_Free(target->tls_key_pass);
-        }
-        target->tls_key_pass = RedisModule_Strdup(value);
     } else if (!strcmp(keyword, CONF_CLUSTER_PASSWORD)) {
         if (target->cluster_password) {
             RedisModule_Free(target->cluster_password);
@@ -635,18 +607,6 @@ void ConfigGet(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, 
     if (stringmatch(pattern, CONF_TLS_ENABLED, 1)) {
         len++;
         replyConfigBool(ctx, CONF_TLS_ENABLED, config->tls_enabled);
-    }
-    if (stringmatch(pattern, CONF_TLS_CA_CERT, 1)) {
-        len++;
-        replyConfigStr(ctx, CONF_TLS_CA_CERT, config->tls_ca_cert);
-    }
-    if (stringmatch(pattern, CONF_TLS_CERT, 1)) {
-        len++;
-        replyConfigStr(ctx, CONF_TLS_CERT, config->tls_cert);
-    }
-    if (stringmatch(pattern, CONF_TLS_KEY, 1)) {
-        len++;
-        replyConfigStr(ctx, CONF_TLS_KEY, config->tls_key);
     }
     if (stringmatch(pattern, CONF_CLUSTER_USER, 1)) {
         len++;

--- a/src/config.c
+++ b/src/config.c
@@ -659,19 +659,19 @@ void updateTLSConfig(RedisModuleCtx *ctx, RedisRaftConfig *config) {
     config->tls_ca_cert = getRedisConfig(ctx, "tls-ca-cert-file");
     config->tls_key = getRedisConfig(ctx, "tls-key-file");
     char *key = getRedisConfig(ctx, "tls-client-key-file");
-    if (*key != 0) {
+    if (key) {
         RedisModule_Free(config->tls_key);
         config->tls_key = key;
     }
     config->tls_key_file_pass = getRedisConfig(ctx, "tls-key-file-pass");
     char *pass = getRedisConfig(ctx, "tls-client-key-file-pass");
-    if (*pass != 0) {
+    if (pass) {
         RedisModule_Free(config->tls_key_file_pass);
         config->tls_key_file_pass = pass;
     }
     config->tls_cert = getRedisConfig(ctx, "tls-cert-file");
     char *cert = getRedisConfig(ctx, "tls-client-cert-file");
-    if (*cert != 0) {
+    if (cert) {
         RedisModule_Free(config->tls_cert);
         config->tls_cert = cert;
     }

--- a/src/config.c
+++ b/src/config.c
@@ -48,10 +48,10 @@ static const char *CONF_IGNORED_COMMANDS = "ignored-commands";
 static const char *CONF_EXTERNAL_SHARDING = "external-sharding";
 static const char *CONF_MAX_APPEND_REQ_IN_FLIGHT = "max-append-req-in-flight";
 static const char *CONF_TLS_ENABLED = "tls-enabled";
-static const char *CONF_TLS_CA_CERT = "tls-ca-cert";
-static const char *CONF_TLS_CERT = "tls-cert";
-static const char *CONF_TLS_KEY = "tls-key";
-static const char *CONF_TLS_KEY_PASS = "tls-key-pass";
+static const char *CONF_TLS_CA_CERT = "tls-ca-cert-file";
+static const char *CONF_TLS_CERT = "tls-cert-file";
+static const char *CONF_TLS_KEY = "tls-key-file";
+static const char *CONF_TLS_KEY_PASS = "tls-key-file-pass";
 static const char *CONF_CLUSTER_USER = "cluster-user";
 static const char *CONF_CLUSTER_PASSWORD = "cluster-password";
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -80,13 +80,6 @@ static void ConnFree(Connection *conn)
 
     LIST_REMOVE(conn, entries);
 
-#ifdef HAVE_TLS
-    if (conn->ssl) {
-//        SSL_free(conn->ssl);
-        conn->ssl = NULL;
-    }
-#endif
-
     RedisModule_Free(conn);
 }
 
@@ -321,11 +314,6 @@ static void handleResolved(void *arg)
 
 #ifdef HAVE_TLS
     if (conn->rr->config->tls_enabled) {
-        if (conn->ssl) {
-//            SSL_free(conn->ssl);
-            conn->ssl = NULL;
-        }
-
         SSL *ssl = SSL_new(conn->rr->ssl);
         if (!ssl) {
             CONN_LOG_WARNING(conn, "Couldn't create SSL object");
@@ -333,11 +321,9 @@ static void handleResolved(void *arg)
         }
         int result = redisInitiateSSL(&conn->rc->c, ssl);
         if (result != REDIS_OK) {
-//            SSL_free(ssl);
             CONN_LOG_WARNING(conn, "redisInitiateSSL error(%d): %s", conn->rc->c.err, conn->rc->c.errstr);
             goto fail;
         }
-        conn->ssl = ssl;
     }
 #endif
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -82,7 +82,8 @@ static void ConnFree(Connection *conn)
 
 #ifdef HAVE_TLS
     if (conn->ssl) {
-        SSL_free(conn->ssl);
+//        SSL_free(conn->ssl);
+        conn->ssl = NULL;
     }
 #endif
 
@@ -321,7 +322,7 @@ static void handleResolved(void *arg)
 #ifdef HAVE_TLS
     if (conn->rr->config->tls_enabled) {
         if (conn->ssl) {
-            SSL_free(conn->ssl);
+//            SSL_free(conn->ssl);
             conn->ssl = NULL;
         }
 
@@ -332,8 +333,7 @@ static void handleResolved(void *arg)
         }
         int result = redisInitiateSSL(&conn->rc->c, ssl);
         if (result != REDIS_OK) {
-            SSL_free(ssl);
-            CONN_LOG_WARNING(conn, "SSL Error!");
+//            SSL_free(ssl);
             CONN_LOG_WARNING(conn, "redisInitiateSSL error(%d): %s", conn->rc->c.err, conn->rc->c.errstr);
             goto fail;
         }

--- a/src/connection.c
+++ b/src/connection.c
@@ -316,7 +316,8 @@ static void handleResolved(void *arg)
     if (conn->rr->config->tls_enabled) {
         SSL *ssl = SSL_new(conn->rr->ssl);
         if (!ssl) {
-            CONN_LOG_WARNING(conn, "Couldn't create SSL object");
+            unsigned long e = ERR_peek_last_error();
+            CONN_LOG_WARNING(conn, "Couldn't create SSL object: %s", ERR_reason_error_string(e));
 	        goto fail;
         }
         int result = redisInitiateSSL(&conn->rc->c, ssl);

--- a/src/connection.c
+++ b/src/connection.c
@@ -80,7 +80,7 @@ static void ConnFree(Connection *conn)
 
     LIST_REMOVE(conn, entries);
 
-#ifdef SSL
+#ifdef HAVE_TLS
     if (conn->ssl) {
         SSL_free(conn->ssl);
     }

--- a/src/connection.c
+++ b/src/connection.c
@@ -317,11 +317,12 @@ static void handleResolved(void *arg)
         SSL *ssl = SSL_new(conn->rr->ssl);
         if (!ssl) {
             CONN_LOG_WARNING(conn, "Couldn't create SSL object");
-	    goto fail;
+	        goto fail;
         }
         int result = redisInitiateSSL(&conn->rc->c, ssl);
         if (result != REDIS_OK) {
             CONN_LOG_WARNING(conn, "redisInitiateSSL error(%d): %s", conn->rc->c.err, conn->rc->c.errstr);
+            SSL_free(ssl);
             goto fail;
         }
     }

--- a/src/connection.c
+++ b/src/connection.c
@@ -313,7 +313,13 @@ static void handleResolved(void *arg)
 
 #ifdef HAVE_TLS
     if (conn->rr->config->tls_enabled) {
-        if (redisInitiateSSLWithContext(&conn->rc->c, conn->rr->ssl) != REDIS_OK) {
+        SSL *ssl = SSL_new(conn->rr->ssl);
+        if (!ssl) {
+            CONN_LOG_WARNING(conn, "Couldn't create SSL object");
+            RedisModule_Assert(NULL);
+        }
+        if (redisInitiateSSL(&conn->rc->c, ssl) != REDIS_OK) {
+            SSL_free(ssl);
             CONN_LOG_WARNING(conn, "SSL Error!");
             goto fail;
         }

--- a/src/join.c
+++ b/src/join.c
@@ -36,7 +36,12 @@ static void handleNodeAddResponse(redisAsyncContext *c, void *r, void *privdata)
     redisReply *reply = r;
 
     if (!reply) {
+#ifndef HAVE_TLS
         LOG_WARNING("RAFT.NODE ADD failed: connection dropped.");
+#else
+        unsigned long e = ERR_peek_last_error();
+        LOG_WARNING("RAFT.NODE ADD failed: connection dropped: %s", ERR_reason_error_string(e));
+#endif
         ConnMarkDisconnected(conn);
     } else if (reply->type == REDIS_REPLY_ERROR) {
         /* -MOVED? */

--- a/src/redismodule.h
+++ b/src/redismodule.h
@@ -236,13 +236,15 @@ typedef uint64_t RedisModuleTimerID;
 /* Declare that the module can handle errors with RedisModule_SetModuleOptions. */
 #define REDISMODULE_OPTIONS_HANDLE_IO_ERRORS    (1<<0)
 
-/* Declare that the module can handle diskless async replication with RedisModule_SetModuleOptions. */
-#define REDISMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD    (1<<1)
-
 /* When set, Redis will not call RedisModule_SignalModifiedKey(), implicitly in
  * RedisModule_CloseKey, and the module needs to do that when manually when keys
  * are modified from the user's sperspective, to invalidate WATCH. */
 #define REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED (1<<1)
+
+/* Declare that the module can handle diskless async replication with RedisModule_SetModuleOptions. */
+#define REDISMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD    (1<<2)
+
+/* Definitions for RedisModule_SetCommandInfo. */
 
 typedef enum {
     REDISMODULE_ARG_TYPE_STRING,
@@ -260,12 +262,146 @@ typedef enum {
 #define REDISMODULE_CMD_ARG_OPTIONAL        (1<<0) /* The argument is optional (like GET in SET command) */
 #define REDISMODULE_CMD_ARG_MULTIPLE        (1<<1) /* The argument may repeat itself (like key in DEL) */
 #define REDISMODULE_CMD_ARG_MULTIPLE_TOKEN  (1<<2) /* The argument may repeat itself, and so does its token (like `GET pattern` in SORT) */
+#define _REDISMODULE_CMD_ARG_NEXT           (1<<3)
 
-/* Redis ACL key permission flags, which specify which permissions a module
- * needs on a key. */
-#define REDISMODULE_KEY_PERMISSION_READ (1<<0)
-#define REDISMODULE_KEY_PERMISSION_WRITE (1<<1)
-#define REDISMODULE_KEY_PERMISSION_ALL (REDISMODULE_KEY_PERMISSION_READ | REDISMODULE_KEY_PERMISSION_WRITE)
+typedef enum {
+    REDISMODULE_KSPEC_BS_INVALID = 0, /* Must be zero. An implicitly value of
+                                       * zero is provided when the field is
+                                       * absent in a struct literal. */
+    REDISMODULE_KSPEC_BS_UNKNOWN,
+    REDISMODULE_KSPEC_BS_INDEX,
+    REDISMODULE_KSPEC_BS_KEYWORD
+} RedisModuleKeySpecBeginSearchType;
+
+typedef enum {
+    REDISMODULE_KSPEC_FK_OMITTED = 0, /* Used when the field is absent in a
+                                       * struct literal. Don't use this value
+                                       * explicitly. */
+    REDISMODULE_KSPEC_FK_UNKNOWN,
+    REDISMODULE_KSPEC_FK_RANGE,
+    REDISMODULE_KSPEC_FK_KEYNUM
+} RedisModuleKeySpecFindKeysType;
+
+/* Key-spec flags. For details, see the documentation of
+ * RedisModule_SetCommandInfo and the key-spec flags in server.h. */
+#define REDISMODULE_CMD_KEY_RO (1ULL<<0)
+#define REDISMODULE_CMD_KEY_RW (1ULL<<1)
+#define REDISMODULE_CMD_KEY_OW (1ULL<<2)
+#define REDISMODULE_CMD_KEY_RM (1ULL<<3)
+#define REDISMODULE_CMD_KEY_ACCESS (1ULL<<4)
+#define REDISMODULE_CMD_KEY_UPDATE (1ULL<<5)
+#define REDISMODULE_CMD_KEY_INSERT (1ULL<<6)
+#define REDISMODULE_CMD_KEY_DELETE (1ULL<<7)
+#define REDISMODULE_CMD_KEY_NOT_KEY (1ULL<<8)
+#define REDISMODULE_CMD_KEY_INCOMPLETE (1ULL<<9)
+#define REDISMODULE_CMD_KEY_VARIABLE_FLAGS (1ULL<<10)
+
+/* Channel flags, for details see the documentation of
+ * RedisModule_ChannelAtPosWithFlags. */
+#define REDISMODULE_CMD_CHANNEL_PATTERN (1ULL<<0)
+#define REDISMODULE_CMD_CHANNEL_PUBLISH (1ULL<<1)
+#define REDISMODULE_CMD_CHANNEL_SUBSCRIBE (1ULL<<2)
+#define REDISMODULE_CMD_CHANNEL_UNSUBSCRIBE (1ULL<<3)
+
+typedef struct RedisModuleCommandArg {
+    const char *name;
+    RedisModuleCommandArgType type;
+    int key_spec_index;       /* If type is KEY, this is a zero-based index of
+                               * the key_spec in the command. For other types,
+                               * you may specify -1. */
+    const char *token;        /* If type is PURE_TOKEN, this is the token. */
+    const char *summary;
+    const char *since;
+    int flags;                /* The REDISMODULE_CMD_ARG_* macros. */
+    struct RedisModuleCommandArg *subargs;
+} RedisModuleCommandArg;
+
+typedef struct {
+    const char *since;
+    const char *changes;
+} RedisModuleCommandHistoryEntry;
+
+typedef struct {
+    const char *notes;
+    uint64_t flags; /* REDISMODULE_CMD_KEY_* macros. */
+    RedisModuleKeySpecBeginSearchType begin_search_type;
+    union {
+        struct {
+            /* The index from which we start the search for keys */
+            int pos;
+        } index;
+        struct {
+            /* The keyword that indicates the beginning of key args */
+            const char *keyword;
+            /* An index in argv from which to start searching.
+             * Can be negative, which means start search from the end, in reverse
+             * (Example: -2 means to start in reverse from the panultimate arg) */
+            int startfrom;
+        } keyword;
+    } bs;
+    RedisModuleKeySpecFindKeysType find_keys_type;
+    union {
+        struct {
+            /* Index of the last key relative to the result of the begin search
+             * step. Can be negative, in which case it's not relative. -1
+             * indicating till the last argument, -2 one before the last and so
+             * on. */
+            int lastkey;
+            /* How many args should we skip after finding a key, in order to
+             * find the next one. */
+            int keystep;
+            /* If lastkey is -1, we use limit to stop the search by a factor. 0
+             * and 1 mean no limit. 2 means 1/2 of the remaining args, 3 means
+             * 1/3, and so on. */
+            int limit;
+        } range;
+        struct {
+            /* Index of the argument containing the number of keys to come
+             * relative to the result of the begin search step */
+            int keynumidx;
+            /* Index of the fist key. (Usually it's just after keynumidx, in
+             * which case it should be set to keynumidx + 1.) */
+            int firstkey;
+            /* How many args should we skip after finding a key, in order to
+             * find the next one, relative to the result of the begin search
+             * step. */
+            int keystep;
+        } keynum;
+    } fk;
+} RedisModuleCommandKeySpec;
+
+typedef struct {
+    int version;
+    size_t sizeof_historyentry;
+    size_t sizeof_keyspec;
+    size_t sizeof_arg;
+} RedisModuleCommandInfoVersion;
+
+static const RedisModuleCommandInfoVersion RedisModule_CurrentCommandInfoVersion = {
+    .version = 1,
+    .sizeof_historyentry = sizeof(RedisModuleCommandHistoryEntry),
+    .sizeof_keyspec = sizeof(RedisModuleCommandKeySpec),
+    .sizeof_arg = sizeof(RedisModuleCommandArg)
+};
+
+#define REDISMODULE_COMMAND_INFO_VERSION (&RedisModule_CurrentCommandInfoVersion)
+
+typedef struct {
+    /* Always set version to REDISMODULE_COMMAND_INFO_VERSION */
+    const RedisModuleCommandInfoVersion *version;
+    /* Version 1 fields (added in Redis 7.0.0) */
+    const char *summary;          /* Summary of the command */
+    const char *complexity;       /* Complexity description */
+    const char *since;            /* Debut module version of the command */
+    RedisModuleCommandHistoryEntry *history; /* History */
+    /* A string of space-separated tips meant for clients/proxies regarding this
+     * command */
+    const char *tips;
+    /* Number of arguments, it is possible to use -N to say >= N */
+    int arity;
+    RedisModuleCommandKeySpec *key_specs;
+    RedisModuleCommandArg *args;
+} RedisModuleCommandInfo;
 
 /* Eventloop definitions. */
 #define REDISMODULE_EVENTLOOP_READABLE 1
@@ -293,7 +429,8 @@ typedef void (*RedisModuleEventLoopOneShotFunc)(void *user_data);
 #define REDISMODULE_EVENT_FORK_CHILD 13
 #define REDISMODULE_EVENT_REPL_ASYNC_LOAD 14
 #define REDISMODULE_EVENT_EVENTLOOP 15
-#define _REDISMODULE_EVENT_NEXT 16 /* Next event flag, should be updated if a new event added. */
+#define REDISMODULE_EVENT_CONFIG 16
+#define _REDISMODULE_EVENT_NEXT 17 /* Next event flag, should be updated if a new event added. */
 
 typedef struct RedisModuleEvent {
     uint64_t id;        /* REDISMODULE_EVENT_... defines. */
@@ -382,7 +519,7 @@ static const RedisModuleEvent
     /* Deprecated since Redis 7.0, not used anymore. */
     __attribute__ ((deprecated))
     RedisModuleEvent_ReplBackup = {
-        REDISMODULE_EVENT_REPL_BACKUP,
+        REDISMODULE_EVENT_REPL_BACKUP, 
         1
     },
     RedisModuleEvent_ReplAsyncLoad = {
@@ -396,7 +533,11 @@ static const RedisModuleEvent
     RedisModuleEvent_EventLoop = {
         REDISMODULE_EVENT_EVENTLOOP,
         1
-};
+    },
+    RedisModuleEvent_Config = {
+        REDISMODULE_EVENT_CONFIG,
+        1
+    };
 
 /* Those are values that are used for the 'subevent' callback argument. */
 #define REDISMODULE_SUBEVENT_PERSISTENCE_RDB_START 0
@@ -437,6 +578,9 @@ static const RedisModuleEvent
 #define REDISMODULE_SUBEVENT_MODULE_LOADED 0
 #define REDISMODULE_SUBEVENT_MODULE_UNLOADED 1
 #define _REDISMODULE_SUBEVENT_MODULE_NEXT 2
+
+#define REDISMODULE_SUBEVENT_CONFIG_CHANGE 0
+#define _REDISMODULE_SUBEVENT_CONFIG_NEXT 1
 
 #define REDISMODULE_SUBEVENT_LOADING_PROGRESS_RDB 0
 #define REDISMODULE_SUBEVENT_LOADING_PROGRESS_AOF 1
@@ -538,6 +682,17 @@ typedef struct RedisModuleModuleChange {
 
 #define RedisModuleModuleChange RedisModuleModuleChangeV1
 
+#define REDISMODULE_CONFIGCHANGE_VERSION 1
+typedef struct RedisModuleConfigChange {
+    uint64_t version;       /* Not used since this structure is never passed
+                               from the module to the core right now. Here
+                               for future compatibility. */
+    uint32_t num_changes;   /* how many redis config options were changed */
+    const char **config_names; /* the config names that were changed */
+} RedisModuleConfigChangeV1;
+
+#define RedisModuleConfigChange RedisModuleConfigChangeV1
+
 #define REDISMODULE_CRON_LOOP_VERSION 1
 typedef struct RedisModuleCronLoopInfo {
     uint64_t version;       /* Not used since this structure is never passed
@@ -623,7 +778,6 @@ typedef struct RedisModuleScanCursor RedisModuleScanCursor;
 typedef struct RedisModuleDefragCtx RedisModuleDefragCtx;
 typedef struct RedisModuleUser RedisModuleUser;
 typedef struct RedisModuleKeyOptCtx RedisModuleKeyOptCtx;
-typedef struct RedisModuleCommandArg RedisModuleCommandArg;
 
 typedef int (*RedisModuleCmdFunc)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 typedef void (*RedisModuleDisconnectFunc)(RedisModuleCtx *ctx, RedisModuleBlockedClient *bc);
@@ -697,6 +851,7 @@ REDISMODULE_API int (*RedisModule_GetApi)(const char *, void *) REDISMODULE_ATTR
 REDISMODULE_API int (*RedisModule_CreateCommand)(RedisModuleCtx *ctx, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleCommand *(*RedisModule_GetCommand)(RedisModuleCtx *ctx, const char *name) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CreateSubcommand)(RedisModuleCommand *parent, const char *name, RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey, int lastkey, int keystep) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_SetCommandInfo)(RedisModuleCommand *command, const RedisModuleCommandInfo *info) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_SetModuleAttribs)(RedisModuleCtx *ctx, const char *name, int ver, int apiver) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsModuleNameBusy)(const char *name) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_WrongArity)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
@@ -810,6 +965,9 @@ REDISMODULE_API long long (*RedisModule_StreamTrimByLength)(RedisModuleKey *key,
 REDISMODULE_API long long (*RedisModule_StreamTrimByID)(RedisModuleKey *key, int flags, RedisModuleStreamID *id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_IsKeysPositionRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API void (*RedisModule_KeyAtPos)(RedisModuleCtx *ctx, int pos) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_KeyAtPosWithFlags)(RedisModuleCtx *ctx, int pos, int flags) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_IsChannelsPositionRequest)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
+REDISMODULE_API void (*RedisModule_ChannelAtPosWithFlags)(RedisModuleCtx *ctx, int pos, int flags) REDISMODULE_ATTR;
 REDISMODULE_API unsigned long long (*RedisModule_GetClientId)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_GetClientUserNameById)(RedisModuleCtx *ctx, uint64_t id) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetClientInfoById)(void *ci, uint64_t id) REDISMODULE_ATTR;
@@ -924,14 +1082,6 @@ REDISMODULE_API int (*RedisModule_GetKeyspaceNotificationFlagsAll)() REDISMODULE
 REDISMODULE_API int (*RedisModule_IsSubEventSupported)(RedisModuleEvent event, uint64_t subevent) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetServerVersion)() REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_GetTypeMethodVersion)() REDISMODULE_ATTR;
-#ifdef INCLUDE_UNRELEASED_KEYSPEC_API
-REDISMODULE_API int (*RedisModule_AddCommandKeySpec)(RedisModuleCommand *command, const char *specflags, int *spec_id) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetCommandKeySpecBeginSearchIndex)(RedisModuleCommand *command, int spec_id, int index) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetCommandKeySpecBeginSearchKeyword)(RedisModuleCommand *command, int spec_id, const char *keyword, int startfrom) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetCommandKeySpecFindKeysRange)(RedisModuleCommand *command, int spec_id, int lastkey, int keystep, int limit) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetCommandKeySpecFindKeysKeynum)(RedisModuleCommand *command, int spec_id, int keynumidx, int firstkey, int keystep) REDISMODULE_ATTR;
-#endif
-
 REDISMODULE_API void (*RedisModule_Yield)(RedisModuleCtx *ctx, int flags, const char *busy_reply) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleBlockedClient * (*RedisModule_BlockClient)(RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback, RedisModuleCmdFunc timeout_callback, void (*free_privdata)(RedisModuleCtx*,void*), long long timeout_ms) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_UnblockClient)(RedisModuleBlockedClient *bc, void *privdata) REDISMODULE_ATTR;
@@ -995,6 +1145,7 @@ REDISMODULE_API int (*RedisModule_AuthenticateClientWithUser)(RedisModuleCtx *ct
 REDISMODULE_API int (*RedisModule_DeauthenticateAndCloseClient)(RedisModuleCtx *ctx, uint64_t client_id) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleString * (*RedisModule_GetClientCertificate)(RedisModuleCtx *ctx, uint64_t id) REDISMODULE_ATTR;
 REDISMODULE_API int *(*RedisModule_GetCommandKeys)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *num_keys) REDISMODULE_ATTR;
+REDISMODULE_API int *(*RedisModule_GetCommandKeysWithFlags)(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *num_keys, int **out_flags) REDISMODULE_ATTR;
 REDISMODULE_API const char *(*RedisModule_GetCurrentCommandName)(RedisModuleCtx *ctx) REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_RegisterDefragFunc)(RedisModuleCtx *ctx, RedisModuleDefragFunc func) REDISMODULE_ATTR;
 REDISMODULE_API void *(*RedisModule_DefragAlloc)(RedisModuleDefragCtx *ctx, void *ptr) REDISMODULE_ATTR;
@@ -1023,6 +1174,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(CreateCommand);
     REDISMODULE_GET_API(GetCommand);
     REDISMODULE_GET_API(CreateSubcommand);
+    REDISMODULE_GET_API(SetCommandInfo);
     REDISMODULE_GET_API(SetModuleAttribs);
     REDISMODULE_GET_API(IsModuleNameBusy);
     REDISMODULE_GET_API(WrongArity);
@@ -1136,6 +1288,9 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(StreamTrimByID);
     REDISMODULE_GET_API(IsKeysPositionRequest);
     REDISMODULE_GET_API(KeyAtPos);
+    REDISMODULE_GET_API(KeyAtPosWithFlags);
+    REDISMODULE_GET_API(IsChannelsPositionRequest);
+    REDISMODULE_GET_API(ChannelAtPosWithFlags);
     REDISMODULE_GET_API(GetClientId);
     REDISMODULE_GET_API(GetClientUserNameById);
     REDISMODULE_GET_API(GetContextFlags);
@@ -1250,13 +1405,6 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(IsSubEventSupported);
     REDISMODULE_GET_API(GetServerVersion);
     REDISMODULE_GET_API(GetTypeMethodVersion);
-#ifdef INCLUDE_UNRELEASED_KEYSPEC_API
-    REDISMODULE_GET_API(AddCommandKeySpec);
-    REDISMODULE_GET_API(SetCommandKeySpecBeginSearchIndex);
-    REDISMODULE_GET_API(SetCommandKeySpecBeginSearchKeyword);
-    REDISMODULE_GET_API(SetCommandKeySpecFindKeysRange);
-    REDISMODULE_GET_API(SetCommandKeySpecFindKeysKeynum);
-#endif
     REDISMODULE_GET_API(Yield);
     REDISMODULE_GET_API(GetThreadSafeContext);
     REDISMODULE_GET_API(GetDetachedThreadSafeContext);
@@ -1320,6 +1468,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
     REDISMODULE_GET_API(AuthenticateClientWithUser);
     REDISMODULE_GET_API(GetClientCertificate);
     REDISMODULE_GET_API(GetCommandKeys);
+    REDISMODULE_GET_API(GetCommandKeysWithFlags);
     REDISMODULE_GET_API(GetCurrentCommandName);
     REDISMODULE_GET_API(RegisterDefragFunc);
     REDISMODULE_GET_API(DefragAlloc);
@@ -1347,7 +1496,6 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver, int 
 /* Things only defined for the modules core, not exported to modules
  * including this file. */
 #define RedisModuleString robj
-#define RedisModuleCommandArg redisCommandArg
 
 #endif /* REDISMODULE_CORE */
 #endif /* REDISMODULE_H */

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1084,16 +1084,19 @@ SSL_CTX *generateSSLContext(RedisModuleCtx *ctx, RedisRaftCtx *rr) {
     }
 
     if (!SSL_CTX_load_verify_locations(ssl_ctx, rr->config->tls_ca_cert, NULL)) {
-        LOG_ERROR("REDIS_SSL_CTX_CA_CERT_LOAD_FAILED: tls_ca_ccert = %s", rr->config->tls_ca_cert);
+        unsigned long e = ERR_peek_last_error();
+        LOG_ERROR("SSL_CTX_load_verify_locations(): %s", ERR_reason_error_string(e));
         goto error;
     }
 
     if (!SSL_CTX_use_certificate_chain_file(ssl_ctx, rr->config->tls_cert)) {
-        LOG_ERROR("REDIS_SSL_CTX_CLIENT_CERT_LOAD_FAILED: tls_cert = %s", rr->config->tls_cert);
+        unsigned long e = ERR_peek_last_error();
+        LOG_ERROR("SSL_CTX_use_certificate_chain_file(): tls_cert = %s, err = %s", rr->config->tls_cert, ERR_reason_error_string(e));
         goto error;
     }
     if (!SSL_CTX_use_PrivateKey_file(ssl_ctx, rr->config->tls_key, SSL_FILETYPE_PEM)) {
-        LOG_ERROR("REDIS_SSL_CTX_PRIVATE_KEY_LOAD_FAILED");
+        unsigned long e = ERR_peek_last_error();
+        LOG_ERROR("SSL_CTX_use_PrivateKey_file(): tls_key = %s, err = %s", rr->config->tls_key, ERR_reason_error_string(e));
         goto error;
     }
 

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1070,8 +1070,7 @@ static int tlsPasswordCallback(char *buf, int size, int rwflag, void *u) {
 SSL_CTX *generateSSLContext(RedisModuleCtx *ctx, RedisRaftCtx *rr) {
     SSL_CTX *ssl_ctx = SSL_CTX_new(SSLv23_client_method());
     if (!ssl_ctx) {
-        RedisModule_Log(ctx, REDIS_WARNING, "REDIS_SSL_CTX_CREATE_FAILED");
-//        if (error) *error = REDIS_SSL_CTX_CREATE_FAILED;
+        LOG_ERROR("REDIS_SSL_CTX_CREATE_FAILED");
         return NULL;
     }
 
@@ -1080,39 +1079,33 @@ SSL_CTX *generateSSLContext(RedisModuleCtx *ctx, RedisRaftCtx *rr) {
 
     if ((rr->config->tls_cert != NULL && rr->config->tls_key == NULL) ||
             (rr->config->tls_key != NULL && rr->config->tls_cert == NULL)) {
-        RedisModule_Log(ctx, REDIS_WARNING, "REDIS_SSL_CTX_CERT_KEY_REQUIRED");
-//        if (error) *error = REDIS_SSL_CTX_CERT_KEY_REQUIRED;
+        LOG_ERROR("REDIS_SSL_CTX_CERT_KEY_REQUIRED");
         goto error;
     }
 
     if (!SSL_CTX_load_verify_locations(ssl_ctx, rr->config->tls_ca_cert, NULL)) {
-        RedisModule_Log(ctx, REDIS_WARNING, "REDIS_SSL_CTX_CA_CERT_LOAD_FAILED: tls_ca_ccert = %s", rr->config->tls_ca_cert);
-//        if (error) *error = REDIS_SSL_CTX_CA_CERT_LOAD_FAILED;
+        LOG_ERROR("REDIS_SSL_CTX_CA_CERT_LOAD_FAILED: tls_ca_ccert = %s", rr->config->tls_ca_cert);
         goto error;
     }
 
     if (!SSL_CTX_use_certificate_chain_file(ssl_ctx, rr->config->tls_cert)) {
-        RedisModule_Log(ctx, REDIS_WARNING, "REDIS_SSL_CTX_CLIENT_CERT_LOAD_FAILED: tls_cert = %s", rr->config->tls_cert);
-//        if (error) *error = REDIS_SSL_CTX_CLIENT_CERT_LOAD_FAILED;
+        LOG_ERROR("REDIS_SSL_CTX_CLIENT_CERT_LOAD_FAILED: tls_cert = %s", rr->config->tls_cert);
         goto error;
     }
     if (!SSL_CTX_use_PrivateKey_file(ssl_ctx, rr->config->tls_key, SSL_FILETYPE_PEM)) {
-        RedisModule_Log(ctx, REDIS_WARNING, "REDIS_SSL_CTX_PRIVATE_KEY_LOAD_FAILED");
-//        if (error) *error = REDIS_SSL_CTX_PRIVATE_KEY_LOAD_FAILED;
+        LOG_ERROR("REDIS_SSL_CTX_PRIVATE_KEY_LOAD_FAILED");
         goto error;
     }
 
-    if (*rr->config->tls_key_pass != 0) {
+    if (rr->config->tls_key_pass && *rr->config->tls_key_pass != '\0') {
         SSL_CTX_set_default_passwd_cb(ssl_ctx, tlsPasswordCallback);
         SSL_CTX_set_default_passwd_cb_userdata(ssl_ctx, (void *) rr->config->tls_key_pass);
     }
 
-    RedisModule_Log(ctx, REDIS_WARNING, "returning %p", ssl_ctx);
     return ssl_ctx;
 
 error:
     SSL_CTX_free(ssl_ctx);
-    RedisModule_Log(ctx, REDIS_WARNING, "returning %p", NULL);
     return NULL;
 }
 #endif

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1419,7 +1419,6 @@ __attribute__((__unused__)) int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisMod
 
 #ifdef HAVE_TLS
     if (rr->config->tls_enabled) {
-        RedisModule_Log(ctx, REDIS_WARNING, "Generating SSL Context");
         rr->ssl = generateSSLContext(ctx, rr);
     }
 #endif

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1120,7 +1120,6 @@ error:
 
 void handleConfigChangeEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data)
 {
-    LOG_WARNING("handleConfigChangeEvent: enter");
     if (eid.id != REDISMODULE_EVENT_CONFIG || subevent != REDISMODULE_SUBEVENT_CONFIG_CHANGE) {
         return;
     }
@@ -1135,7 +1134,11 @@ void handleConfigChangeEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t
     for (unsigned int i = 0; i < ei->num_changes; i++) {
         if (strcmp("tls-ca-cert-file", ei->config_names[i]) == 0 ||
                 strcmp("tls-key-file", ei->config_names[i]) == 0 ||
-                strcmp("tls-cert-file", ei->config_names[i]) == 0) {
+                strcmp("tls-key-file-pass", ei->config_names[i]) == 0 ||
+                strcmp("tls-client-key-file", ei->config_names[i]) == 0 ||
+                strcmp("tls-client-key-file-pass", ei->config_names[i]) == 0 ||
+                strcmp("tls-cert-file", ei->config_names[i]) == 0 ||
+                strcmp("tls-client-cert-file", ei->config_names[i]) == 0) {
             updateTLSConfig(ctx, redis_raft.config);
             SSL_CTX *new_ctx = generateSSLContext(ctx, &redis_raft);
             if (new_ctx != NULL) {

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1097,9 +1097,9 @@ SSL_CTX *generateSSLContext(RedisModuleCtx *ctx, RedisRaftCtx *rr) {
         goto error;
     }
 
-    if (*rr->config->tls_key_file_pass != 0) {
+    if (*rr->config->tls_key_pass != 0) {
         SSL_CTX_set_default_passwd_cb(ssl_ctx, tlsPasswordCallback);
-        SSL_CTX_set_default_passwd_cb_userdata(ssl_ctx, (void *) rr->config->tls_key_file_pass);
+        SSL_CTX_set_default_passwd_cb_userdata(ssl_ctx, (void *) rr->config->tls_key_pass);
     }
 
     return ssl_ctx;

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1053,21 +1053,25 @@ static int cmdRaftRandom(RedisModuleCtx *ctx,
 
 #ifdef HAVE_TLS
 /* Callback for passing a keyfile password stored as a char * to OpenSSL,  copied from redis */
-static int tlsPasswordCallback(char *buf, int size, int rwflag, void *u) {
-    UNUSED(rwflag);
-
+static int tlsPasswordCallback(char *buf, int size, int rwflag, void *u)
+{
     const char *pass = u;
     size_t pass_len;
 
-    if (!pass) return -1;
+    if (!pass) {
+        return -1;
+    }
     pass_len = strlen(pass);
-    if (pass_len > (size_t) size) return -1;
+    if (pass_len > (size_t) size) {
+        return -1;
+    }
     memcpy(buf, pass, pass_len);
 
     return (int) pass_len;
 }
 
-SSL_CTX *generateSSLContext(RedisModuleCtx *ctx, RedisRaftCtx *rr) {
+SSL_CTX *generateSSLContext(RedisModuleCtx *ctx, RedisRaftCtx *rr)
+{
     SSL_CTX *ssl_ctx = SSL_CTX_new(SSLv23_client_method());
     if (!ssl_ctx) {
         LOG_ERROR("REDIS_SSL_CTX_CREATE_FAILED");
@@ -1127,7 +1131,7 @@ void handleConfigChangeEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t
 
     RedisModuleConfigChangeV1 *ei = data;
 
-    for(unsigned int i = 0; i < ei->num_changes; i++) {
+    for (unsigned int i = 0; i < ei->num_changes; i++) {
         if (strcmp("tls-ca-cert-file", ei->config_names[i]) == 0 ||
                 strcmp("tls-key-file", ei->config_names[i]) == 0 ||
                 strcmp("tls-cert-file", ei->config_names[i]) == 0) {
@@ -1417,7 +1421,6 @@ __attribute__((__unused__)) int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisMod
         RedisModule_Log(ctx, REDIS_WARNING, "Generating SSL Context");
         rr->ssl = generateSSLContext(ctx, rr);
     }
-    RedisModule_Log(ctx, REDIS_WARNING, "ssl context = %p", rr->ssl);
 #endif
 
     RedisModule_CreateTimer(ctx, rr->config->raft_interval, callRaftPeriodic, rr);

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1120,6 +1120,7 @@ error:
 
 void handleConfigChangeEvent(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent, void *data)
 {
+    LOG_WARNING("handleConfigChangeEvent: enter");
     if (eid.id != REDISMODULE_EVENT_CONFIG || subevent != REDISMODULE_SUBEVENT_CONFIG_CHANGE) {
         return;
     }

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -410,7 +410,6 @@ typedef struct RedisRaftConfig {
     char *ignored_commands;             /* Comma delimited list of commands that should not be intercepted */
     int external_sharding;              /* use external sharding orchestrator only */
     bool tls_enabled;                   /* use TLS for all inter cluster communication */
-    bool tls_manual;                    /* if shouldn't reconfigure tls via redis.  true if any element via module */
     char *tls_ca_cert;
     char *tls_cert;
     char *tls_key;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -20,6 +20,7 @@
 #include "hiredis/hiredis.h"
 #ifdef HAVE_TLS
 #include <openssl/ssl.h>
+#include <openssl/err.h>
 #include "hiredis/hiredis_ssl.h"
 #endif
 #include "hiredis/async.h"
@@ -199,6 +200,10 @@ typedef struct Connection {
 
     /* Linkage to global connections list */
     LIST_ENTRY(Connection) entries;
+
+#ifdef HAVE_TLS
+    SSL *ssl;
+#endif
 } Connection;
 
 /* -------------------- Global Raft Context -------------------- */
@@ -344,7 +349,7 @@ typedef struct RedisRaftCtx {
     char *resp_call_fmt;                         /* Format string to use in RedisModule_Call(), Redis version-specific */
     int entered_eval;                            /* handling a lua script */
 #ifdef HAVE_TLS
-    SSL_CTX *ssl;                                    /* OpenSSL context for use by hiredis */
+    SSL_CTX *ssl;                                /* OpenSSL context for use by hiredis */
 #endif
 
 } RedisRaftCtx;
@@ -409,6 +414,7 @@ typedef struct RedisRaftConfig {
     char *ignored_commands;             /* Comma delimited list of commands that should not be intercepted */
     int external_sharding;              /* use external sharding orchestrator only */
     bool tls_enabled;                   /* use TLS for all inter cluster communication */
+    bool tls_trace;                     /* trace TLS connections for debugging purposes */
     bool tls_manual;                    /* if shouldn't reconfigure tls via redis.  true if any element via module */
     char *tls_ca_cert;
     char *tls_cert;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -413,7 +413,7 @@ typedef struct RedisRaftConfig {
     char *tls_ca_cert;
     char *tls_cert;
     char *tls_key;
-    char *tls_key_file_pass;
+    char *tls_key_pass;
     char *cluster_user;                 /* acl user to use for internode communication */
     char *cluster_password;             /* password used for internode communication */
 } RedisRaftConfig;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -200,10 +200,6 @@ typedef struct Connection {
 
     /* Linkage to global connections list */
     LIST_ENTRY(Connection) entries;
-
-#ifdef HAVE_TLS
-    SSL *ssl;
-#endif
 } Connection;
 
 /* -------------------- Global Raft Context -------------------- */
@@ -793,7 +789,6 @@ void ConfigSet(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, 
 void ConfigGet(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 RRStatus ConfigReadFromRedis(RedisRaftCtx *rr);
 RRStatus ConfigureRedis(RedisModuleCtx *ctx);
-char *getRedisConfig(RedisModuleCtx *ctx, const char *name);
 void updateTLSConfig(RedisModuleCtx *ctx, RedisRaftConfig *config);
 
 /* snapshot.c */

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -19,6 +19,7 @@
 
 #include "hiredis/hiredis.h"
 #ifdef HAVE_TLS
+#include <openssl/ssl.h>
 #include "hiredis/hiredis_ssl.h"
 #endif
 #include "hiredis/async.h"
@@ -343,7 +344,7 @@ typedef struct RedisRaftCtx {
     char *resp_call_fmt;                         /* Format string to use in RedisModule_Call(), Redis version-specific */
     int entered_eval;                            /* handling a lua script */
 #ifdef HAVE_TLS
-    redisSSLContext *ssl;                        /* hiredis context for ssl */
+    SSL_CTX *ssl;                                    /* OpenSSL context for use by hiredis */
 #endif
 
 } RedisRaftCtx;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -414,7 +414,6 @@ typedef struct RedisRaftConfig {
     char *ignored_commands;             /* Comma delimited list of commands that should not be intercepted */
     int external_sharding;              /* use external sharding orchestrator only */
     bool tls_enabled;                   /* use TLS for all inter cluster communication */
-    bool tls_trace;                     /* trace TLS connections for debugging purposes */
     bool tls_manual;                    /* if shouldn't reconfigure tls via redis.  true if any element via module */
     char *tls_ca_cert;
     char *tls_cert;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -408,9 +408,11 @@ typedef struct RedisRaftConfig {
     char *ignored_commands;             /* Comma delimited list of commands that should not be intercepted */
     int external_sharding;              /* use external sharding orchestrator only */
     bool tls_enabled;                   /* use TLS for all inter cluster communication */
+    bool tls_manual;                    /* if shouldn't reconfigure tls via redis.  true if any element via module */
     char *tls_ca_cert;
     char *tls_cert;
     char *tls_key;
+    char *tls_key_file_pass;
     char *cluster_user;                 /* acl user to use for internode communication */
     char *cluster_password;             /* password used for internode communication */
 } RedisRaftConfig;
@@ -785,6 +787,8 @@ void ConfigSet(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, 
 void ConfigGet(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 RRStatus ConfigReadFromRedis(RedisRaftCtx *rr);
 RRStatus ConfigureRedis(RedisModuleCtx *ctx);
+char *getRedisConfig(RedisModuleCtx *ctx, const char *name);
+void updateTLSConfig(RedisModuleCtx *ctx, RedisRaftConfig *config);
 
 /* snapshot.c */
 extern RedisModuleTypeMethods RedisRaftTypeMethods;

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -79,15 +79,15 @@ class RedisRaft(object):
         if password:
             self.args += ['--requirepass', password]
 
-        cert = os.getcwd() + '/tests/tls/redis.crt'
-        key = os.getcwd() + '/tests/tls/redis.key'
-        cacert = os.getcwd() + '/tests/tls/ca.crt'
+        self.cert = os.getcwd() + '/tests/tls/redis.crt'
+        self.key = os.getcwd() + '/tests/tls/redis.key'
+        self.cacert = os.getcwd() + '/tests/tls/ca.crt'
 
         if config.tls:
             self.args += ['--tls-port', str(port),
-                          '--tls-cert-file', cert,
-                          '--tls-key-file', key,
-                          '--tls-ca-cert-file', cacert]
+                          '--tls-cert-file', self.cert,
+                          '--tls-key-file', self.key,
+                          '--tls-ca-cert-file', self.cacert]
 
         self.args += redis_args if redis_args else []
         self.args += ['--loadmodule', os.path.abspath(config.raftmodule)]
@@ -119,9 +119,9 @@ class RedisRaft(object):
         self.client = redis.Redis(host='localhost', port=self.port,
                                   password=password,
                                   ssl = config.tls,
-                                  ssl_certfile = cert,
-                                  ssl_keyfile = key,
-                                  ssl_ca_certs = cacert)
+                                  ssl_certfile = self.cert,
+                                  ssl_keyfile = self.key,
+                                  ssl_ca_certs = self.cacert)
 
         self.client.connection_pool.connection_kwargs['parser_class'] = \
             redis.connection.PythonParser

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -384,9 +384,11 @@ def test_rolled_back_read_only_multi_reply(cluster):
     with raises(ResponseError, match='TIMEOUT'):
         assert conn.read_response() == None
 
-# need to figure out how to only run in context of tls
-#te@pytest.mark.skip()
+
 def test_tls_reconfig(cluster):
+    if not cluster.config.tls:
+        return
+
     cluster.create(3)
     cluster.node(1).client.execute_command("config", "set", "tls-cert-file", cluster.node(1).cert)
     cluster.node(2).restart()

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -383,3 +383,16 @@ def test_rolled_back_read_only_multi_reply(cluster):
 
     with raises(ResponseError, match='TIMEOUT'):
         assert conn.read_response() == None
+
+# need to figure out how to only run in context of tls
+#te@pytest.mark.skip()
+def test_tls_reconfig(cluster):
+    cluster.create(3)
+    cluster.node(1).client.execute_command("config", "set", "tls-cert-file", cluster.node(1).cert)
+    cluster.node(2).restart()
+    cluster.node(3).restart()
+    cluster.node(3).wait_for_election()
+    assert cluster.node(3).raft_info().get('leader_id') == 1
+    commit_idx = cluster.leader_node().commit_index()
+    cluster.node(3).wait_for_commit_index(commit_idx, gt_ok=True)
+    cluster.node(3).wait_for_log_applied()


### PR DESCRIPTION
* update RedisRaft to latest modules for config event subscriptions
* sbscribe to config events to follow tls config changes
* use client variables if they are defined
* ignore redis tls configs if defined via module config
* add key pass config/callback
* add documentation for configuring TLS via redis-server and via module configuration

+ abstracted out redis config updating and hiredis ssl context creating as used in multiple places

todo:
- [x] improve documentation
- [x] hookup key pass configuration with hiredis
- [x] improve debugging

fixes #257 