### PR TITLE
Refactor multi handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,7 @@ add_library(redisraft MODULE
         src/fsync.c
         src/join.c
         src/log.c
+        src/multi.c
         src/node.c
         src/node_addr.c
         src/proxy.c
@@ -218,6 +219,7 @@ add_executable(main
         src/fsync.c
         src/join.c
         src/log.c
+        src/multi.c
         src/node.c
         src/node_addr.c
         src/proxy.c

--- a/src/multi.c
+++ b/src/multi.c
@@ -1,8 +1,7 @@
 /* Handle MULTI/EXEC transactions here.
  *
  * If this logic was applied, the return value is true, indicating no further
- * processing is required. Otherwise, the main handleRedisCommand() flow is
- * applied.
+ * processing is required.
  *
  * 1) On MULTI, we create a RaftRedisCommandArray which will store all
  *    user commands as they are queued.

--- a/src/multi.c
+++ b/src/multi.c
@@ -1,0 +1,156 @@
+/* Handle MULTI/EXEC transactions here.
+ *
+ * If this logic was applied, the return value is true, indicating no further
+ * processing is required. Otherwise, the main handleRedisCommand() flow is
+ * applied.
+ *
+ * 1) On MULTI, we create a RaftRedisCommandArray which will store all
+ *    user commands as they are queued.
+ * 2) On EXEC, we remove the RaftRedisCommandArray with all queued commands
+ *    from multi_client_state, place it in the RaftReq and let the rest of the
+ *    code handle it.
+ * 3) On DISCARD we simply remove the queued commands array.
+ *
+ * Important notes:
+ * 1) Although as a module we don't need to pass MULTI to Redis, we still keep
+ *    it in the array, because when processing the array we want to distinguish
+ *    between a MULTI with a single command and a non-MULTI scenario.
+ * 2) If our RaftReq contains multiple commands, we assume it was received as
+ *    a RAFT.ENTRY in which case we need to process it as an EXEC.  That means
+ *    we don't need to reply with +OK and multiple +QUEUED, but just process
+ *    the commands atomically.  This is common when a follower proxies a batch
+ *    of commands to a leader: the follower handles the user interaction and
+ *    the leader only handles the execution (when the user issued the final
+ *    EXEC).
+ *
+ * Error handling rules (derived from Redis):
+ * 1) MULTI and DISCARD should always succeed.
+ * 2) If we encounter errors inside a MULTI context, we need to flag that
+ *    transaction as failed but keep going until EXEC/DISCARD.
+ * 3) RAFT related state checks can be postponed and evaluated only at the
+ *    time of EXEC.
+ */
+
+#include <strings.h>
+
+#include "redisraft.h"
+
+
+typedef struct MultiState {
+    RaftRedisCommandArray cmds;
+    bool error;
+} MultiState;
+
+void MultiInitClientState(RedisRaftCtx *rr)
+{
+    rr->multi_client_state = RedisModule_CreateDict(NULL);
+}
+
+uint64_t MultiClientStateCount(RedisRaftCtx *rr)
+{
+    return RedisModule_DictSize(rr->multi_client_state);
+}
+
+void MultiFreeClientState(RedisRaftCtx *rr, unsigned long long client_id)
+{
+    MultiState *state = NULL;
+
+    if (RedisModule_DictDelC(rr->multi_client_state, &client_id,
+                             sizeof(client_id), &state) == REDISMODULE_OK) {
+        if (state) {
+            RaftRedisCommandArrayFree(&state->cmds);
+            RedisModule_Free(state);
+        }
+    }
+}
+
+bool MultiHandleCommand(RedisRaftCtx *rr,
+                        RedisModuleCtx *ctx, RaftRedisCommandArray *cmds)
+{
+    unsigned long long client_id;
+    MultiState *multiState;
+
+    /* MULTI/EXEC bundling takes place only if we have a single command. If we
+     * have multiple commands we've received this as a RAFT.ENTRY input and
+     * bundling, probably through a proxy, and bundling was done before.
+     */
+    if (cmds->len != 1) {
+        return false;
+    }
+
+    client_id = RedisModule_GetClientId(ctx);
+    multiState = RedisModule_DictGetC(rr->multi_client_state,
+                                      &client_id, sizeof(client_id), NULL);
+
+    /* Is this a MULTI command? */
+    RaftRedisCommand *cmd = cmds->commands[0];
+    size_t cmd_len;
+    const char *cmd_str = RedisModule_StringPtrLen(cmd->argv[0], &cmd_len);
+
+    if (cmd_len == 5 && !strncasecmp(cmd_str, "MULTI", 5)) {
+        if (multiState) {
+            RedisModule_ReplyWithError(ctx, "ERR MULTI calls can not be nested");
+        } else {
+            multiState = RedisModule_Calloc(sizeof(MultiState), 1);
+            RedisModule_DictSetC(rr->multi_client_state, &client_id, sizeof(client_id), multiState);
+
+            /* We put the MULTI as the first command in the array, as we still
+             * need to distinguish single-MULTI array from a single command.
+             */
+            RaftRedisCommandArrayMove(&multiState->cmds, cmds);
+            RedisModule_ReplyWithSimpleString(ctx, "OK");
+        }
+
+        return true;
+    } else if (cmd_len == 4 && !strncasecmp(cmd_str, "EXEC", 4)) {
+        if (!multiState) {
+            RedisModule_ReplyWithError(ctx, "ERR EXEC without MULTI");
+            return true;
+        }
+
+        if (multiState->error) {
+            RedisModule_ReplyWithError(ctx, "EXECABORT Transaction discarded because of previous errors.");
+            return true;
+        }
+
+        /* Just swap our commands with the EXEC command and proceed. */
+        RaftRedisCommandArrayFree(cmds);
+        RaftRedisCommandArrayMove(cmds, &multiState->cmds);
+        MultiFreeClientState(rr, client_id);
+
+        return false;
+    } else if (cmd_len == 7 && !strncasecmp(cmd_str, "DISCARD", 7)) {
+        if (!multiState) {
+            RedisModule_ReplyWithError(ctx, "ERR DISCARD without MULTI");
+            return true;
+        }
+
+        MultiFreeClientState(rr, client_id);
+        RedisModule_ReplyWithSimpleString(ctx, "OK");
+
+        return true;
+    }
+
+    /* Are we in MULTI? */
+    if (multiState) {
+        /* We have to detect commands that are unsupported or must not be
+         * intercepted and reject the transaction.
+         */
+        unsigned int cmd_flags = CommandSpecGetAggregateFlags(cmds, 0);
+
+        if (cmd_flags & CMD_SPEC_UNSUPPORTED) {
+            RedisModule_ReplyWithError(ctx, "ERR not supported by RedisRaft");
+            multiState->error = 1;
+        } else if (cmd_flags & CMD_SPEC_DONT_INTERCEPT) {
+            RedisModule_ReplyWithError(ctx, "ERR not supported by RedisRaft inside MULTI/EXEC");
+            multiState->error = 1;
+        } else {
+            RaftRedisCommandArrayMove(&multiState->cmds, cmds);
+            RedisModule_ReplyWithSimpleString(ctx, "QUEUED");
+        }
+
+        return true;
+    }
+
+    return false;
+}

--- a/src/raft.c
+++ b/src/raft.c
@@ -1137,7 +1137,7 @@ RRStatus RedisRaftInit(RedisModuleCtx *ctx, RedisRaftCtx *rr, RedisRaftConfig *c
     }
 
     /* Client state for MULTI support */
-    rr->multiClientState = RedisModule_CreateDict(ctx);
+    rr->multi_client_state = RedisModule_CreateDict(ctx);
 
     /* Read configuration from Redis */
     if (ConfigReadFromRedis(rr) == RR_ERROR) {
@@ -1306,148 +1306,6 @@ static void handleReadOnlyCommand(void *arg, int can_read)
 
 exit:
     RaftReqFree(req);
-}
-
-/* Handle MULTI/EXEC transactions here.
- *
- * If this logic was applied, the return value is true, indicating no further
- * processing is required. Otherwise, the main handleRedisCommand() flow is
- * applied.
- *
- * 1) On MULTI, we create a RaftRedisCommandArray which will store all
- *    user commands as they are queued.
- * 2) On EXEC, we remove the RaftRedisCommandArray with all queued commands
- *    from multiClientState, place it in the RaftReq and let the rest of the
- *    code handle it.
- * 3) On DISCARD we simply remove the queued commands array.
- *
- * Important notes:
- * 1) Although as a module we don't need to pass MULTI to Redis, we still keep
- *    it in the array, because when processing the array we want to distinguish
- *    between a MULTI with a single command and a non-MULTI scenario.
- * 2) If our RaftReq contains multiple commands, we assume it was received as
- *    a RAFT.ENTRY in which case we need to process it as an EXEC.  That means
- *    we don't need to reply with +OK and multiple +QUEUED, but just process
- *    the commands atomically.  This is common when a follower proxies a batch
- *    of commands to a leader: the follower handles the user interaction and
- *    the leader only handles the execution (when the user issued the final
- *    EXEC).
- *
- * Error handling rules (derived from Redis):
- * 1) MULTI and DISCARD should always succeed.
- * 2) If we encounter errors inside a MULTI context, we need to flag that
- *    transaction as failed but keep going until EXEC/DISCARD.
- * 3) RAFT related state checks can be postponed and evaluated only at the
- *    time of EXEC.
- */
-
-typedef struct MultiState {
-    RaftRedisCommandArray cmds;
-    bool error;
-} MultiState;
-
-void MultiFreeClientState(RedisRaftCtx *rr, unsigned long long client_id)
-{
-    MultiState *state = NULL;
-
-    if (RedisModule_DictDelC(rr->multiClientState, &client_id,
-                             sizeof(client_id), &state) == REDISMODULE_OK) {
-        if (state) {
-            RaftRedisCommandArrayFree(&state->cmds);
-            RedisModule_Free(state);
-        }
-    }
-}
-
-bool MultiHandleCommand(RedisRaftCtx *rr,
-                        RedisModuleCtx *ctx, RaftRedisCommandArray *cmds)
-{
-    MultiState *multiState;
-
-    /* MULTI/EXEC bundling takes place only if we have a single command. If we
-     * have multiple commands we've received this as a RAFT.ENTRY input and
-     * bundling, probably through a proxy, and bundling was done before.
-     */
-    if (cmds->len != 1) {
-        return false;
-    }
-
-    unsigned long long client_id = RedisModule_GetClientId(ctx);
-
-    multiState = RedisModule_DictGetC(rr->multiClientState,
-                                      &client_id, sizeof(client_id), NULL);
-
-    /* Is this a MULTI command? */
-    RaftRedisCommand *cmd = cmds->commands[0];
-    size_t cmd_len;
-    const char *cmd_str = RedisModule_StringPtrLen(cmd->argv[0], &cmd_len);
-
-    if (cmd_len == 5 && !strncasecmp(cmd_str, "MULTI", 5)) {
-        if (multiState) {
-            RedisModule_ReplyWithError(ctx, "ERR MULTI calls can not be nested");
-        } else {
-            multiState = RedisModule_Calloc(sizeof(MultiState), 1);
-            RedisModule_DictSetC(rr->multiClientState, &client_id, sizeof(client_id), multiState);
-
-            /* We put the MULTI as the first command in the array, as we still need to
-             * distinguish single-MULTI array from a single command.
-             */
-            RaftRedisCommandArrayMove(&multiState->cmds, cmds);
-            RedisModule_ReplyWithSimpleString(ctx, "OK");
-        }
-
-        return true;
-    } else if (cmd_len == 4 && !strncasecmp(cmd_str, "EXEC", 4)) {
-        if (!multiState) {
-            RedisModule_ReplyWithError(ctx, "ERR EXEC without MULTI");
-            return true;
-        }
-
-        if (multiState->error) {
-            RedisModule_ReplyWithError(ctx, "EXECABORT Transaction discarded because of previous errors.");
-            return true;
-        }
-
-        /* Just swap our commands with the EXEC command and proceed. */
-        RaftRedisCommandArrayFree(cmds);
-        RaftRedisCommandArrayMove(cmds, &multiState->cmds);
-        MultiFreeClientState(rr, client_id);
-
-        return false;
-    } else if (cmd_len == 7 && !strncasecmp(cmd_str, "DISCARD", 7)) {
-        if (!multiState) {
-            RedisModule_ReplyWithError(ctx, "ERR DISCARD without MULTI");
-            return true;
-        }
-
-        MultiFreeClientState(rr, client_id);
-        RedisModule_ReplyWithSimpleString(ctx, "OK");
-
-        return true;
-    }
-
-    /* Are we in MULTI? */
-    if (multiState) {
-        /* We have to detect commands that are unsupported or must not be
-         * intercepted and reject the transaction.
-         */
-        unsigned int cmd_flags = CommandSpecGetAggregateFlags(cmds, 0);
-
-        if (cmd_flags & CMD_SPEC_UNSUPPORTED) {
-            RedisModule_ReplyWithError(ctx, "ERR not supported by RedisRaft");
-            multiState->error = 1;
-        } else if (cmd_flags & CMD_SPEC_DONT_INTERCEPT) {
-            RedisModule_ReplyWithError(ctx, "ERR not supported by RedisRaft inside MULTI/EXEC");
-            multiState->error = 1;
-        } else {
-            RaftRedisCommandArrayMove(&multiState->cmds, cmds);
-            RedisModule_ReplyWithSimpleString(ctx, "QUEUED");
-        }
-
-        return true;
-    }
-
-    return false;
 }
 
 void handleInfoCommand(RedisRaftCtx *rr, RaftReq *req)
@@ -1761,7 +1619,7 @@ void handleInfo(RedisRaftCtx *rr, RaftReq *req)
             "proxy_failed_reqs:%llu\r\n"
             "proxy_failed_responses:%llu\r\n"
             "proxy_outstanding_reqs:%ld\r\n",
-            RedisModule_DictSize(rr->multiClientState),
+            MultiClientStateCount(rr),
             rr->proxy_reqs,
             rr->proxy_failed_reqs,
             rr->proxy_failed_responses,

--- a/src/raft.c
+++ b/src/raft.c
@@ -27,7 +27,6 @@ const char *RaftReqTypeStr[] = {
     [RR_REDISCOMMAND]         = "RR_REDISCOMMAND",
     [RR_INFO]                 = "RR_INFO",
     [RR_DEBUG]                = "RR_DEBUG",
-    [RR_CLIENT_DISCONNECT]    = "RR_CLIENT_DISCONNECT",
     [RR_SHARDGROUP_ADD]       = "RR_SHARDGROUP_ADD",
     [RR_SHARDGROUPS_REPLACE]  = "RR_SHARDGROUPS_REPLACE",
     [RR_SHARDGROUP_LINK]      = "RR_SHARDGROUP_LINK",
@@ -1628,12 +1627,6 @@ void handleInfo(RedisRaftCtx *rr, RaftReq *req)
     RedisModule_ReplyWithStringBuffer(req->ctx, s, strlen(s));
     RedisModule_Free(s);
 
-    RaftReqFree(req);
-}
-
-void handleClientDisconnect(RedisRaftCtx *rr, RaftReq *req)
-{
-    MultiFreeClientState(rr, req->r.client_disconnect.client_id);
     RaftReqFree(req);
 }
 

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1054,12 +1054,15 @@ static int cmdRaftRandom(RedisModuleCtx *ctx,
 void handleClientDisconnectEvent(RedisModuleCtx *ctx,
         RedisModuleEvent eid, uint64_t subevent, void *data)
 {
+    (void) ctx;
+
+    RedisRaftCtx *rr = &redis_raft;
+    RedisModuleClientInfo *ci = data;
+
     if (eid.id == REDISMODULE_EVENT_CLIENT_CHANGE &&
-            subevent == REDISMODULE_SUBEVENT_CLIENT_CHANGE_DISCONNECTED) {
-        RedisModuleClientInfo *ci = (RedisModuleClientInfo *) data;
-        RaftReq *req = RaftReqInit(NULL, RR_CLIENT_DISCONNECT);
-        req->r.client_disconnect.client_id = ci->id;
-        handleClientDisconnect(&redis_raft, req);
+        subevent == REDISMODULE_SUBEVENT_CLIENT_CHANGE_DISCONNECTED) {
+
+        MultiFreeClientState(rr, ci->id);
     }
 }
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -331,7 +331,7 @@ typedef struct RedisRaftCtx {
     struct RaftReq *transfer_req;                /* RaftReq if a leader transfer is in progress */
     RedisModuleCommandFilter *registered_filter; /* Command filter is used for intercepting redis commands */
     struct ShardingInfo *sharding_info;          /* Information about sharding, when cluster mode is enabled */
-    RedisModuleDict *multiClientState;           /* A dict that tracks multi state of the clients */
+    RedisModuleDict *multi_client_state;         /* A dict that tracks multi state of the clients */
 
     /* General stats */
     unsigned long client_attached_entries;       /* Number of log entries attached to user connections */
@@ -856,4 +856,9 @@ const CommandSpec *CommandSpecGet(const RedisModuleString *cmd);
 /* sort.c */
 void handleSort(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
+/* multi.c */
+void MultiInitClientState(RedisRaftCtx *rr);
+uint64_t MultiClientStateCount(RedisRaftCtx *rr);
+void MultiFreeClientState(RedisRaftCtx *rr, unsigned long long client_id);
+bool MultiHandleCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds);
 #endif  /* _REDISRAFT_H */

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -453,7 +453,6 @@ enum RaftReqType {
     RR_REDISCOMMAND,
     RR_INFO,
     RR_DEBUG,
-    RR_CLIENT_DISCONNECT,
     RR_SHARDGROUP_ADD,
     RR_SHARDGROUPS_REPLACE,
     RR_SHARDGROUP_LINK,
@@ -573,9 +572,6 @@ typedef struct RaftReq {
             RaftRedisCommandArray cmds;
             msg_entry_response_t response;
         } redis;
-        struct {
-            unsigned long long client_id;
-        } client_disconnect;
         struct {
             int fail;
             int delay;
@@ -719,7 +715,6 @@ void shutdownAfterRemoval(RedisRaftCtx *rr);
 bool hasNodeIdBeenUsed(RedisRaftCtx *rr, raft_node_id_t node_id);
 void handleRedisCommand(RedisRaftCtx *rr,RaftReq *req);
 void handleAppendEntries(RedisRaftCtx *rr, RaftReq *req);
-void handleClientDisconnect(RedisRaftCtx *rr, RaftReq *req);
 void handleInfo(RedisRaftCtx *rr, RaftReq *req);
 void callRaftPeriodic(RedisModuleCtx *ctx, void *arg);
 void callHandleNodeStates(RedisModuleCtx *ctx, void *arg);

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -331,6 +331,7 @@ typedef struct RedisRaftCtx {
     struct RaftReq *transfer_req;                /* RaftReq if a leader transfer is in progress */
     RedisModuleCommandFilter *registered_filter; /* Command filter is used for intercepting redis commands */
     struct ShardingInfo *sharding_info;          /* Information about sharding, when cluster mode is enabled */
+    RedisModuleDict *multiClientState;           /* A dict that tracks multi state of the clients */
 
     /* General stats */
     unsigned long client_attached_entries;       /* Number of log entries attached to user connections */


### PR DESCRIPTION
Refactored multi handling.

- Moved multi command handling into multi.c
  - Changed multi handling to work without RaftReq
  - Deleted leftover checks like  `REDISMODULE_CTX_FLAGS_MULTI_DIRTY`. 
  - Changed client disconnect handling not to use RaftReq

