### PR TITLE
Migrate RAFT.INFO into Redis INFO

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Now add the third node in the same way:
 
     redis-cli -p 5003 RAFT.CLUSTER JOIN localhost:5001
 
-To query the cluster state, run the `RAFT.INFO` command:
+To query the cluster state, run the `INFO raft` command:
 
-    redis-cli --raw -p 5001 RAFT.INFO
+    redis-cli -p 5001 INFO raft
 
 Now you can start using this RedisRaft cluster. All [supported Redis commands](docs/Using.md) will be executed in a strongly-consistent manner using the Raft protocol.
 

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -105,10 +105,10 @@ Before creating the cluster, the first node must be launched. Initially, a node 
 
 We can validate our node is indeed `uninitialized` as follows:
 
-    $ redis-cli --raw -p 5001 RAFT.INFO
+    $ redis-cli -p 5001 INFO raft
     # Raft
-    node_id:0
-    state:uninitialized
+    raft_node_id:0
+    raft_state:uninitialized
     [...]
 
 You can see the `state` indicates the node is uninitialized. Notice also that its `node_id` is `0`.
@@ -142,19 +142,19 @@ Since the cluster already exists, we don't need to run `RAFT.CLUSTER INIT`. Inst
 
 > :bulb: Notice we use `redis-cli` to communicate with the new node, but we specify the host and port of the existing leader node as the argument to the `RAFT.CLUSTER JOIN` command.
 
-At this point we can run `RAFT.INFO` again to query the status of our cluster. Querying the second node should result in a response similar to this:
+At this point we can run `INFO raft` again to query the status of our cluster. Querying the second node should result in a response similar to this:
 
-    $ redis-cli -p 5002 --raw RAFT.INFO
+    $ redis-cli -p 5002 INFO raft
     # Raft
-    node_id:595100767
-    state:up
-    role:follower
-    is_voting:yes
-    leader_id:1733428433
-    current_term:1
-    num_nodes:2
-    num_voting_nodes:2
-    node1:id=1733428433,state=connected,voting=yes,addr=localhost,port=5001,last_conn_secs=5,conn_errors=0,conn_oks=1
+    raft_node_id:595100767
+    raft_state:up
+    raft_role:follower
+    raft_is_voting:yes
+    raft_leader_id:1733428433
+    raft_current_term:1
+    raft_num_nodes:2
+    raft_num_voting_nodes:2
+    raft_node1:id=1733428433,state=connected,voting=yes,addr=localhost,port=5001,last_conn_secs=5,conn_errors=0,conn_oks=1
 
 Some things to notice:
 * When joining the cluster, our node has been assigned a unique `node_id`.
@@ -168,7 +168,7 @@ Cluster Management
 
 ### Monitoring
 
-The primary tool for monitoring the status and health of a RedisRaft cluster is the `RAFT.INFO` command.
+The primary tool for monitoring the status and health of a RedisRaft cluster is the `INFO raft` command.
 
 RedisRaft nodes communicate with each other over the Redis port, using dedicated commands for the implementation of the Raft RPC. It is important to verify the network configuration is correct. In particular:
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -142,7 +142,6 @@ RRStatus CommandSpecInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
             { "raft.requestvote",             CMD_SPEC_DONT_INTERCEPT },
             { "raft.snapshot",                CMD_SPEC_DONT_INTERCEPT },
             { "raft.debug",                   CMD_SPEC_DONT_INTERCEPT },
-            { "raft.info",                    CMD_SPEC_DONT_INTERCEPT },
             { "raft.nodeshutdown",            CMD_SPEC_DONT_INTERCEPT },
             { "raft.transfer_leader",         CMD_SPEC_DONT_INTERCEPT },
             { "raft.timeout_now",             CMD_SPEC_DONT_INTERCEPT },

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -616,142 +616,6 @@ static int cmdRaftEntry(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     return REDISMODULE_OK;
 }
 
