### PR TITLE
Improve non-quorum read safety

### DIFF
--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -782,6 +782,10 @@ static int cmdRaftAppendEntries(RedisModuleCtx *ctx, RedisModuleString **argv, i
         return REDISMODULE_OK;
     }
 
+    if (rr->debug_appendreq_delay) {
+        usleep(rr->debug_appendreq_delay);
+    }
+
     int target_node_id;
     if (RedisModuleStringToInt(argv[1], &target_node_id) == REDISMODULE_ERR ||
         target_node_id != rr->config->id) {
@@ -1364,6 +1368,14 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
             RedisModule_ReplyWithCallReply(ctx, reply);
             RedisModule_FreeCallReply(reply);
         }
+    } else if (!strncasecmp(cmd, "delayappend", cmdlen) && argc == 3) {
+        long long delay;
+        if (RedisModule_StringToLongLong(argv[2], &delay) != REDISMODULE_OK) {
+            RedisModule_ReplyWithError(ctx, "ERR invalid append delay value");
+            return REDISMODULE_OK;
+        }
+        rr->debug_appendreq_delay = delay;
+        RedisModule_ReplyWithSimpleString(ctx, "OK");
     } else {
         RedisModule_ReplyWithError(ctx, "ERR invalid debug subcommand");
     }

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -329,6 +329,7 @@ typedef struct RedisRaftCtx {
     int snapshot_child_fd;                       /* Pipe connected to snapshot child process */
     SnapshotFile outgoing_snapshot_file;         /* Snapshot file memory map to send to followers */
     RaftSnapshotInfo snapshot_info;              /* Current snapshot info */
+    long long debug_appendreq_delay;             /* 'RAFT.DEBUG delayappend micros' value to delay appendreq processing */
     struct RaftReq *debug_req;                   /* Current RAFT.DEBUG request context, if processing one */
     struct RaftReq *transfer_req;                /* RaftReq if a leader transfer is in progress */
     RedisModuleCommandFilter *registered_filter; /* Command filter is used for intercepting redis commands */


### PR DESCRIPTION
Before serving non-quorum read requests, wait until the new leader applies an entry from the current term.

Otherwise, we might process a request before replaying logs. The state machine will be in an older state. Reading from it might look like going backward in time.

Fixes https://github.com/RedisLabs/redisraft/issues/316