### PR TITLE
Catch crashes and failures together in Jepsen results

### DIFF
--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -55,7 +55,7 @@ jobs:
                   --nemesis kill,pause,partition,member \
                   --redis-version unstable \
                   --raft-repo https://github.com/${{ env.REDISRAFT_REPO }} \
-                  --raft-version ${{ env.REDISRAFT_VERSION }} | rg --passthrough '^0 failures'
+                  --raft-version ${{ env.REDISRAFT_VERSION }} | rg --multiline --multiline-dotall --passthrough '^0 failures.*\n0 crashed|^0 crashed.*\n0 failures'
     - name: Archive Jepsen results
       uses: actions/upload-artifact@v2
       if: failure() || cancelled()


### PR DESCRIPTION
We don't catch crashes in Jepsen test results, so, tests become green in CI even all tests are crashed. Changed regex to require "0 crashed" and  "0 failures" together, in any order.

Sample output to try:
```
0 successes
0 unknown
20 crashed
0 failures
Cleaning up orphan processes
```