### PR TITLE
Move nodeshutdown handling to command callback

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -17,21 +17,21 @@
 #include "redisraft.h"
 
 const char *RaftReqTypeStr[] = {
-    "<undef>",
-    "RR_CLUSTER_INIT",
-    "RR_CLUSTER_JOIN",
-    "RR_CFGCHANGE_ADDNODE",
-    "RR_CFGCHANGE_REMOVENODE",
-    "RR_APPENDENTRIES",
-    "RR_REDISCOMMAND",
-    "RR_INFO",
-    "RR_DEBUG",
-    "RR_CLIENT_DISCONNECT",
-    "RR_SHARDGROUP_ADD",
-    "RR_SHARDGROUPS_REPLACE",
-    "RR_SHARDGROUP_GET",
-    "RR_SHARDGROUP_LINK",
-    "RR_TRANSFER_LEADER"
+    [0]                       = "<undef>",
+    [RR_CLUSTER_INIT]         = "RR_CLUSTER_INIT",
+    [RR_CLUSTER_JOIN]         = "RR_CLUSTER_JOIN",
+    [RR_CFGCHANGE_ADDNODE]    = "RR_CFGCHANGE_ADDNODE",
+    [RR_CFGCHANGE_REMOVENODE] = "RR_CFGCHANGE_REMOVENODE",
+    [RR_APPENDENTRIES]        = "RR_APPENDENTRIES",
+    [RR_REDISCOMMAND]         = "RR_REDISCOMMAND",
+    [RR_INFO]                 = "RR_INFO",
+    [RR_DEBUG]                = "RR_DEBUG",
+    [RR_CLIENT_DISCONNECT]    = "RR_CLIENT_DISCONNECT",
+    [RR_SHARDGROUP_ADD]       = "RR_SHARDGROUP_ADD",
+    [RR_SHARDGROUPS_REPLACE]  = "RR_SHARDGROUPS_REPLACE",
+    [RR_SHARDGROUP_GET]       = "RR_SHARDGROUP_GET",
+    [RR_SHARDGROUP_LINK]      = "RR_SHARDGROUP_LINK",
+    [RR_TRANSFER_LEADER]      = "RR_TRANSFER_LEADER"
 };
 
 /* Forward declarations */

--- a/src/raft.c
+++ b/src/raft.c
@@ -25,10 +25,10 @@ const char *RaftReqTypeStr[] = {
     "RR_APPENDENTRIES",
     "RR_REDISCOMMAND",
     "RR_INFO",
-    "RR_COMPACT",
+    "RR_DEBUG",
     "RR_CLIENT_DISCONNECT",
     "RR_SHARDGROUP_ADD",
-    "RR_SHARDGROUP_UPDATE",
+    "RR_SHARDGROUPS_REPLACE",
     "RR_SHARDGROUP_GET",
     "RR_SHARDGROUP_LINK",
     "RR_TRANSFER_LEADER"
@@ -2175,18 +2175,6 @@ void handleShardGroupGet(RedisRaftCtx *rr, RaftReq *req)
     RedisModule_ReplySetArrayLength(req->ctx, node_count);
 exit:
     RaftReqFree(req);
-}
-
-void handleNodeShutdown(RedisRaftCtx *rr, RaftReq *req)
-{
-    if (req->r.node_shutdown.id != raft_get_nodeid(rr->raft)) {
-        LOG_ERROR("Received invalid nodeshutdown message with id : %d.",
-                  req->r.node_shutdown.id);
-        return;
-    }
-
-    RaftReqFree(req);
-    shutdownAfterRemoval(rr);
 }
 
 /* Callback for fsync thread. This will be triggerred by fsync thread but will

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -969,16 +969,12 @@ static int cmdRaftNodeShutdown(RedisModuleCtx *ctx,
 
     long long node_id;
     if (RedisModule_StringToLongLong(argv[1], &node_id) != REDISMODULE_OK ||
-        (node_id && !VALID_NODE_ID(node_id))) {
+        node_id != rr->config->id) {
         RedisModule_ReplyWithError(ctx, "invalid node id");
         return REDISMODULE_OK;
     }
 
-    RaftReq *req = RaftReqInit(ctx, RR_NODE_SHUTDOWN);
-    req->r.node_shutdown.id = (raft_node_id_t) node_id;
-
-    handleNodeShutdown(rr, req);
-
+    shutdownAfterRemoval(rr);
     return REDISMODULE_OK;
 }
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -462,7 +462,8 @@ enum RaftReqType {
     RR_SHARDGROUPS_REPLACE,
     RR_SHARDGROUP_GET,
     RR_SHARDGROUP_LINK,
-    RR_TRANSFER_LEADER
+    RR_TRANSFER_LEADER,
+    RR_RAFTREQ_MAX
 };
 
 extern const char *RaftReqTypeStr[];

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -462,7 +462,6 @@ enum RaftReqType {
     RR_SHARDGROUPS_REPLACE,
     RR_SHARDGROUP_GET,
     RR_SHARDGROUP_LINK,
-    RR_NODE_SHUTDOWN,
     RR_TRANSFER_LEADER
 };
 
@@ -593,9 +592,6 @@ typedef struct RaftReq {
             int fail;
             int delay;
         } debug;
-        struct {
-            raft_node_id_t id;
-        } node_shutdown;
         struct {
             ShardGroup **shardgroups;
             unsigned int len;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -739,7 +739,6 @@ void handleRedisCommand(RedisRaftCtx *rr,RaftReq *req);
 void handleAppendEntries(RedisRaftCtx *rr, RaftReq *req);
 void handleShardGroupAdd(RedisRaftCtx *rr, RaftReq *req);
 void handleShardGroupGet(RedisRaftCtx *rr, RaftReq *req);
-void handleNodeShutdown(RedisRaftCtx *rr, RaftReq *req);
 void handleClientDisconnect(RedisRaftCtx *rr, RaftReq *req);
 void handleShardGroupsReplace(RedisRaftCtx *rr, RaftReq *req);
 void handleInfo(RedisRaftCtx *rr, RaftReq *req);

--- a/tests/integration/test_membership.py
+++ b/tests/integration/test_membership.py
@@ -306,3 +306,11 @@ def test_transfer_unexpected(cluster):
     Thread(target=timeout, daemon=True).start()
     with raises(ResponseError, match="different node elected leader"):
         cluster.leader_node().transfer_leader(2)
+
+
+def test_nodeshutdown_wrong_id(cluster):
+    cluster.create(1, raft_args={'election-timeout': '10000'})
+
+    with raises(ResponseError, match='invalid node id'):
+        cluster.node(1).client.execute_command('RAFT.NODESHUTDOWN', 51423122)
+

--- a/tests/test_util.c
+++ b/tests/test_util.c
@@ -16,6 +16,13 @@
 
 #include "../src/redisraft.h"
 
+static void test_raftreq_str(void **state)
+{
+    for (int i = 1; i < RR_RAFTREQ_MAX; i++) {
+        assert_ptr_not_equal(RaftReqTypeStr[i], NULL);
+    }
+}
+
 static void test_memory_conversion(void **state)
 {
     unsigned long val;
@@ -124,6 +131,7 @@ static void test_redis_info_iterate(void **state)
 }
 
 const struct CMUnitTest util_tests[] = {
+    cmocka_unit_test(test_raftreq_str),
     cmocka_unit_test(test_redis_info_iterate),
     cmocka_unit_test(test_memory_conversion),
     { .test_func = NULL }


### PR DESCRIPTION
Move nodeshutdown handling to command callback.

Also, fixes minor leak if nodeshutdown id is wrong. 