### PR TITLE
migrate command

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -23,8 +23,11 @@
  * However if the key contains the {...} pattern, only the part between
  * { and } is hashed. This may be useful in the future to force certain
  * keys to be in the same node (assuming no resharding is in progress). */
-unsigned int keyHashSlot(const char *key, int keylen) {
-    int s, e; /* start-end indexes of { and } */
+unsigned int keyHashSlot(RedisModuleString * str) {
+    size_t keylen;
+    const char * key = RedisModule_StringPtrLen(str, &keylen);
+
+    size_t s, e; /* start-end indexes of { and } */
 
     for (s = 0; s < keylen; s++)
         if (key[s] == '{') break;
@@ -1200,9 +1203,9 @@ RRStatus computeHashSlot(RedisRaftCtx *rr,
         int num_keys = 0;
         int *keyindex = RedisModule_GetCommandKeys(rr->ctx, cmd->argv, cmd->argc, &num_keys);
         for (int j = 0; j < num_keys; j++) {
-            size_t key_len;
-            const char *key = RedisModule_StringPtrLen(cmd->argv[keyindex[j]], &key_len);
-            int thisslot = (int) keyHashSlot(key, (int) key_len);
+            RedisModuleString *key = cmd->argv[keyindex[j]];
+
+            int thisslot = (int) keyHashSlot(key);
 
             if (*slot == -1) {
                 /* First key */

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -23,9 +23,10 @@
  * However if the key contains the {...} pattern, only the part between
  * { and } is hashed. This may be useful in the future to force certain
  * keys to be in the same node (assuming no resharding is in progress). */
-unsigned int keyHashSlot(RedisModuleString * str) {
+unsigned int keyHashSlot(RedisModuleString *str)
+{
     size_t keylen;
-    const char * key = RedisModule_StringPtrLen(str, &keylen);
+    const char *key = RedisModule_StringPtrLen(str, &keylen);
 
     size_t s, e; /* start-end indexes of { and } */
 
@@ -784,7 +785,7 @@ ShardGroup *getShardGroupById(RedisRaftCtx *rr, const char *id)
 {
     ShardingInfo *si = rr->sharding_info;
 
-    return RedisModule_DictGetC(si->shard_group_map, (char *) id, strlen(id), NULL);
+    return RedisModule_DictGetC(si->shard_group_map, (void *) id, strlen(id), NULL);
 }
 
 /* Update an existing ShardGroup in the active ShardingInfo.

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -47,14 +47,6 @@ unsigned int keyHashSlot(RedisModuleString * str) {
     return crc16_ccitt(key+s+1,e-s-1) & 0x3FFF;
 }
 
-unsigned int KeyHashSlotRedisString(RedisModuleString *s)
-{
-    size_t key_len;
-    const char *key_str = RedisModule_StringPtrLen(s, &key_len);
-    return keyHashSlot(key_str, (int) key_len);
-}
-
-
 /* -----------------------------------------------------------------------------
  * ShardGroup Handling
  * -------------------------------------------------------------------------- */

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -785,11 +785,11 @@ RRStatus ShardingInfoValidateShardGroup(RedisRaftCtx *rr, ShardGroup *new_sg)
     return RR_OK;
 }
 
-static ShardGroup *getShardGroupById(RedisRaftCtx *rr, char *id)
+ShardGroup *getShardGroupById(RedisRaftCtx *rr, const char *id)
 {
     ShardingInfo *si = rr->sharding_info;
 
-    return RedisModule_DictGetC(si->shard_group_map, id, strlen(id), NULL);
+    return RedisModule_DictGetC(si->shard_group_map, (char *) id, strlen(id), NULL);
 }
 
 /* Update an existing ShardGroup in the active ShardingInfo.

--- a/src/migrate.c
+++ b/src/migrate.c
@@ -267,7 +267,7 @@ static void transferKeys(Connection *conn)
     argv_len[1] = n;
     argv[2] = RedisModule_Alloc(32);
     // FIXME needs to be taken from sg (in raft.import pr))
-    n = snprintf(argv[1], 32, "%u", 0);
+    n = snprintf(argv[1], 32, "%llu", (long long unsigned) 0);
     argv_len[2] = n;
 
     for (size_t i = 0; i < req->r.migrate_keys.num_keys; i++) {

--- a/src/migrate.c
+++ b/src/migrate.c
@@ -256,46 +256,32 @@ static void transferKeys(Connection *conn)
     }
 
     // raft.import term magic <key1_name> <key1_serialized> ... <keyn_name> <keyn_serialized>
-    int argc = 3 + (req->r.migrate_keys.num_keys * 2);
+    int argc = 3 + (req->r.migrate_keys.num_serialized_keys * 2);
     char **argv = RedisModule_Calloc(argc, sizeof(char *));
     size_t *argv_len = RedisModule_Calloc(argc, sizeof(size_t));
 
     argv[0] = RedisModule_Strdup("RAFT.IMPORT");
     argv_len[0] = strlen("RAFT.IMPORT");
     argv[1] = RedisModule_Alloc(32);
-    int n = snprintf(argv[1], 64, "%ld", raft_get_current_term(rr->raft));
+    int n = snprintf(argv[1], 64, "%ld", req->r.migrate_keys.migrate_term);
     argv_len[1] = n;
     argv[2] = RedisModule_Alloc(32);
 
     for (size_t i = 0; i < req->r.migrate_keys.num_keys; i++) {
+        if (req->r.migrate_keys.keys_serialized[i] == NULL) {
+            continue;
+        }
+
         size_t key_len;
         const char * key = RedisModule_StringPtrLen(req->r.migrate_keys.keys[i], &key_len);
         argv[3 + (i*2)] = RedisModule_Strdup(key);
         argv_len[3+ (i*2)] = key_len;
 
-        enterRedisModuleCall();
-        RedisModuleCallReply * reply = RedisModule_Call(rr->ctx, "DUMP", "c", key);
-        exitRedisModuleCall();
-
-        if (reply && RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_STRING) {
-            size_t str_len;
-            const char * str = RedisModule_CallReplyStringPtr(reply, &str_len);
-            argv[3 + (i*2) + 1] = RedisModule_Alloc(str_len);
-            memcpy(argv[3 + (i*2) + 1], str, str_len);
-            argv_len[3 + (i*2) + 1] = str_len;
-            RedisModule_FreeCallReply(reply);
-        } else {
-            if (reply) {
-                LOG_WARNING("unexpected response type = %d", RedisModule_CallReplyType(reply));
-                RedisModule_FreeCallReply(reply);
-            } else {
-                LOG_WARNING("didn't get a reply!");
-            }
-            ConnAsyncTerminate(conn);
-            RedisModule_ReplyWithError(req->ctx, "ERR see logs");
-            RaftReqFree(req);
-            goto exit;
-        }
+        size_t str_len;
+        const char * str = RedisModule_StringPtrLen(req->r.migrate_keys.keys_serialized[i], &str_len);
+        argv[3 + (i*2) + 1] = RedisModule_Alloc(str_len);
+        memcpy(argv[3 + (i*2) + 1], str, str_len);
+        argv_len[3 + (i*2) + 1] = str_len;
     }
 
     if (redisAsyncCommandArgv(ConnGetRedisCtx(conn), transferKeysResponse, conn, argc, (const char **) argv, argv_len) != REDIS_OK) {
@@ -303,7 +289,6 @@ static void transferKeys(Connection *conn)
         ConnMarkDisconnected(conn);
     }
 
-exit:
     for(int i = 0; i < argc; i++) {
         RedisModule_Free(argv[i]);
     }
@@ -320,11 +305,42 @@ void MigrateKeys(RedisRaftCtx *rr, RaftReq *req)
     ShardGroup * sg = getShardGroupById(rr, req->r.migrate_keys.shardGroupId);
     if (sg == NULL) {
         RedisModule_ReplyWithError(req->ctx, "ERR couldn't resolve shardgroup id");
-        RaftReqFree(req);
-        return;
+        goto exit;
+    }
+    req->r.migrate_keys.migrate_term = raft_get_current_term(rr->raft);
+
+    for (size_t i = 0; i < req->r.migrate_keys.num_keys; i++) {
+        RedisModuleString *key = req->r.migrate_keys.keys[i];
+
+        if (RedisModule_KeyExists(req->ctx, key)) {
+            req->r.migrate_keys.num_serialized_keys++;
+
+            enterRedisModuleCall();
+            RedisModuleCallReply *reply = RedisModule_Call(rr->ctx, "DUMP", "c", key);
+            exitRedisModuleCall();
+
+            if (reply && RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_STRING) {
+                req->r.migrate_keys.keys_serialized[i] = RedisModule_CreateStringFromCallReply(reply);
+            } else {
+                if (reply) {
+                    LOG_WARNING("unexpected response type = %d", RedisModule_CallReplyType(reply));
+                    RedisModule_FreeCallReply(reply);
+                } else {
+                    LOG_WARNING("didn't get a reply!");
+                }
+                RedisModule_ReplyWithError(req->ctx, "ERR see logs");
+                goto exit;
+            }
+        }
     }
 
-    for (unsigned int i = 0; i < sg->nodes_num; i++) {
+    /* nothing to migrate, return quickly */
+    if (req->r.migrate_keys.num_serialized_keys == 0) {
+        RedisModule_ReplyWithCString(req->ctx, "OK");
+        goto exit;
+    }
+
+     for (unsigned int i = 0; i < sg->nodes_num; i++) {
         LOG_WARNING("MigrateKeys: adding %s:%d", sg->nodes[i].addr.host, sg->nodes[i].addr.port);
         NodeAddrListAddElement(&state->addr, &sg->nodes[i].addr);
     }
@@ -333,4 +349,8 @@ void MigrateKeys(RedisRaftCtx *rr, RaftReq *req)
     char *username = req->r.migrate_keys.auth_username;
     char *password = req->r.migrate_keys.auth_password;
     state->conn = ConnCreate(rr, state, joinLinkIdleCallback, joinLinkFreeCallback, username, password);
+    return;
+
+exit:
+    RaftReqFree(req);
 }

--- a/src/migrate.c
+++ b/src/migrate.c
@@ -342,7 +342,7 @@ void MigrateKeys(RedisRaftCtx *rr, RaftReq *req)
         goto exit;
     }
 
-     for (unsigned int i = 0; i < sg->nodes_num; i++) {
+    for (unsigned int i = 0; i < sg->nodes_num; i++) {
         LOG_WARNING("MigrateKeys: adding %s:%d", sg->nodes[i].addr.host, sg->nodes[i].addr.port);
         NodeAddrListAddElement(&state->addr, &sg->nodes[i].addr);
     }

--- a/src/migrate.c
+++ b/src/migrate.c
@@ -175,3 +175,162 @@ fail:
     RaftReqFree(req);
     return REDISMODULE_OK;
 }
+
+void raftAppendRaftDeleteEntry(RedisRaftCtx *rr, RaftReq *req)
+{
+    raft_entry_resp_t response;
+
+    raft_entry_t *entry = RaftRedisLockKeysSerialize(req->r.migrate_keys.keys, req->r.migrate_keys.num_keys);
+    entry->id = rand();
+    entry->type = RAFT_LOGTYPE_DELETE_UNLOCK_KEYS;
+    entryAttachRaftReq(rr, entry, req);
+
+    int e = raft_recv_entry(rr->raft, entry, &response);
+    if (e != 0) {
+        replyRaftError(req->ctx, e);
+        entryDetachRaftReq(rr, entry);
+        raft_entry_release(entry);
+        goto exit;
+    }
+
+    raft_entry_release(entry);
+
+    /* Unless applied by raft_apply_all() (and freed by it), the request
+     * is pending so we don't free it or unblock the client.
+     */
+    return;
+
+    exit:
+    RaftReqFree(req);
+}
+
+static void transferKeysResponse(redisAsyncContext *c, void *r, void *privdata)
+{
+    LOG_WARNING("calling transferKeysResponse");
+    Connection *conn = privdata;
+    JoinLinkState *state = ConnGetPrivateData(conn);
+    RedisRaftCtx *rr = ConnGetRedisRaftCtx(conn);
+    RaftReq *req = state->req;
+
+    redisReply *reply = r;
+
+    if (!reply) {
+        LOG_WARNING("RAFT.IMPORT failed: connection dropped.");
+        ConnMarkDisconnected(conn);
+    } else if (reply->type == REDIS_REPLY_ERROR) {
+        ConnAsyncTerminate(conn);
+
+        LOG_WARNING("RAFT.IMPORT failed: %.*s", (int) reply->len, reply->str);
+        RedisModule_ReplyWithError(req->ctx, "ERR: Migrate failed importing keys into remote cluster, try again");
+        RaftReqFree(req);
+    } else if (reply->type != REDIS_REPLY_STATUS || reply->len != 2 || strncmp(reply->str, "OK", 2)) {
+        ConnAsyncTerminate(conn);
+
+        /* FIXME: above should be changed to string eventually? */
+        LOG_WARNING("RAFT.IMPORT unexpected response: type = %d (wanted %d), len = %ld, response = %.*s", reply->type, REDIS_REPLY_STATUS, reply->len, (int) reply->len, reply->str);
+        RedisModule_ReplyWithError(req->ctx, "ERR: received unexpected response from remote cluster, see logs");
+        RaftReqFree(req);
+    } else {
+        ConnAsyncTerminate(conn);
+        raftAppendRaftDeleteEntry(rr, req);
+    }
+
+    redisAsyncDisconnect(c);
+}
+
+static void transferKeys(Connection *conn)
+{
+    LOG_WARNING("calling transferKeys");
+    RedisRaftCtx *rr = ConnGetRedisRaftCtx(conn);
+    JoinLinkState *state = ConnGetPrivateData(conn);
+    RaftReq *req = state->req;
+
+    /* Connection is not good?  Terminate and continue */
+    if (!ConnIsConnected(conn)) {
+        return;
+    }
+
+    ShardGroup * sg = getShardGroupById(rr, req->r.migrate_keys.shardGroupId);
+    if (sg == NULL) {
+        //FIXME: error
+    }
+
+    // raft.import term magic <key1_name> <key1_serialized> ... <keyn_name> <keyn_serialized>
+    int argc = 3 + (req->r.migrate_keys.num_keys * 2);
+    char **argv = RedisModule_Calloc(argc, sizeof(char *));
+    size_t *argv_len = RedisModule_Calloc(argc, sizeof(size_t));
+
+    argv[0] = RedisModule_Strdup("RAFT.IMPORT");
+    argv_len[0] = strlen("RAFT.IMPORT");
+    argv[1] = RedisModule_Alloc(32);
+    int n = snprintf(argv[1], 64, "%ld", raft_get_current_term(rr->raft));
+    argv_len[1] = n;
+    argv[2] = RedisModule_Alloc(32);
+
+    for (size_t i = 0; i < req->r.migrate_keys.num_keys; i++) {
+        size_t key_len;
+        const char * key = RedisModule_StringPtrLen(req->r.migrate_keys.keys[i], &key_len);
+        argv[3 + (i*2)] = RedisModule_Strdup(key);
+        argv_len[3+ (i*2)] = key_len;
+
+        enterRedisModuleCall();
+        RedisModuleCallReply * reply = RedisModule_Call(rr->ctx, "DUMP", "c", key);
+        exitRedisModuleCall();
+
+        if (reply && RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_STRING) {
+            size_t str_len;
+            const char * str = RedisModule_CallReplyStringPtr(reply, &str_len);
+            argv[3 + (i*2) + 1] = RedisModule_Alloc(str_len);
+            memcpy(argv[3 + (i*2) + 1], str, str_len);
+            argv_len[3 + (i*2) + 1] = str_len;
+            RedisModule_FreeCallReply(reply);
+        } else {
+            if (reply) {
+                LOG_WARNING("unexpected response type = %d", RedisModule_CallReplyType(reply));
+                RedisModule_FreeCallReply(reply);
+            } else {
+                LOG_WARNING("didn't get a reply!");
+            }
+            ConnAsyncTerminate(conn);
+            RedisModule_ReplyWithError(req->ctx, "ERR see logs");
+            RaftReqFree(req);
+            goto exit;
+        }
+    }
+
+    if (redisAsyncCommandArgv(ConnGetRedisCtx(conn), transferKeysResponse, conn, argc, (const char **) argv, argv_len) != REDIS_OK) {
+        redisAsyncDisconnect(ConnGetRedisCtx(conn));
+        ConnMarkDisconnected(conn);
+    }
+
+exit:
+    for(int i = 0; i < argc; i++) {
+        RedisModule_Free(argv[i]);
+    }
+    RedisModule_Free(argv);
+    RedisModule_Free(argv_len);
+}
+
+void MigrateKeys(RedisRaftCtx *rr, RaftReq *req)
+{
+    JoinLinkState *state = RedisModule_Calloc(1, sizeof(*state));
+    state->type = "migrate";
+    state->connect_callback = transferKeys;
+    time(&(state->start));
+    ShardGroup * sg = getShardGroupById(rr, req->r.migrate_keys.shardGroupId);
+    if (sg == NULL) {
+        RedisModule_ReplyWithError(req->ctx, "ERR couldn't resolve shardgroup id");
+        RaftReqFree(req);
+        return;
+    }
+
+    for (unsigned int i = 0; i < sg->nodes_num; i++) {
+        LOG_WARNING("MigrateKeys: adding %s:%d", sg->nodes[i].addr.host, sg->nodes[i].addr.port);
+        NodeAddrListAddElement(&state->addr, &sg->nodes[i].addr);
+    }
+    state->req = req;
+
+    char *username = req->r.migrate_keys.auth_username;
+    char *password = req->r.migrate_keys.auth_password;
+    state->conn = ConnCreate(rr, state, joinLinkIdleCallback, joinLinkFreeCallback, username, password);
+}

--- a/src/raft.c
+++ b/src/raft.c
@@ -452,7 +452,8 @@ static void unlockDeleteKeys(RedisRaftCtx *rr, raft_entry_t *entry)
     keys = RaftRedisLockKeysDeserialize(entry->data, entry->data_len, &num_keys);
 
     enterRedisModuleCall();
-    RedisModuleCallReply *reply = RedisModule_Call(redis_raft.ctx, "del", "v", keys, num_keys);
+    RedisModuleCallReply *reply;
+    RedisModule_Assert((reply = RedisModule_Call(redis_raft.ctx, "del", "v", keys, num_keys)) != NULL);
     exitRedisModuleCall();
     RedisModule_FreeCallReply(reply);
 

--- a/src/raft.c
+++ b/src/raft.c
@@ -385,7 +385,7 @@ static void lockKeys(RedisRaftCtx *rr, raft_entry_t *entry)
                 if (req) {
                     RedisModule_ReplyWithError(req->ctx, "ERR keys don't all belong to same slot");
                 }
-                goto exit;
+                goto error;
             }
         }
     }
@@ -394,7 +394,7 @@ static void lockKeys(RedisRaftCtx *rr, raft_entry_t *entry)
         if (req) {
             RedisModule_ReplyWithSimpleString(req->ctx, "OK");
         }
-        goto exit;
+        goto error;
     }
 
     ShardingInfo *si = rr->sharding_info;
