### PR TITLE
refactor intercept cluster command handling for getkeysinslot

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1488,7 +1488,14 @@ static void handleGetKeysInSlot(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedis
         return;
     }
 
-    ReadOnlyCommand(rr, ctx, cmds);
+    /* Check that we're part of a bootstrapped cluster and not in the middle of
+     * joining or loading data.
+     */
+    if (checkRaftState(rr, ctx) == RR_ERROR) {
+        return;
+    }
+
+    ReadOnlyCommand(rr, ctx, cmds, true);
 }
 
 /* Process CLUSTER commands, as intercepted earlier by the Raft module.

--- a/src/commands.c
+++ b/src/commands.c
@@ -130,6 +130,7 @@ RRStatus CommandSpecInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
             { "pubsub",                 CMD_SPEC_DONT_INTERCEPT },
             { "slowlog",                CMD_SPEC_DONT_INTERCEPT },
             { "acl",                    CMD_SPEC_DONT_INTERCEPT },
+            { "info",                   CMD_SPEC_DONT_INTERCEPT },
 
             /* RedisRaft Commands */
             { "raft",                         CMD_SPEC_DONT_INTERCEPT },

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1648,15 +1648,14 @@ __attribute__((__unused__)) int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisMod
     redis_raft_log_ctx = RedisModule_GetDetachedThreadSafeContext(ctx);
     RedisModule_RegisterInfoFunc(ctx, handleInfo);
 
-    /* Sanity check that not running with cluster_enabled */
-/*    RedisModuleServerInfoData *info = RedisModule_GetServerInfo(ctx, "cluster");
+    /* Sanity check that we are running with cluster_enabled */
+    RedisModuleServerInfoData *info = RedisModule_GetServerInfo(ctx, "cluster");
     int cluster_enabled = (int) RedisModule_ServerInfoGetFieldSigned(info, "cluster_enabled", NULL);
     RedisModule_FreeServerInfo(ctx, info);
-    if (cluster_enabled) {
-        LOG_WARNING("Redis Raft requires Redis not be started with cluster_enabled!");
+    if (!cluster_enabled) {
+        LOG_WARNING("Redis Raft requires Redis be started with cluster_enabled!");
         return REDISMODULE_ERR;
     }
-*/
 
     /* Report arguments */
     size_t str_len = 1024;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -732,7 +732,7 @@ RRStatus formatExactMemorySize(unsigned long value, char *buf, size_t buf_size);
 void handleRMCallError(RedisModuleCtx *reply_ctx, int ret_errno, const char *cmd, size_t cmdlen);
 void AddBasicLocalShardGroup(RedisRaftCtx *rr);
 void HandleAsking(RaftRedisCommandArray *cmds);
-void ReadOnlyCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds);
+void ReadOnlyCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds, bool quorum_reads);
 
 /* log.c */
 RaftLog *RaftLogCreate(const char *filename, const char *dbid, raft_term_t snapshot_term, raft_index_t snapshot_index, RedisRaftConfig *config);
@@ -779,6 +779,7 @@ void ConfigSet(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, 
 void ConfigGet(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 RRStatus ConfigReadFromRedis(RedisRaftCtx *rr);
 RRStatus ConfigureRedis(RedisModuleCtx *ctx);
+RRStatus ConfigureRedisCluster(RedisModuleCtx *ctx);
 void updateTLSConfig(RedisModuleCtx *ctx, RedisRaftConfig *config);
 
 /* snapshot.c */

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -732,6 +732,7 @@ RRStatus formatExactMemorySize(unsigned long value, char *buf, size_t buf_size);
 void handleRMCallError(RedisModuleCtx *reply_ctx, int ret_errno, const char *cmd, size_t cmdlen);
 void AddBasicLocalShardGroup(RedisRaftCtx *rr);
 void HandleAsking(RaftRedisCommandArray *cmds);
+void ReadOnlyCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds);
 
 /* log.c */
 RaftLog *RaftLogCreate(const char *filename, const char *dbid, raft_term_t snapshot_term, raft_index_t snapshot_index, RedisRaftConfig *config);
@@ -822,7 +823,7 @@ void ShardGroupTerm(ShardGroup *sg);
 ShardGroup *ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int base_argv_idx, int *num_elems);
 ShardGroup **ShardGroupsParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *len);
 RRStatus computeHashSlotOrReplyError(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds, int *slot);
-void ShardingHandleClusterCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommand *cmd);
+void ShardingHandleClusterCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds);
 void ShardingInfoInit(RedisRaftCtx *rr);
 void ShardingInfoReset(RedisRaftCtx *rr);
 RRStatus ShardingInfoValidateShardGroup(RedisRaftCtx *rr, ShardGroup *new_sg);

--- a/src/util.c
+++ b/src/util.c
@@ -414,9 +414,9 @@ static void handleReadOnlyCommand(void *arg, int can_read)
     RaftReqFree(req);
 }
 
-void ReadOnlyCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds)
+void ReadOnlyCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds, bool quorum_reads)
 {
-    if (rr->config->quorum_reads) {
+    if (quorum_reads) {
         RaftReq *req = RaftReqInit(ctx, RR_REDISCOMMAND);
         RaftRedisCommandArrayMove(&req->r.redis.cmds, cmds);
         raft_queue_read_request(rr->raft, handleReadOnlyCommand, req);

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -71,7 +71,8 @@ class RedisRaft(object):
         self.keepfiles = config.keepfiles
         self.args = config.args.copy() if config.args else []
 
-        self.args += ['--port', str(0) if config.tls else str(port),
+        self.args += ['--cluster-enabled', 'yes',
+                      '--port', str(0) if config.tls else str(port),
                       '--bind', '0.0.0.0',
                       '--dir', self.serverdir,
                       '--dbfilename', self._dbfilename,


### PR DESCRIPTION
we now treat cluster getkeysinslot as a readonly command so it can be used by clients issues migrate commands