### PR TITLE
Fix flaky non-quorum read test

### DIFF
--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -329,7 +329,6 @@ typedef struct RedisRaftCtx {
     int snapshot_child_fd;                       /* Pipe connected to snapshot child process */
     SnapshotFile outgoing_snapshot_file;         /* Snapshot file memory map to send to followers */
     RaftSnapshotInfo snapshot_info;              /* Current snapshot info */
-    long long debug_appendreq_delay;             /* 'RAFT.DEBUG delayappend micros' value to delay appendreq processing */
     struct RaftReq *debug_req;                   /* Current RAFT.DEBUG request context, if processing one */
     struct RaftReq *transfer_req;                /* RaftReq if a leader transfer is in progress */
     RedisModuleCommandFilter *registered_filter; /* Command filter is used for intercepting redis commands */


### PR DESCRIPTION
Use help from libraft to test non-quorum reads:

- Disable apply on a node.
- Make that node leader. It will commit the NOOP entry but won't be able to apply it.
- Non-quorum reads must fail.