@@ -402,14 +402,14 @@ static void lockKeys(RedisRaftCtx *rr, raft_entry_t *entry)
         if (req) {
             RedisModule_ReplyWithError(req->ctx, "ERR not migratable keys");
         }
-        goto exit;
+        goto error;
     }
 
     if (!si->importing_slots_map[slot] || si->importing_slots_map[slot]->local) {
         if (req) {
             RedisModule_ReplyWithError(req->ctx, "ERR not importable keys");
         }
-        goto exit;
+        goto error;
     }
 
     for (size_t i = 0; i < num_keys; i++) {
@@ -426,7 +426,14 @@ static void lockKeys(RedisRaftCtx *rr, raft_entry_t *entry)
         memcpy(req->r.migrate_keys.shardGroupId, si->importing_slots_map[slot]->id, RAFT_DBID_LEN);
         /* currently, we just return, but eventually this is where should kick off migration of the keys */
         RedisModule_ReplyWithSimpleString(req->ctx, "OK");
+        RaftReqFree(req);
 //        MigrateKeys(rr, req);
+        goto exit;
+    }
+
+error:
+    if (req) {
+        RaftReqFree(req);
     }
 
 exit:
@@ -434,10 +441,6 @@ exit:
         RedisModule_FreeString(rr->ctx, keys[i]);
     }
     RedisModule_Free(keys);
