### PR TITLE
implement raft.scan to provide a scan that can filter by slots

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -11,42 +11,6 @@
 #include <stdlib.h>
 
 #include "redisraft.h"
-#include "crc16.h"
-
-/* -----------------------------------------------------------------------------
- * Hashing code - copied directly from Redis.
- * -------------------------------------------------------------------------- */
-
-/* We have 16384 hash slots. The hash slot of a given key is obtained
- * as the least significant 14 bits of the crc16 of the key.
- *
- * However if the key contains the {...} pattern, only the part between
- * { and } is hashed. This may be useful in the future to force certain
- * keys to be in the same node (assuming no resharding is in progress). */
-unsigned int keyHashSlot(RedisModuleString *str)
-{
-    size_t keylen;
-    const char *key = RedisModule_StringPtrLen(str, &keylen);
-
-    size_t s, e; /* start-end indexes of { and } */
-
-    for (s = 0; s < keylen; s++)
-        if (key[s] == '{') break;
-
-    /* No '{' ? Hash the whole key. This is the base case. */
-    if (s == keylen) return crc16_ccitt(key,keylen) & 0x3FFF;
-
-    /* '{' found? Check if we have the corresponding '}'. */
-    for (e = s+1; e < keylen; e++)
-        if (key[e] == '}') break;
-
-    /* No '}' or nothing between {} ? Hash the whole key. */
-    if (e == keylen || e == s+1) return crc16_ccitt(key,keylen) & 0x3FFF;
-
-    /* If we are here there is both a { and a } on its right. Hash
-     * what is in the middle between { and }. */
-    return crc16_ccitt(key+s+1,e-s-1) & 0x3FFF;
-}
 
 /* -----------------------------------------------------------------------------
  * ShardGroup Handling

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1162,7 +1162,7 @@ RRStatus computeHashSlot(RedisRaftCtx *rr,
         for (int j = 0; j < num_keys; j++) {
             RedisModuleString *key = cmd->argv[keyindex[j]];
 
-            int thisslot = (int) keyHashSlot(key);
+            int thisslot = (int) keyHashSlotRedisString(key);
 
             if (*slot == -1) {
                 /* First key */

--- a/src/commands.c
+++ b/src/commands.c
@@ -148,6 +148,7 @@ RRStatus CommandSpecInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
             { "raft._sort_reply",             CMD_SPEC_DONT_INTERCEPT },
             { "raft._reject_random_command",  CMD_SPEC_DONT_INTERCEPT },
             { "raft.import",                  CMD_SPEC_DONT_INTERCEPT },
+            { "raft.scan",                    CMD_SPEC_READONLY },
             { NULL,0 }
     };
 

--- a/src/config.c
+++ b/src/config.c
@@ -50,6 +50,7 @@ static const char *CONF_MAX_APPEND_REQ_IN_FLIGHT = "max-append-req-in-flight";
 static const char *CONF_TLS_ENABLED = "tls-enabled";
 static const char *CONF_CLUSTER_USER = "cluster-user";
 static const char *CONF_CLUSTER_PASSWORD = "cluster-password";
