### PR TITLE
Fix config get crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ utils/create-cluster/*.db
 utils/create-cluster/*.db.idx
 venv
 buildinfo.h
+build/*

--- a/src/config.c
+++ b/src/config.c
@@ -598,7 +598,7 @@ void ConfigGet(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, 
     }
     if (stringmatch(pattern, CONF_IGNORED_COMMANDS, 1)) {
         len++;
-        replyConfigStr(ctx, CONF_IGNORED_COMMANDS, config->ignored_commands);
+        replyConfigStr(ctx, CONF_IGNORED_COMMANDS, config->ignored_commands ? config->ignored_commands : "");
     }
     if (stringmatch(pattern, CONF_MAX_APPEND_REQ_IN_FLIGHT, 1)) {
         len++;
@@ -680,6 +680,7 @@ void ConfigInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
     config->external_sharding = false;
     config->slot_config = "0:16383";
     config->shardgroup_update_interval = REDIS_RAFT_DEFAULT_SHARDGROUP_UPDATE_INTERVAL;
+    config->ignored_commands = NULL;
     config->max_appendentries_inflight = REDIS_RAFT_DEFAULT_MAX_APPENDENTRIES;
 #ifdef HAVE_TLS
     updateTLSConfig(ctx, config);

--- a/src/util.c
+++ b/src/util.c
@@ -79,10 +79,10 @@ char *catsnprintf(char *strbuf, size_t *strbuf_len, const char *fmt, ...)
 /* Glob-style pattern matching. */
 int stringmatchlen(const char *pattern, int patternLen, const char *string, int stringLen, int nocase)
 {
-    while (patternLen) {
+    while (patternLen && stringLen) {
         switch (pattern[0]) {
         case '*':
-            while (pattern[1] == '*') {
+            while (patternLen && pattern[1] == '*') {
                 pattern++;
                 patternLen--;
             }
@@ -93,7 +93,7 @@ int stringmatchlen(const char *pattern, int patternLen, const char *string, int 
 
             while (stringLen) {
                 if (stringmatchlen(pattern + 1, patternLen - 1,
-                                   string, stringLen, nocase)) {
+                            string, stringLen, nocase)) {
                     return 1;    /* match */
                 }
 
@@ -128,7 +128,7 @@ int stringmatchlen(const char *pattern, int patternLen, const char *string, int 
             match = 0;
 
             while (1) {
-                if (pattern[0] == '\\') {
+                if (pattern[0] == '\\' && patternLen >= 2) {
                     pattern++;
                     patternLen--;
 
@@ -141,7 +141,7 @@ int stringmatchlen(const char *pattern, int patternLen, const char *string, int 
                     pattern--;
                     patternLen++;
                     break;
-                } else if (pattern[1] == '-' && patternLen >= 3) {
+                } else if (patternLen >= 3 && pattern[1] == '-') {
                     int start = pattern[0];
                     int end = pattern[2];
                     int c = string[0];
@@ -199,7 +199,7 @@ int stringmatchlen(const char *pattern, int patternLen, const char *string, int 
                 patternLen--;
             }
 
-        /* fall through */
+            /* fall through */
         default:
             if (!nocase) {
                 if (pattern[0] != string[0]) {


### PR DESCRIPTION
# Describe

When I use `config get *`, I find that the server crashes directly, I found that the of variable `ignored_commands` was not initialized. In addition, I found some problems with `stringmatchlen`:
+ https://github.com/redis/redis/commit/c710d4afdccc0c797745bc3264f3f32a4cdd85da
+ https://github.com/redis/redis/commit/e17f9311c8ee18996e4b932a1284e4cfe29c05b4
+ https://github.com/redis/redis/commit/f43eb5adcfa3be6368f116656348a29f22f580eb
