### PR TITLE
Test cluster should wait until configuration entries are applied

### DIFF
--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -500,9 +500,10 @@ class Cluster(object):
             else:
                 logging.info("{} joining".format(_id))
                 node.join(['localhost:{}'.format(self.base_port + 1)])
+
         self.leader = 1
         self.node(1).wait_for_num_voting_nodes(len(self.nodes))
-        self.node(1).wait_for_log_applied()
+        self.wait_for_unanimity()
 
         # Pre-populate if asked
         for _ in range(prepopulate_log):


### PR DESCRIPTION
If configuration entries are not applied yet, the node won't have a connection to others. So, if the node starts an election, the election will not be successful. This issue causes test failures on the daily build. The solution is to wait until log entries are applied. 