+static const char *CONF_SCAN_SIZE = "scan-size";
 
 static RRStatus setRedisConfig(RedisModuleCtx *ctx, const char *param, const char *value)
 {
@@ -75,7 +76,7 @@ static RRStatus setRedisConfig(RedisModuleCtx *ctx, const char *param, const cha
         goto exit;
     }
 
-    exit:
+exit:
     exitRedisModuleCall();
     if (reply) {
         RedisModule_FreeCallReply(reply);
@@ -111,7 +112,7 @@ char *getRedisConfig(RedisModuleCtx *ctx, const char *name)
     memcpy(buf, str, len);
     buf[len] = '\0';
 
-    exit:
+exit:
     exitRedisModuleCall();
     if (reply_name) {
         RedisModule_FreeCallReply(reply_name);
@@ -422,6 +423,16 @@ static RRStatus processConfigParam(const char *keyword, const char *value, Redis
         if (strlen(value) > 0) {
             target->cluster_user = RedisModule_Strdup(value);
         }
+    } else if (!strcmp(keyword, CONF_SCAN_SIZE)) {
+        if (target->scan_size) {
+            RedisModule_Free(target->scan_size);
+            target->scan_size = NULL;
+        }
+        if (strlen(value) > 0) {
+            target->scan_size = RedisModule_Strdup(value);
+        } else {
+            target->scan_size = RedisModule_Strdup("1000");
+        }
     } else {
         snprintf(errbuf, errbuflen-1, "invalid parameter '%s'", keyword);
         return RR_ERROR;
@@ -612,6 +623,10 @@ void ConfigGet(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, 
         len++;
         replyConfigStr(ctx, CONF_CLUSTER_USER, config->cluster_user ? config->cluster_user : "");
     }
+    if (stringmatch(pattern, CONF_SCAN_SIZE, 1)) {
+        len++;
+        replyConfigStr(ctx, CONF_SCAN_SIZE, config->scan_size);
+    }
     RedisModule_ReplySetArrayLength(ctx, len * 2);
 }
 
@@ -687,6 +702,7 @@ void ConfigInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
 #endif
     config->cluster_user = RedisModule_Strdup("default");
     config->cluster_password = NULL;
+    config->scan_size = "1000";
 }
 
 

--- a/src/migrate.c
+++ b/src/migrate.c
@@ -51,7 +51,7 @@ void importKeys(RedisRaftCtx *rr, raft_entry_t *entry)
     RedisModule_Assert(import_keys.num_keys > 0);
 
     // FIXME: validate no cross slot migration at append time
-    int slot = keyHashSlot(import_keys.key_names[0]);
+    int slot = keyHashSlotRedisString(import_keys.key_names[0]);
 
     if (!validSlot(rr, slot)) {
         if (req) {

--- a/src/raft.c
+++ b/src/raft.c
@@ -360,8 +360,6 @@ void RaftExecuteCommandArray(RedisRaftCtx *rr,
     }
 }
 
-unsigned int keyHashSlot(RedisModuleString * str);
-
 static void lockKeys(RedisRaftCtx *rr, raft_entry_t *entry)
 {
     RedisModule_Assert(entry->type == RAFT_LOGTYPE_LOCK_KEYS);
@@ -377,7 +375,7 @@ static void lockKeys(RedisRaftCtx *rr, raft_entry_t *entry)
     for (size_t i = 0; i < num_keys; i++) {
         RedisModuleString * key = keys[i];
 
-        unsigned int thisslot = keyHashSlot(key);
+        unsigned int thisslot = keyHashSlotRedisString(key);
         if (slot == -1) {
             slot = (int) thisslot;
         } else {

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -775,7 +775,8 @@ void handleRMCallError(RedisModuleCtx *reply_ctx, int ret_errno, const char *cmd
 void AddBasicLocalShardGroup(RedisRaftCtx *rr);
 void HandleAsking(RaftRedisCommandArray *cmds);
 void FreeImportKeys(ImportKeys *target);
-unsigned int keyHashSlot(RedisModuleString *s);
+unsigned int keyHashSlot(const char *key, size_t keylen);
+unsigned int keyHashSlotRedisString(RedisModuleString *s);
 RRStatus parseHashSlots(char * slots, char * string);
 
 /* log.c */

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -420,6 +420,7 @@ typedef struct RedisRaftConfig {
     char *tls_key_pass;
     char *cluster_user;                 /* acl user to use for internode communication */
     char *cluster_password;             /* password used for internode communication */
+    char *scan_size;                    /* how many keys to fetch at a time internally for raft.scan */
 } RedisRaftConfig;
 
 typedef struct PendingResponse {
@@ -774,6 +775,8 @@ void handleRMCallError(RedisModuleCtx *reply_ctx, int ret_errno, const char *cmd
 void AddBasicLocalShardGroup(RedisRaftCtx *rr);
 void HandleAsking(RaftRedisCommandArray *cmds);
 void FreeImportKeys(ImportKeys *target);
+unsigned int keyHashSlot(RedisModuleString *s);
+RRStatus parseHashSlots(char * slots, char * string);
 
 /* log.c */
 RaftLog *RaftLogCreate(const char *filename, const char *dbid, raft_term_t snapshot_term, raft_index_t snapshot_index, RedisRaftConfig *config);
@@ -879,7 +882,6 @@ void ShardGroupLink(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **a
 void ShardGroupGet(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 void ShardGroupAdd(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 void ShardGroupReplace(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-unsigned int keyHashSlot(RedisModuleString *s);
 ShardGroup *getShardGroupById(RedisRaftCtx *rr, const char *id);
 
 /* join.c */

--- a/src/util.c
+++ b/src/util.c
@@ -10,8 +10,8 @@
 #include <strings.h>
 #include <stdlib.h>
 #include <ctype.h>
-#include <assert.h>
 #include "redisraft.h"
+#include "crc16.h"
 
 int RedisModuleStringToInt(RedisModuleString *str, int *value)
 {
@@ -378,7 +378,7 @@ void AddBasicLocalShardGroup(RedisRaftCtx *rr) {
 
     sg->local = true;
     memcpy(sg->id, rr->log->dbid, RAFT_DBID_LEN);
-    sg->id[RAFT_DBID_LEN] = 0;
+    sg->id[RAFT_DBID_LEN] = '\0';
 
     RRStatus ret = ShardingInfoAddShardGroup(rr, sg);
     RedisModule_Assert(ret == RR_OK);
@@ -400,8 +400,7 @@ void HandleAsking(RaftRedisCommandArray *cmds)
     }
 }
 
-void FreeImportKeys(ImportKeys *target)
-{
+void FreeImportKeys(ImportKeys *target) {
     if (target->num_keys) {
         if (target->key_names) {
             for (size_t i = 0; i < target->num_keys; i++) {
@@ -422,4 +421,79 @@ void FreeImportKeys(ImportKeys *target)
             target->key_serialized = NULL;
         }
     }
+}
+
+/* -----------------------------------------------------------------------------
+ * Hashing code - copied directly from Redis.
+ * -------------------------------------------------------------------------- */
+
+/* We have 16384 hash slots. The hash slot of a given key is obtained
+ * as the least significant 14 bits of the crc16 of the key.
+ *
+ * However if the key contains the {...} pattern, only the part between
+ * { and } is hashed. This may be useful in the future to force certain
+ * keys to be in the same node (assuming no resharding is in progress). */
+unsigned int keyHashSlot(RedisModuleString *str) {
+    size_t keylen;
+    char * key = RedisModule_StringPtrLen(str, &keylen);
+
+    int s, e; /* start-end indexes of { and } */
+
+    for (s = 0; s < keylen; s++)
+        if (key[s] == '{') break;
+
+    /* No '{' ? Hash the whole key. This is the base case. */
+    if (s == keylen) return crc16_ccitt(key,keylen) & 0x3FFF;
+
+    /* '{' found? Check if we have the corresponding '}'. */
+    for (e = s+1; e < keylen; e++)
+        if (key[e] == '}') break;
+
+    /* No '}' or nothing between {} ? Hash the whole key. */
+    if (e == keylen || e == s+1) return crc16_ccitt(key,keylen) & 0x3FFF;
+
+    /* If we are here there is both a { and a } on its right. Hash
+     * what is in the middle between { and }. */
+    return crc16_ccitt(key+s+1,e-s-1) & 0x3FFF;
+}
+
+RRStatus parseHashSlots(char * slots, char * string)
+{
+    string = RedisModule_Strdup(string);
+    RRStatus ret = RR_OK;
+    char *tok = strtok(string, ",");
+    while (tok != NULL) {
+        char * dash = strchr(tok, '-');
+        if (dash == NULL) {
+            char *endptr;
+            unsigned int slot = strtoul(tok, &endptr, 10);
+            if (*endptr != 0 || slot > REDIS_RAFT_HASH_MAX_SLOT) {
+                ret = RR_ERROR;
+                goto exit;
+            }
+            slots[slot] = 1;
+        } else {
+            *dash = '\0';
+            char *endptr;
+            unsigned int start = strtoul(tok, &endptr, 10);
+            if (*endptr != 0 || start > REDIS_RAFT_HASH_MAX_SLOT) {
+                ret = RR_ERROR;
+                goto exit;
+            }
+            tok = dash + 1;
+            unsigned int end = strtoul(tok, &endptr, 10);
+            if (*endptr != 0 || end > REDIS_RAFT_HASH_MAX_SLOT || end < start) {
+                ret = RR_ERROR;
+                goto exit;
+            }
+            for (unsigned int i = start; i <= end; i++) {
+                slots[i] = 1;
+            }
+        }
+        tok = strtok(NULL, ",");
+    }
+
+exit:
+    RedisModule_Free(string);
+    return ret;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -433,11 +433,8 @@ void FreeImportKeys(ImportKeys *target) {
  * However if the key contains the {...} pattern, only the part between
  * { and } is hashed. This may be useful in the future to force certain
  * keys to be in the same node (assuming no resharding is in progress). */
-unsigned int keyHashSlot(RedisModuleString *str) {
-    size_t keylen;
-    char * key = RedisModule_StringPtrLen(str, &keylen);
-
-    int s, e; /* start-end indexes of { and } */
+unsigned int keyHashSlot(const char *key, size_t keylen) {
+    size_t s, e; /* start-end indexes of { and } */
 
     for (s = 0; s < keylen; s++)
         if (key[s] == '{') break;
@@ -455,6 +452,13 @@ unsigned int keyHashSlot(RedisModuleString *str) {
     /* If we are here there is both a { and a } on its right. Hash
      * what is in the middle between { and }. */
     return crc16_ccitt(key+s+1,e-s-1) & 0x3FFF;
+}
+
+unsigned int keyHashSlotRedisString(RedisModuleString *str) {
+    size_t keylen;
+    const char *key = RedisModule_StringPtrLen(str, &keylen);
+
+    return keyHashSlot(key, keylen);
 }
 
 RRStatus parseHashSlots(char * slots, char * string)

--- a/tests/dut_premble.h
+++ b/tests/dut_premble.h
@@ -33,7 +33,17 @@ static inline struct RedisModuleString *mock_CreateString(const char *s, size_t 
     return (struct RedisModuleString *) buf;
 }
 
+static inline char * mock_Strdup(const char * s)
+{
+    size_t len = strlen(s);
+    char * buf = test_malloc(len + 1);
+    memcpy(buf, s, len);
+    buf[len] = '\0';
+    return buf;
+}
+
 #define RedisModule_StringPtrLen(__s, __len)            mock_StringPtrLen(__s, __len)
 #define RedisModule_CreateString(__ctx, __s, __len)     mock_CreateString(__s, __len)
 #define RedisModule_FreeString(__ctx, __s)              test_free(__s)
 #define RedisModule_MonotonicMicroseconds()             0
+#define RedisModule_Strdup(__s)                         mock_Strdup(__s)

--- a/tests/test_util.c
+++ b/tests/test_util.c
@@ -80,8 +80,53 @@ static void test_memory_conversion(void **state)
     assert_int_equal(formatExactMemorySize(1000*1000, buf, 4), RR_ERROR);
 }
 
+static void test_parse_slots(void **state)
+{
+    char slots[REDIS_RAFT_HASH_SLOTS] = {0};
+    parseHashSlots(slots, "0");
+    assert_int_equal(slots[0], 1);
+    for (size_t i = 1; i < REDIS_RAFT_HASH_SLOTS; i++) {
+        assert_int_equal(slots[i], 0);
+    }
+    bzero(slots, REDIS_RAFT_HASH_SLOTS);
+    parseHashSlots(slots, "0-10");
+    for (size_t i = 0; i < 11; i++) {
+        assert_int_equal(slots[i], 1);
+    }
+    for (size_t i = 11; i < REDIS_RAFT_HASH_SLOTS; i++) {
+        assert_int_equal(slots[i], 0);
+    }
+    bzero(slots, REDIS_RAFT_HASH_SLOTS);
+    parseHashSlots(slots, "0,5-10,16,58-62,100");
+    assert_int_equal(slots[0], 1);
+    for (size_t i = 1; i < 5; i++) {
+        assert_int_equal(slots[i], 0);
+    }
+    for (size_t i = 5; i < 11; i++) {
+        assert_int_equal(slots[i], 1);
+    }
+    for (size_t i = 11; i < 16; i++) {
+        assert_int_equal(slots[i], 0);
+    }
+    assert_int_equal(slots[16], 1);
+    for (size_t i = 17; i < 58 ; i++) {
+        assert_int_equal(slots[i], 0);
+    }
+    for (size_t i = 58; i < 63 ; i++) {
+        assert_int_equal(slots[i], 1);
+    }
+    for (size_t i = 63; i < 100 ; i++) {
+        assert_int_equal(slots[i], 0);
+    }
+    assert_int_equal(slots[100], 1);
+    for (size_t i = 101; i < REDIS_RAFT_HASH_SLOTS ; i++) {
+        assert_int_equal(slots[i], 0);
+    }
+}
+
 const struct CMUnitTest util_tests[] = {
     cmocka_unit_test(test_raftreq_str),
     cmocka_unit_test(test_memory_conversion),
+    cmocka_unit_test(test_parse_slots),
     { .test_func = NULL }
 };


### PR DESCRIPTION
mimics redis's scan i.e. either

`raft.scan slots <slot definition>`

or when called again

`raft.scan <cursor> slots <slot definition>`

slot definition is a comma delimited list of slot ranges.  a slot range is either a single slot (100) or a dash delimited slot range (500-520).  So one can do something like "5,15-80,100,0-2"

it returns a 2 element array.

1st element is the cursor (like scan) for next call
2nd element is an array of 2 element arrays [key,slot] that conain the key and slot it belongs to

ex of return values

```
127.0.0.1:5001> raft.scan 28903 slots 1
1) "22991"
2) (empty array)
```
no keys belonging to slot 1, but when called again
```
127.0.0.1:5001> raft.scan 16731 slots 1
1) "28903"
2) 1) 1) "key11850"
      2) (integer) 1
```
we get one key that belonged

and finally
```
127.0.0.1:5001> raft.scan 22991 slots 1
1) "0"
2) (empty array)
```
cursor 0 means we scanned the entire keyspace.