### PR TITLE
tests that will have to pass for asking to work correctly

### DIFF
--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -403,7 +403,6 @@ def test_shard_group_refresh(cluster_factory):
     assert_after(check_slots, 10)
 
 
-
 def test_shard_group_no_slots(cluster):
     cluster.create(3, raft_args={
         'sharding': 'yes',
@@ -426,6 +425,7 @@ def test_shard_group_reshard_to_migrate(cluster):
 
     cluster.execute("set", "key", "value");
 
+    assert cluster.execute(
         'RAFT.SHARDGROUP', 'REPLACE',
         '2',
         '12345678901234567890123456789013',
@@ -493,4 +493,4 @@ def test_shard_group_reshard_to_import(cluster):
     assert cluster.execute("asking", "del", "key") == 1
 
     with raises(ResponseError, match="TRYAGAIN"):
-        cluster.execute("asking", "get", "key")
+        cluster.execute("asking", "get", "key1")

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -419,7 +419,6 @@ def test_shard_group_reshard_to_migrate(cluster):
 
     cluster.execute("set", "key", "value");
 
-    assert cluster.execute(
         'RAFT.SHARDGROUP', 'REPLACE',
         '2',
         '12345678901234567890123456789013',

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -64,6 +64,13 @@ def test_shard_group_sanity(cluster):
     with raises(ResponseError, match='MOVED [0-9]+ 1.1.1.1:111'):
         c.set('key', 'value')
 
+    # Follower redirect straight to remote shardgroup to
+    # avoid another redirect hop.
+    cluster.wait_for_unanimity()
+    cluster.node(2).wait_for_log_applied()  # to get shardgroup
+    with raises(ResponseError, match='MOVED [0-9]+ 1.1.1.1:111'):
+        cluster.node(2).client.set('key', 'value')
+
     cluster_slots = cluster.node(3).client.execute_command('CLUSTER', 'SLOTS')
 
     # Test by adding another fake shardgroup with same shardgroup id, should fail


### PR DESCRIPTION
simulates requests in the middle of a migration by creating keys with a stable slot, then converting the slot to a migrating or importing slot