-/* RAFT.INFO
- *   Display Raft module specific info.
- * Reply:
- *   Raw text output, formatted like INFO.
- */
-static int cmdRaftInfo(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
-{
-    RedisRaftCtx *rr = &redis_raft;
-    size_t slen = 1024;
-    char *s = RedisModule_Calloc(1, slen);
-    const char* role;
-
-    if (!rr->raft) {
-        role = "-";
-    } else {
-        switch (raft_get_state(rr->raft)) {
-            case RAFT_STATE_FOLLOWER:
-                role = "follower";
-                break;
-            case RAFT_STATE_LEADER:
-                role = "leader";
-                break;
-            case RAFT_STATE_PRECANDIDATE:
-                role = "pre-candidate";
-                break;
-            case RAFT_STATE_CANDIDATE:
-                role = "candidate";
-                break;
-            default:
-                role = "(none)";
-                break;
-        }
-    }
-
-    raft_node_t *me = rr->raft ? raft_get_my_node(rr->raft) : NULL;
-    s = catsnprintf(s, &slen,
-            "# RedisRaft\r\n"
-            "redisraft_version:%s\r\n"
-            "redisraft_git_sha1:%s\r\n"
-            "\r\n"
-            "# Raft\r\n"
-            "dbid:%s\r\n"
-            "node_id:%d\r\n"
-            "state:%s\r\n"
-            "role:%s\r\n"
-            "is_voting:%s\r\n"
-            "leader_id:%d\r\n"
-            "current_term:%ld\r\n"
-            "num_nodes:%d\r\n"
-            "num_voting_nodes:%d\r\n",
-            REDISRAFT_VERSION,
-            REDISRAFT_GIT_SHA1,
-            rr->snapshot_info.dbid,
-            rr->config->id,
-            getStateStr(rr),
-            role,
-            me ? (raft_node_is_voting(raft_get_my_node(rr->raft)) ? "yes" : "no") : "-",
-            rr->raft ? raft_get_leader_id(rr->raft) : -1,
-            rr->raft ? raft_get_current_term(rr->raft) : 0,
-            rr->raft ? raft_get_num_nodes(rr->raft) : 0,
-            rr->raft ? raft_get_num_voting_nodes(rr->raft) : 0);
-
-    int i;
-    long long now = RedisModule_Milliseconds();
-    int num_nodes = rr->raft ? raft_get_num_nodes(rr->raft) : 0;
-    for (i = 0; i < num_nodes; i++) {
-        raft_node_t *rnode = raft_get_node_from_idx(rr->raft, i);
-        Node *node = raft_node_get_udata(rnode);
-        if (!node) {
-            continue;
-        }
-
-        s = catsnprintf(s, &slen,
-                "node%d:id=%d,state=%s,voting=%s,addr=%s,port=%d,last_conn_secs=%lld,conn_errors=%lu,conn_oks=%lu\r\n",
-                i, node->id, ConnGetStateStr(node->conn),
-                raft_node_is_voting(rnode) ? "yes" : "no",
-                node->addr.host, node->addr.port,
-                node->conn->last_connected_time ? (now - node->conn->last_connected_time)/1000 : -1,
-                node->conn->connect_errors, node->conn->connect_oks);
-    }
-
-    s = catsnprintf(s, &slen,
-            "\r\n# Log\r\n"
-            "log_entries:%ld\r\n"
-            "current_index:%ld\r\n"
-            "commit_index:%ld\r\n"
-            "last_applied_index:%ld\r\n"
-            "file_size:%lu\r\n"
-            "cache_memory_size:%lu\r\n"
-            "cache_entries:%lu\r\n"
-            "client_attached_entries:%lu\r\n"
-            "fsync_count:%"PRIu64"\r\n"
-            "fsync_max_microseconds:%"PRIu64"\r\n"
-            "fsync_avg_microseconds:%"PRIu64"\r\n",
-            rr->raft ? raft_get_log_count(rr->raft) : 0,
-            rr->raft ? raft_get_current_idx(rr->raft) : 0,
-            rr->raft ? raft_get_commit_idx(rr->raft) : 0,
-            rr->raft ? raft_get_last_applied_idx(rr->raft) : 0,
-            rr->log ? rr->log->file_size : 0,
-            rr->logcache ? rr->logcache->entries_memsize : 0,
-            rr->logcache ? rr->logcache->len : 0,
-            rr->client_attached_entries,
-            rr->log ? rr->log->fsync_count : 0,
-            rr->log ? rr->log->fsync_max : 0,
-            rr->log ? rr->log->fsync_count ?
-                        (rr->log->fsync_total / rr->log->fsync_count) : 0 : 0);
-
-    s = catsnprintf(s, &slen,
-            "\r\n# Snapshot\r\n"
-            "snapshot_in_progress:%s\r\n"
-            "snapshots_loaded:%lu\r\n"
-            "snapshots_created:%lu\r\n",
-            rr->snapshot_in_progress ? "yes" : "no",
-            rr->snapshots_loaded,
-            rr->snapshots_created);
-
-    s = catsnprintf(s, &slen,
-            "\r\n# Clients\r\n"
-            "clients_in_multi_state:%"PRIu64"\r\n"
-            "proxy_reqs:%llu\r\n"
-            "proxy_failed_reqs:%llu\r\n"
-            "proxy_failed_responses:%llu\r\n"
-            "proxy_outstanding_reqs:%ld\r\n",
-            MultiClientStateCount(rr),
-            rr->proxy_reqs,
-            rr->proxy_failed_reqs,
-            rr->proxy_failed_responses,
-            rr->proxy_outstanding_reqs);
-
-    RedisModule_ReplyWithStringBuffer(ctx, s, strlen(s));
-    RedisModule_Free(s);
-
-    return REDISMODULE_OK;
-}
-
-
 /* RAFT.AE [target_node_id] [src_node_id]
  *         [leader_id]:[term]:[prev_log_idx]:[prev_log_term]:[leader_commit]:[msg_id]
  *         [n_entries] [<term>:<id>:<type> <entry>]...
@@ -1590,6 +1454,92 @@ static void beforeSleep(RedisModuleCtx *ctx,
     }
 }
 
+static void handleInfo(RedisModuleInfoCtx *ctx, int for_crash_report)
+{
+    (void) for_crash_report;
+
+    RedisRaftCtx *rr = &redis_raft;
+
+    RedisModule_InfoAddSection(ctx, "version");
+    RedisModule_InfoAddFieldCString(ctx, "version", REDISRAFT_VERSION);
+    RedisModule_InfoAddFieldCString(ctx, "git_sha1", REDISRAFT_GIT_SHA1);
+
+    RedisModule_InfoAddSection(ctx, "general");
+    RedisModule_InfoAddFieldCString(ctx, "dbid", rr->snapshot_info.dbid);
+    RedisModule_InfoAddFieldLongLong(ctx, "node_id", rr->config->id);
+    RedisModule_InfoAddFieldCString(ctx, "state", getStateStr(rr));
+    RedisModule_InfoAddFieldCString(ctx, "role", rr->raft ? raft_get_state_str(rr->raft) : "(none)");
+
+    char *voting = "-";
+    if (rr->raft) {
+        voting = raft_node_is_voting(raft_get_my_node(rr->raft)) ? "yes" : "no";
+    }
+    RedisModule_InfoAddFieldCString(ctx, "is_voting", voting);
+    RedisModule_InfoAddFieldLongLong(ctx, "leader_id", rr->raft ? raft_get_leader_id(rr->raft) : -1);
+    RedisModule_InfoAddFieldLongLong(ctx, "current_term", rr->raft ? raft_get_current_term(rr->raft) : 0);
+    RedisModule_InfoAddFieldLongLong(ctx, "num_nodes", rr->raft ? raft_get_num_nodes(rr->raft) : 0);
+    RedisModule_InfoAddFieldLongLong(ctx, "num_voting_nodes", rr->raft ? raft_get_num_voting_nodes(rr->raft) : 0);
+
+    long long now = RedisModule_Milliseconds();
+    int num_nodes = rr->raft ? raft_get_num_nodes(rr->raft) : 0;
+    for (int i = 0; i < num_nodes; i++) {
+        raft_node_t *rn = raft_get_node_from_idx(rr->raft, i);
+        Node *n = raft_node_get_udata(rn);
+        if (!n) {
+            continue;
+        }
+
+        char name[32];
+        snprintf(name, sizeof(name), "node%d", i);
+
+        RedisModule_InfoBeginDictField(ctx, name);
+        RedisModule_InfoAddFieldLongLong(ctx, "id", n->id);
+        RedisModule_InfoAddFieldCString(ctx, "state", ConnGetStateStr(n->conn));
+        RedisModule_InfoAddFieldCString(ctx, "voting", raft_node_is_voting(rn) ? "yes" : "no");
+        RedisModule_InfoAddFieldCString(ctx, "addr", n->addr.host);
+        RedisModule_InfoAddFieldULongLong(ctx, "port", n->addr.port);
+
+        long long int last = -1;
+        if (n->conn->last_connected_time) {
+            last = (now - n->conn->last_connected_time) / 1000;
+        }
+        RedisModule_InfoAddFieldLongLong(ctx, "last_conn_secs", last);
+
+        RedisModule_InfoAddFieldULongLong(ctx, "conn_errors", n->conn->connect_errors);
+        RedisModule_InfoAddFieldULongLong(ctx, "conn_oks", n->conn->connect_oks);
+        RedisModule_InfoEndDictField(ctx);
+    }
+
+    RedisModule_InfoAddSection(ctx, "log");
+    RedisModule_InfoAddFieldLongLong(ctx, "log_entries", rr->raft ? raft_get_log_count(rr->raft) : 0);
+    RedisModule_InfoAddFieldLongLong(ctx, "current_index", rr->raft ? raft_get_current_idx(rr->raft) : 0);
+    RedisModule_InfoAddFieldLongLong(ctx, "commit_index", rr->raft ? raft_get_commit_idx(rr->raft) : 0);
+    RedisModule_InfoAddFieldLongLong(ctx, "last_applied_index", rr->raft ? raft_get_last_applied_idx(rr->raft) : 0);
+    RedisModule_InfoAddFieldULongLong(ctx, "file_size", rr->log ? rr->log->file_size : 0);
+    RedisModule_InfoAddFieldULongLong(ctx, "cache_memory_size", rr->logcache ? rr->logcache->entries_memsize : 0);
+    RedisModule_InfoAddFieldLongLong(ctx, "cache_entries", rr->logcache ? rr->logcache->len : 0);
+    RedisModule_InfoAddFieldULongLong(ctx, "client_attached_entries", rr->client_attached_entries);
+    RedisModule_InfoAddFieldULongLong(ctx, "fsync_count", rr->log ? rr->log->fsync_count : 0);
+    RedisModule_InfoAddFieldULongLong(ctx, "fsync_max_microseconds", rr->log ? rr->log->fsync_max : 0);
+
+    uint64_t avg = 0;
+    if (rr->log && rr->log->fsync_count) {
+        avg = rr->log->fsync_total / rr->log->fsync_count;
+    }
+    RedisModule_InfoAddFieldULongLong(ctx, "fsync_avg_microseconds", avg);
+
+    RedisModule_InfoAddSection(ctx, "snapshot");
+    RedisModule_InfoAddFieldCString(ctx, "snapshot_in_progress", rr->snapshot_in_progress ? "yes" : "no");
+    RedisModule_InfoAddFieldULongLong(ctx, "snapshots_loaded", rr->snapshots_loaded);
+    RedisModule_InfoAddFieldULongLong(ctx, "snapshots_created", rr->snapshots_created);
+
+    RedisModule_InfoAddSection(ctx, "clients");
+    RedisModule_InfoAddFieldULongLong(ctx, "clients_in_multi_state", MultiClientStateCount(rr));
+    RedisModule_InfoAddFieldULongLong(ctx, "proxy_reqs", rr->proxy_reqs);
+    RedisModule_InfoAddFieldULongLong(ctx, "proxy_failed_reqs", rr->proxy_failed_reqs);
+    RedisModule_InfoAddFieldULongLong(ctx, "proxy_failed_responses", rr->proxy_failed_responses);
+    RedisModule_InfoAddFieldULongLong(ctx, "proxy_outstanding_reqs", rr->proxy_outstanding_reqs);
+}
 
 static int registerRaftCommands(RedisModuleCtx *ctx)
 {
@@ -1606,11 +1556,6 @@ static int registerRaftCommands(RedisModuleCtx *ctx)
 
     if (RedisModule_CreateCommand(ctx, "raft.entry",
                 cmdRaftEntry, "write", 0, 0, 0) == REDISMODULE_ERR) {
-        return REDISMODULE_ERR;
-    }
-
-    if (RedisModule_CreateCommand(ctx, "raft.info",
-                cmdRaftInfo, "admin", 0, 0, 0) == REDISMODULE_ERR) {
         return REDISMODULE_ERR;
     }
 
@@ -1690,7 +1635,7 @@ static int registerRaftCommands(RedisModuleCtx *ctx)
 
 __attribute__((__unused__)) int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 {
-    if (RedisModule_Init(ctx, "redisraft", 1, REDISMODULE_APIVER_1) != REDISMODULE_OK) {
+    if (RedisModule_Init(ctx, "raft", 1, REDISMODULE_APIVER_1) != REDISMODULE_OK) {
         return REDISMODULE_ERR;
     }
 
@@ -1726,6 +1671,7 @@ __attribute__((__unused__)) int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisMod
 
     /* Create a logging context */
     redis_raft_log_ctx = RedisModule_GetDetachedThreadSafeContext(ctx);
+    RedisModule_RegisterInfoFunc(ctx, handleInfo);
 
     /* Sanity check that not running with cluster_enabled */
     RedisModuleServerInfoData *info = RedisModule_GetServerInfo(ctx, "cluster");

--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -65,13 +65,13 @@ def test_raft_log_max_file_size(cluster):
     """
 
     r1 = cluster.add_node()
-    assert r1.raft_info()['log_entries'] == 1
+    assert r1.info()['raft_log_entries'] == 1
     assert r1.raft_config_set('raft-log-max-file-size', '1kb')
     for _ in range(10):
         assert r1.client.set('testkey', 'x'*500)
 
-    r1.wait_for_info_param('snapshots_created', 1)
-    assert r1.raft_info()['log_entries'] < 10
+    r1.wait_for_info_param('raft_snapshots_created', 1)
+    assert r1.info()['raft_log_entries'] < 10
 
 
 def test_raft_log_max_cache_size(cluster):
@@ -80,22 +80,22 @@ def test_raft_log_max_cache_size(cluster):
     """
 
     r1 = cluster.add_node()
-    assert r1.raft_info()['cache_entries'] == 1
+    assert r1.info()['raft_cache_entries'] == 1
 
     assert r1.raft_config_set('raft-log-max-cache-size', '1kb')
     assert r1.client.set('testkey', 'testvalue')
 
-    info = r1.raft_info()
-    assert info['cache_entries'] == 2
-    assert info['cache_memory_size'] > 0
+    info = r1.info()
+    assert info['raft_cache_entries'] == 2
+    assert info['raft_cache_memory_size'] > 0
 
     for _ in range(10):
         assert r1.client.set('testkey', 'x' * 500)
 
     time.sleep(1)
-    info = r1.raft_info()
-    assert info['log_entries'] == 12
-    assert info['cache_entries'] < 5
+    info = r1.info()
+    assert info['raft_log_entries'] == 12
+    assert info['raft_cache_entries'] < 5
 
 
 def test_reply_to_cache_invalidated_entry(cluster):
@@ -126,9 +126,9 @@ def test_reply_to_cache_invalidated_entry(cluster):
 
     # confirm all raft entries were created but some have been evicted
     # from cache already.
-    info = cluster.node(1).raft_info()
-    assert info['log_entries'] == 15
-    assert info['cache_entries'] < 10
+    info = cluster.node(1).info()
+    assert info['raft_log_entries'] == 15
+    assert info['raft_cache_entries'] < 10
 
     # Repair cluster and wait
     cluster.node(2).start()

--- a/tests/integration/test_multi.py
+++ b/tests/integration/test_multi.py
@@ -65,7 +65,7 @@ def test_multi_exec(cluster):
 
     # MULTI does not go itself to the log
     assert conn.execute('MULTI') == b'OK'
-    assert r1.raft_info()['current_index'] == 1
+    assert r1.info()['raft_current_index'] == 1
 
     # MULTI cannot be nested
     with raises(ResponseError, match='.*MULTI calls can not be nested'):
@@ -77,9 +77,9 @@ def test_multi_exec(cluster):
     assert conn.execute('INCR', 'key') == b'QUEUED'
 
     # More validations
-    assert r1.raft_info()['current_index'] == 1
+    assert r1.info()['raft_current_index'] == 1
     assert conn.execute('EXEC') == [1, 2, 3]
-    assert r1.raft_info()['current_index'] == 2
+    assert r1.info()['raft_current_index'] == 2
 
     assert conn.execute('GET', 'key') == b'3'
 
@@ -100,13 +100,13 @@ def test_multi_exec_state_cleanup(cluster):
     c2.send_command('MULTI')
     assert c2.read_response() == b'OK'
 
-    assert r1.raft_info()['clients_in_multi_state'] == 2
+    assert r1.info()['raft_clients_in_multi_state'] == 2
 
     c1.disconnect()
     c2.disconnect()
 
     time.sleep(1)   # Not ideal
-    assert r1.raft_info()['clients_in_multi_state'] == 0
+    assert r1.info()['raft_clients_in_multi_state'] == 0
 
 
 def test_multi_exec_proxying(cluster):
@@ -120,7 +120,7 @@ def test_multi_exec_proxying(cluster):
 
     # Basic sanity
     n2 = cluster.node(2)
-    assert n2.raft_info()['current_index'] == 5
+    assert n2.info()['raft_current_index'] == 5
     conn = RawConnection(n2.client)
 
     assert conn.execute('MULTI') == b'OK'
@@ -128,7 +128,7 @@ def test_multi_exec_proxying(cluster):
     assert conn.execute('INCR', 'key') == b'QUEUED'
     assert conn.execute('INCR', 'key') == b'QUEUED'
     assert conn.execute('EXEC') == [1, 2, 3]
-    assert n2.raft_info()['current_index'] == 6
+    assert n2.info()['raft_current_index'] == 6
 
 
 def test_multi_mixed_ro_rw(cluster_factory):

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -92,7 +92,7 @@ def test_shard_group_replace(cluster):
         '1', '1',
         '8', '16383', '1',
         '1234567890123456789012345678901334567890', '3.3.3.3:3333',
-        cluster.leader_node().raft_info()['dbid'],
+        cluster.leader_node().info()['raft_dbid'],
         '1', '1',
         '0', '5', '1',
         '1234567890123456789012345678901234567890', '2.2.2.2:2222',
@@ -105,7 +105,8 @@ def test_shard_group_replace(cluster):
     def validate_slots(cluster_slots):
         assert len(cluster_slots) == 3
         for i in range(len(cluster_slots)):
-            if cluster_slots[i][2][2] == "{}00000001".format(cluster.leader_node().raft_info()['dbid']).encode():
+            if cluster_slots[i][2][2] == "{}00000001".format(
+                    cluster.leader_node().info()['raft_dbid']).encode():
                 assert cluster_slots[i][0] == 0, cluster_slots
                 assert cluster_slots[i][1] == 5, cluster_slots
             elif cluster_slots[i][2][2] == b"1234567890123456789012345678901234567890":
@@ -209,7 +210,8 @@ def test_shard_group_persistence(cluster):
     # Make sure received cluster slots is sane
     def validate_slots(cluster_slots):
         assert len(cluster_slots) == 2
-        local_id = "{}00000001".format(cluster.leader_node().raft_info()['dbid']).encode()
+        local_id = "{}00000001".format(
+            cluster.leader_node().info()['raft_dbid']).encode()
         for i in range(len(cluster_slots)):
             if cluster_slots[i][2][2] == local_id:
                 assert cluster_slots[i][0] == 0, cluster_slots
@@ -286,19 +288,23 @@ def test_shard_group_linking(cluster_factory):
         assert len(cluster_nodes) == 7  # blank entry at the end
         for i in [0, 1, 3, 4]:
             node = cluster_nodes[i].split(b' ')
-            if node[0] == "{}00000001".format(cluster1.leader_node().raft_info()['dbid']).encode():
+            if node[0] == "{}00000001".format(
+                    cluster1.leader_node().info()['raft_dbid']).encode():
                 assert node[2] == b"myself"
                 assert node[3] == b"master"
                 assert node[8] == b"0-1"
-            elif node[0] == "{}00000002".format(cluster1.leader_node().raft_info()['dbid']).encode():
+            elif node[0] == "{}00000002".format(
+                    cluster1.leader_node().info()['raft_dbid']).encode():
                 assert node[2] == b"noflags"
                 assert node[3] == b"slave"
                 assert node[8] == b"0-1"
-            elif node[0] == "{}00000001".format(cluster2.leader_node().raft_info()['dbid']).encode():
+            elif node[0] == "{}00000001".format(
+                    cluster2.leader_node().info()['raft_dbid']).encode():
                 assert node[2] == b"noflags"
                 assert node[3] == b"master"
                 assert node[8] == b"2-16383"
-            elif node[0] == "{}00000002".format(cluster2.leader_node().raft_info()['dbid']).encode():
+            elif node[0] == "{}00000002".format(
+                    cluster2.leader_node().info()['raft_dbid']).encode():
                 assert node[2] == b"noflags"
                 assert node[3] == b"slave"
                 assert node[8] == b"2-16383"

--- a/tests/monitor.sh
+++ b/tests/monitor.sh
@@ -3,7 +3,7 @@ NODES=3
 while true; do
     for n in $(seq $NODES); do
         echo "---- NODE $n ----"
-        redis-cli -p $(( 5000 + $n )) --raw raft.info
+        redis-cli -p $(( 5000 + $n )) info raft
     done
     echo "==="
     sleep 1

--- a/utils/create-cluster/create-cluster
+++ b/utils/create-cluster/create-cluster
@@ -90,8 +90,8 @@ then
     PORT=$((PORT+INSTANCE))
     while [ 1 ]; do
         clear
-        echo "`date` | $HOST:$PORT | RAFT.INFO"
-        ${REDIS_CLI_BINARY} -p $PORT --raw raft.info
+        echo "`date` | $HOST:$PORT | INFO raft"
+        ${REDIS_CLI_BINARY} -p $PORT info raft
         sleep 1
     done
     exit 0
@@ -164,12 +164,12 @@ echo "Usage: $0 [start|create|stop|watch|tail|clean|call|call-instance|stop-inst
 echo "start                     -- Launch RedisRaft Redis instances."
 echo "create                    -- Create a RedisRaft cluster."
 echo "stop                      -- Stop RedisRaft instances."
-echo "watch <id>                -- Show RAFT.INFO output first (default) or specified instance."
+echo "watch <id>                -- Show 'INFO raft' output first (default) or specified instance."
 echo "tail <id>                 -- Run tail -f of instance at base port + ID."
 echo "tailall                   -- Run tail -f for all the log files at once."
 echo "clean                     -- Remove all instances data, logs, configs."
 echo "clean-logs                -- Remove just instances logs."
 echo "call <cmd>                -- Call a command on all instances."
 echo "call-instance <id> <cmd>  -- Call a command on a specific instance."
-echo "start-instance <id>   -- Start a RedisRaft instance that has been stopped."
-echo "stop-instance <id>    -- Stop a RedisRaft instance."
+echo "start-instance <id>       -- Start a RedisRaft instance that has been stopped."
+echo "stop-instance <id>        -- Stop a RedisRaft instance."

--- a/utils/create-shard-groups/create-shard-groups
+++ b/utils/create-shard-groups/create-shard-groups
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-REDIS_PATH="${PWD}/../../../redis/src"
+REDIS_SERVER_BINARY="${PWD}/../../../redis/src/redis-server"
+REDIS_CLI_BINARY="${PWD}/../../../redis/src/redis-cli"
 REDISRAFT="${PWD}/../../redisraft.so"
 CREATE_CLUSTER_SCRIPT="${PWD}/../create-cluster/create-cluster"
 NUM_GROUPS=3
@@ -36,7 +37,8 @@ setup() {
         mkdir -p $dirname
 
         cat > $dirname/config.sh <<_END_
-REDIS_PATH=${REDIS_PATH}
+REDIS_SERVER_BINARY=${REDIS_SERVER_BINARY}
+REDIS_CLI_BINARY=${REDIS_CLI_BINARY}
 REDISRAFT=${REDISRAFT}
 PORT=5${group}00
 SHARDING=yes
@@ -92,7 +94,7 @@ watch() {
         while [ $((group <= NUM_GROUPS)) != "0" ]; do
             echo "------ shard-group $group ------"
             ( cd shard-group-$group && \
-                $CREATE_CLUSTER_SCRIPT call-instance 1 --raw RAFT.INFO ) | egrep '^node_id|^role|^current_term|^num_|^node|^log_entries|^current_index|^commit_index|^last_applied_index'
+                $CREATE_CLUSTER_SCRIPT call-instance 1 INFO raft_general )
             echo ""
             group=$((group + 1))
         done
@@ -142,7 +144,7 @@ case "$1" in
         echo "create                -- Create all clusters and configure as shard groups"
         echo "stop                  -- Stop all shard group clusters"
         echo "clean                 -- Remove all shard groups, instances data, logs, configs."
-        echo "watch                 -- Show abbreviated RAFT.INFO output from all groups."
+        echo "watch                 -- Show abbreviated 'INFO raft' output from all groups."
         echo "group <id> <cmd...>   -- Execute a create-cluster command on a specific group."
         exit 2
         ;;


### PR DESCRIPTION
Migrate `RAFT.INFO` into `INFO`. 

`RAFT.INFO` command will not exist anymore. `INFO` or `INFO raft` should be used instead after this commit. 

Extra things: 
- Fixed redis path issue in `create_shard_groups.sh` 
- Jepsen counterpart: https://github.com/RedisLabs/jepsen-redisraft/pull/2

Fixes: https://github.com/RedisLabs/redisraft/issues/219

Sample output:
```
ozan@ozan-x1:~/Desktop/redisraft/jepsen/docker$ redis-cli -p 5001 info raft
# raft_version
raft_version:255.255.255
raft_git_sha1:620af499

# raft_general
raft_dbid:9e552b06e6174378ab8035613b1ebe22
raft_node_id:1943749508
raft_state:up
raft_role:leader
raft_is_voting:yes
raft_leader_id:1943749508
raft_current_term:11
raft_num_nodes:3
raft_num_voting_nodes:3
raft_node1:id=928878968,state=connected,voting=yes,addr=localhost,port=5002,last_conn_secs=729,conn_errors=24,conn_oks=1
raft_node2:id=191801926,state=connected,voting=yes,addr=localhost,port=5003,last_conn_secs=725,conn_errors=60,conn_oks=1

# raft_log
raft_log_entries:127839
raft_current_index:127839
raft_commit_index:127839
raft_last_applied_index:127839
raft_file_size:14438914
raft_cache_memory_size:7953827
raft_cache_entries:72377
raft_client_attached_entries:0
raft_fsync_count:1
raft_fsync_max_microseconds:10
raft_fsync_avg_microseconds:10

# raft_snapshot
raft_snapshot_in_progress:no
raft_snapshots_loaded:0
raft_snapshots_created:0

# raft_clients
raft_clients_in_multi_state:0
raft_proxy_reqs:0
raft_proxy_failed_reqs:0
raft_proxy_failed_responses:0
raft_proxy_outstanding_reqs:0
```