### PR TITLE
Allow info command even cluster is not initialized

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1487,6 +1487,10 @@ void handleClusterCommand(RedisRaftCtx *rr, RaftReq *req)
         goto exit;
     }
 
+    if (checkRaftState(rr, req->ctx) == RR_ERROR) {
+        goto exit;
+    }
+
     size_t cmd_len;
     const char *cmd_str = RedisModule_StringPtrLen(cmd->argv[1], &cmd_len);
 

--- a/src/raft.c
+++ b/src/raft.c
@@ -1595,11 +1595,6 @@ static bool handleInterceptedCommands(RedisRaftCtx *rr, RaftReq *req)
     const char *cmd_str = RedisModule_StringPtrLen(cmd->argv[0], &len);
 
     if (len == strlen("CLUSTER") && strncasecmp(cmd_str, "CLUSTER", len) == 0) {
-        if (checkRaftState(rr, req->ctx) == RR_ERROR) {
-            RaftReqFree(req);
-            return true;
-        }
-
         handleClusterCommand(rr, req);
         return true;
     }
@@ -1680,8 +1675,8 @@ void handleRedisCommand(RedisRaftCtx *rr,RaftReq *req)
         return;
     }
 
-    /* Check that we're part of a boostrapped cluster and not in the middle of joining
-     * or loading data.
+    /* Check that we're part of a boostrapped cluster and not in the middle of
+     * joining or loading data.
      */
     if (checkRaftState(rr, req->ctx) == RR_ERROR) {
         goto exit;

--- a/src/raft.c
+++ b/src/raft.c
@@ -1588,25 +1588,25 @@ void handleInfoCommand(RedisRaftCtx *rr, RaftReq *req)
  * Returns true if the command was intercepted, in which case the RaftReq has
  * been replied to and freed.
  */
-
 static bool handleInterceptedCommands(RedisRaftCtx *rr, RaftReq *req)
 {
-    const char _cmd_cluster[] = "CLUSTER";
-    const char _cmd_info[] = "INFO";
     RaftRedisCommand *cmd = req->r.redis.cmds.commands[0];
-    size_t cmd_len;
-    const char *cmd_str = RedisModule_StringPtrLen(cmd->argv[0], &cmd_len);
+    size_t len;
+    const char *cmd_str = RedisModule_StringPtrLen(cmd->argv[0], &len);
 
-    if (cmd_len == sizeof(_cmd_cluster) - 1 &&
-        !strncasecmp(cmd_str, _cmd_cluster, sizeof(_cmd_cluster) - 1)) {
-            handleClusterCommand(rr, req);
+    if (len == strlen("CLUSTER") && strncasecmp(cmd_str, "CLUSTER", len) == 0) {
+        if (checkRaftState(rr, req->ctx) == RR_ERROR) {
+            RaftReqFree(req);
             return true;
+        }
+
+        handleClusterCommand(rr, req);
+        return true;
     }
 
-    if (cmd_len == sizeof(_cmd_info) - 1 &&
-        !strncasecmp(cmd_str, _cmd_info, sizeof(_cmd_info) - 1)) {
-            handleInfoCommand(rr, req);
-            return true;
+    if (len == strlen("INFO") && strncasecmp(cmd_str, "INFO", len) == 0) {
+        handleInfoCommand(rr, req);
+        return true;
     }
 
     return false;
@@ -1673,18 +1673,18 @@ void handleRedisCommand(RedisRaftCtx *rr,RaftReq *req)
         }
     }
 
-    /* Check that we're part of a boostrapped cluster and not in the middle of joining
-     * or loading data.
-     */
-    if (checkRaftState(rr, req->ctx) == RR_ERROR) {
-        goto exit;
-    }
-
     /* Handle intercepted commands. We do this also on non-leader nodes or if we don't
      * have a leader, so it's up to the commands to check these conditions if they have to.
      */
     if (handleInterceptedCommands(rr, req)) {
         return;
+    }
+
+    /* Check that we're part of a boostrapped cluster and not in the middle of joining
+     * or loading data.
+     */
+    if (checkRaftState(rr, req->ctx) == RR_ERROR) {
+        goto exit;
     }
 
     /* When we're in cluster mode, go through handleSharding. This will perform

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -14,6 +14,12 @@ from pytest import raises, skip
 from .sandbox import RedisRaft, RedisRaftFailedToStart
 
 
+def test_info_before_cluster_init(cluster):
+    node = RedisRaft(1, cluster.base_port, cluster.config)
+    node.start()
+    assert node.raft_info()["state"] == "uninitialized"
+
+
 def test_info(cluster):
     r1 = cluster.add_node()
     data = r1.client.execute_command('info')


### PR DESCRIPTION
We intercept "info" command and check cluster state before replying. If cluster is uninitialized, we return an error. Changed it to work even without cluster is initialized.