### PR TITLE
Add auto target selection for leadership transfer

### DIFF
--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -323,8 +323,9 @@ class RedisRaft(object):
     def current_index(self):
         return self.raft_info()['current_index']
 
-    def transfer_leader(self, target):
-        return self.client.execute_command('raft.transfer_leader', target)
+    def transfer_leader(self, *args, **kwargs):
+        return self.client.execute_command('raft.transfer_leader',
+                                           *args, **kwargs)
 
     def timeout_now(self):
         return self.client.execute_command('raft.timeout_now')

--- a/tests/integration/test_membership.py
+++ b/tests/integration/test_membership.py
@@ -288,6 +288,11 @@ def test_transfer_succeed(cluster):
     cluster.leader_node().transfer_leader(2)
 
 
+def test_transfer_to_any_other(cluster):
+    cluster.create(2, raft_args={'election-timeout': '3000'})
+    cluster.leader_node().transfer_leader()
+
+
 def test_transfer_timeout(cluster):
     cluster.create(3, raft_args={'election-timeout': '3000'})
     cluster.node(2).pause()


### PR DESCRIPTION
Related libraft PR: https://github.com/RedisLabs/raft/pull/95

After this PR, "raft.transfer_leader" can be issued without target node id. In that case, follower node with most entries will be selected as leader transfer target. 

This is useful in two cases, first, you want minimum unavailability while transferring leadership. Follower with most entries will be the best candidate as current leader needs to replicate less entries than other nodes. Second, when you don't care about the next leader. So, you don't need to check out node id of a node in the cluster.