### PR TITLE
only reset redisraft state on connection failure for join

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -239,8 +239,8 @@ void joinLinkIdleCallback(Connection *conn)
 exit_fail:
     ConnAsyncTerminate(conn);
     /* only reset state to UNINITIALIZED on a join failure */
-    if (!strcmp(state->type, "join")) {
-        rr->state = REDIS_RAFT_UNINITIALIZED;
+    if (state->fail_callback) {
+        state->fail_callback(conn);
     }
 
     snprintf(err_msg, sizeof(err_msg), "ERR failed to connect to cluster for %s, please check logs", state->type);

--- a/src/join.c
+++ b/src/join.c
@@ -79,6 +79,13 @@ static void handleNodeAddResponse(redisAsyncContext *c, void *r, void *privdata)
     redisAsyncDisconnect(c);
 }
 
+/* failed join -- reset cluster state */
+static void failed_join_callback(Connection *conn)
+{
+    RedisRaftCtx *rr = ConnGetRedisRaftCtx(conn);
+    rr->state = REDIS_RAFT_UNINITIALIZED;
+}
+
 /* Connect callback -- if connection was established successfully we
  * send the RAFT.NODE ADD command.
  */
@@ -111,6 +118,7 @@ void JoinCluster(RedisRaftCtx *rr, NodeAddrListElement *el, RaftReq *req,
     st->type = "join";
     st->connect_callback = sendNodeAddRequest;
     st->complete_callback = complete_callback;
+    st->fail_callback = failed_join_callback;
     st->start = time(NULL);
     st->req = req;
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -670,6 +670,7 @@ typedef struct JoinLinkState {
     const char *type;                   /* error message to print if exhaust time */
     bool started;                       /* we have started connecting */
     ConnectionCallbackFunc connect_callback;
+    ConnectionCallbackFunc fail_callback;
     void (*complete_callback)(RaftReq *req);
 } JoinLinkState;
 

--- a/tests/integration/test_membership.py
+++ b/tests/integration/test_membership.py
@@ -181,7 +181,7 @@ def test_remove_and_rejoin_node_with_same_id_fails(cluster, use_snapshot):
     cluster.node(cluster.leader).wait_for_num_nodes(2)
 
     logger.info("Re-add node")
-    with raises(ResponseError, match='failed to join'):
+    with raises(ResponseError, match='failed to connect to cluster for join'):
         new_node = cluster.add_node(port=port, node_id=node_id, single_run=True)
 
 
@@ -250,7 +250,7 @@ def test_join_while_cluster_is_down(cluster):
     time.sleep(3)
 
     # Confirm nodes cannot be added
-    with raises(ResponseError, match='failed to join'):
+    with raises(ResponseError, match='failed to connect to cluster for join'):
         cluster.add_node(raft_args={'join-timeout': 1}, single_run=True,
                          join_addr_list=[cluster.node(3).address])
 
@@ -259,7 +259,7 @@ def test_join_wrong_cluster(cluster):
     cluster.create(3)
 
     # Confirm nodes fails fast with bad server address
-    with raises(ResponseError, match='failed to join'):
+    with raises(ResponseError, match='failed to connect to cluster for join'):
         cluster.add_node(raft_args={'join-timeout': 1}, single_run=True,
                          join_addr_list=["bad-server:1234"])
 

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -331,7 +331,7 @@ def test_shard_group_linking_checks(cluster_factory):
         'slot-config': '1:16383'})
 
     # Link
-    with raises(ResponseError, match='failed to link'):
+    with raises(ResponseError, match='failed to connect to cluster for link'):
         cluster1.node(1).client.execute_command(
             'RAFT.SHARDGROUP', 'LINK',
             'localhost:%s' % cluster2.node(1).port)


### PR DESCRIPTION
we were resetting to unitialized on any connection failure, which was breaking clusters with shardgroup link

fixes #288 