-
-    if (req) {
-        RaftReqFree(req);
-    }
 }
 
 static void unlockDeleteKeys(RedisRaftCtx *rr, raft_entry_t *entry)

--- a/src/raft.c
+++ b/src/raft.c
@@ -1462,6 +1462,15 @@ void RaftReqFree(RaftReq *req)
             RedisModule_Free(req->r.migrate_keys.keys);
             req->r.migrate_keys.keys = NULL;
         }
+        if (req->r.migrate_keys.keys_serialized) {
+            for (size_t i = 0; i < req->r.migrate_keys.num_keys; i++) {
+                if (req->r.migrate_keys.keys_serialized[i] != NULL) {
+                    RedisModule_FreeString(req->ctx, req->r.migrate_keys.keys_serialized[i]);
+                }
+            }
+            RedisModule_Free(req->r.migrate_keys.keys_serialized);
+            req->r.migrate_keys.keys_serialized = NULL;
+        }
     }
 
     if (req->ctx) {

--- a/src/raft.c
+++ b/src/raft.c
@@ -405,7 +405,7 @@ static void lockKeys(RedisRaftCtx *rr, raft_entry_t *entry)
         goto exit;
     }
 
-    if (!si->importing_slots_map[slot] || si->migrating_slots_map[slot]->local) {
+    if (!si->importing_slots_map[slot] || si->importing_slots_map[slot]->local) {
         if (req) {
             RedisModule_ReplyWithError(req->ctx, "ERR not importable keys");
         }

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -510,6 +510,7 @@ static void handleMigrateCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedi
     int e = raft_recv_entry(rr->raft, entry, &response);
     if (e != 0) {
         replyRaftError(req->ctx, e);
+        RaftReqFree(req);
         entryDetachRaftReq(rr, entry);
     }
 

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -486,7 +486,7 @@ static RaftReq * cmdToMigrate(RedisRaftCtx *rr, RedisModuleCtx * ctx, RaftRedisC
     /* Overwrite with new data */
     req->r.migrate_keys.num_keys = num_keys;
     req->r.migrate_keys.keys = keys;
-    req->r.migrate_keys.keys_serialized = RedisModule_Calloc(cmd->argc - idx, sizeof(RedisModuleString *));
+    req->r.migrate_keys.keys_serialized = RedisModule_Calloc(num_keys, sizeof(RedisModuleString *));
     memcpy(req->r.migrate_keys.auth_username, migrationInfo->username, 255);
     memcpy(req->r.migrate_keys.auth_password, migrationInfo->password, 255);
 

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -485,6 +485,10 @@ exit:
 
 static void handleMigrateCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommand *cmd)
 {
+    if (checkLeader(rr, ctx, NULL) == RR_ERROR) {
+        return;
+    }
+
     RaftReq * req;
     if ((req = cmdToMigrate(rr, ctx, cmd)) == NULL) {
         return;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -710,6 +710,8 @@ RRStatus checkRaftNotLoading(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 RRStatus checkRaftUninitialized(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 RRStatus checkRaftState(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 void replyRedirect(RedisModuleCtx *ctx, int slot, NodeAddr *addr);
+void replyCrossSlot(RedisModuleCtx *ctx);
+void replyWithFormatErrorString(RedisModuleCtx *ctx, const char * fmt, ...);
 bool parseMovedReply(const char *str, NodeAddr *addr);
 void replyAsk(RedisRaftCtx *rr, RedisModuleCtx *ctx, int slot);
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -875,7 +875,7 @@ void ShardGroupLink(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **a
 void ShardGroupGet(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 void ShardGroupAdd(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 void ShardGroupReplace(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-unsigned int KeyHashSlotRedisString(RedisModuleString *s);
+unsigned int keyHashSlot(RedisModuleString *s);
 ShardGroup *getShardGroupById(RedisRaftCtx *rr, const char *id);
 
 /* join.c */
@@ -884,7 +884,7 @@ void JoinCluster(RedisRaftCtx *rr, NodeAddrListElement *el, RaftReq *req, void (
 /* migrate.c */
 void importKeys(RedisRaftCtx *rr, raft_entry_t *entry);
 int cmdRaftImport(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-
+void MigrateKeys(RedisRaftCtx *rr, RaftReq *req);
 
 /* commands.c */
 RRStatus CommandSpecInit(RedisModuleCtx *ctx, RedisRaftConfig *config);

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -603,6 +603,9 @@ typedef struct RaftReq {
             char auth_password[256];
             size_t num_keys;
             RedisModuleString **keys;
+            RedisModuleString **keys_serialized;
+            size_t num_serialized_keys;
+            raft_term_t migrate_term;
         } migrate_keys;
     } r;
 } RaftReq;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -347,6 +347,7 @@ typedef struct RedisRaftCtx {
     unsigned long snapshots_created;             /* Number of snapshots created */
     char *resp_call_fmt;                         /* Format string to use in RedisModule_Call(), Redis version-specific */
     int entered_eval;                            /* handling a lua script */
+    RedisModuleDict *locked_keys;                /* keys thar have been locked for migration */
 #ifdef HAVE_TLS
     SSL_CTX *ssl;                                /* OpenSSL context for use by hiredis */
 #endif
@@ -462,6 +463,8 @@ enum RaftReqType {
     RR_SHARDGROUP_LINK,
     RR_TRANSFER_LEADER,
     RR_IMPORT_KEYS,
+    RR_MIGRATE_KEYS,
+    RR_DELETE_UNLOCK_KEYS,
     RR_RAFTREQ_MAX
 };
 
@@ -545,6 +548,8 @@ typedef struct ShardGroup {
 #define RAFT_LOGTYPE_ADD_SHARDGROUP      (RAFT_LOGTYPE_NUM+1)
 #define RAFT_LOGTYPE_UPDATE_SHARDGROUP   (RAFT_LOGTYPE_NUM+2)
 #define RAFT_LOGTYPE_REPLACE_SHARDGROUPS (RAFT_LOGTYPE_NUM+3)
+#define RAFT_LOGTYPE_LOCK_KEYS           (RAFT_LOGTYPE_NUM+4)
+#define RAFT_LOGTYPE_DELETE_UNLOCK_KEYS  (RAFT_LOGTYPE_NUM+5)
 #define RAFT_LOGTYPE_IMPORT_KEYS         (RAFT_LOGTYPE_NUM+6)
 
 /* Sharding information, used when cluster_mode is enabled and multiple
@@ -592,6 +597,13 @@ typedef struct RaftReq {
             int delay;
         } debug;
         ImportKeys import_keys;
+        struct {
+            char shardGroupId[RAFT_DBID_LEN+1];
+            char auth_username[256];
+            char auth_password[256];
+            size_t num_keys;
+            RedisModuleString **keys;
+        } migrate_keys;
     } r;
 } RaftReq;
 
@@ -721,6 +733,8 @@ RaftRedisCommand *RaftRedisCommandArrayExtend(RaftRedisCommandArray *target);
 void RaftRedisCommandArrayMove(RaftRedisCommandArray *target, RaftRedisCommandArray *source);
 raft_entry_t *RaftRedisSerializeImport(const ImportKeys *import_keys);
 RRStatus RaftRedisDeserializeImport(ImportKeys * target, const void *buf, size_t buf_size);
+raft_entry_t *RaftRedisLockKeysSerialize(RedisModuleString **argv, size_t argc);
+RedisModuleString ** RaftRedisLockKeysDeserialize(const void *buf, size_t buf_size, size_t *num_keys);
 
 /* raft.c */
 RRStatus RedisRaftInit(RedisModuleCtx *ctx, RedisRaftCtx *rr, RedisRaftConfig *config);
@@ -859,6 +873,7 @@ void ShardGroupGet(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 void ShardGroupAdd(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 void ShardGroupReplace(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 unsigned int KeyHashSlotRedisString(RedisModuleString *s);
+ShardGroup *getShardGroupById(RedisRaftCtx *rr, const char *id);
 
 /* join.c */
 void JoinCluster(RedisRaftCtx *rr, NodeAddrListElement *el, RaftReq *req, void (*complete_callback)(RaftReq *req));

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -593,6 +593,17 @@ int raftLoadSnapshot(raft_server_t* raft, void *user_data, raft_index_t index, r
 
 RedisModuleType *RedisRaftType = NULL;
 
+void LockedKeysRDBLoad(RedisModuleIO *rdb)
+{
+    size_t count = RedisModule_LoadUnsigned(rdb);
+
+    for (size_t i = 0; i < count; i++) {
+        RedisModuleString * key = RedisModule_LoadString(rdb);
+        RedisModule_DictSet(redis_raft.locked_keys, key, NULL);
+        RedisModule_FreeString(NULL, key);
+    }
+}
+
 static int rdbLoadSnapshotInfo(RedisModuleIO *rdb, int encver, int when)
 {
     size_t len;
@@ -664,8 +675,29 @@ static int rdbLoadSnapshotInfo(RedisModuleIO *rdb, int encver, int when)
     /* Load ShardingInfo */
     ShardingInfoRDBLoad(rdb);
 
+    /* Load locked_keys dict */
+    LockedKeysRDBLoad(rdb);
+
     info->loaded = true;
     return REDISMODULE_OK;
+}
+
+void LockedKeysRDBSave(RedisModuleIO *rdb)
+{
+    RedisRaftCtx *rr = &redis_raft;
+    RedisModuleDict * dict = rr->locked_keys;
+
+    RedisModule_SaveUnsigned(rdb, RedisModule_DictSize(dict));
+
+    RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(dict, "^", NULL, 0);
+
+    const char *key;
+    size_t key_len;
+
+    while ((key = RedisModule_DictNextC(iter, &key_len, NULL)) != NULL) {
+        RedisModule_SaveStringBuffer(rdb, key, key_len);
+    }
+    RedisModule_DictIteratorStop(iter);
 }
 
 static void rdbSaveSnapshotInfo(RedisModuleIO *rdb, int when)
@@ -705,6 +737,9 @@ static void rdbSaveSnapshotInfo(RedisModuleIO *rdb, int when)
 
     /* Save ShardingInfo */
     ShardingInfoRDBSave(rdb);
+
+    /* Save LockedKeys dict */
+    LockedKeysRDBSave(rdb);
 }
 
 /* Do nothing -- AOF should never be used with RedisRaft, but we have to specify


### PR DESCRIPTION
1) parses migrate command and creates an entry committed to raft log
2) adds raft log entries to lock keys and unlock/delete keys

the next PR does the actual migration with the raft.import command to the remote cluster.