### PR TITLE
asking as an independent command

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1150,9 +1150,9 @@ void ShardingInfoReset(RedisRaftCtx *rr)
 RRStatus computeHashSlot(RedisRaftCtx *rr,
                          RedisModuleCtx *ctx,
                          RaftRedisCommandArray *cmds,
-                         unsigned int *slot)
+                         int *slot)
 {
-    bool first_key = true;
+    *slot = -1;
     for (int i = 0; i < cmds->len; i++) {
         RaftRedisCommand *cmd = cmds->commands[i];
 
@@ -1162,11 +1162,10 @@ RRStatus computeHashSlot(RedisRaftCtx *rr,
         for (int j = 0; j < num_keys; j++) {
             RedisModuleString *key = cmd->argv[keyindex[j]];
 
-            unsigned int thisslot = keyHashSlotRedisString(key);
+            int thisslot = (int) keyHashSlotRedisString(key);
 
-            if (first_key) {
+            if (*slot) {
                 *slot = thisslot;
-                first_key = false;
             } else {
                 if (*slot != thisslot) {
                     RedisModule_Free(keyindex);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1164,7 +1164,7 @@ RRStatus computeHashSlot(RedisRaftCtx *rr,
 
             int thisslot = (int) keyHashSlotRedisString(key);
 
-            if (*slot) {
+            if (*slot == -1) {
                 *slot = thisslot;
             } else {
                 if (*slot != thisslot) {

--- a/src/commands.c
+++ b/src/commands.c
@@ -242,19 +242,3 @@ unsigned int CommandSpecGetAggregateFlags(RaftRedisCommandArray *array, unsigned
 
     return flags;
 }
-
-bool IsKeyCommands(RedisRaftCtx *rr,
-                   RedisModuleCtx *ctx,
-                   RaftRedisCommandArray *cmds) {
-    for (int i = 0; i < cmds->len; i++) {
-        RaftRedisCommand *cmd = cmds->commands[i];
-
-        /* Iterate command keys */
-        int num_keys = 0;
-        RedisModule_GetCommandKeys(rr->ctx, cmd->argv, cmd->argc, &num_keys);
-        if (num_keys) {
-            return true;
-        }
-    }
-    return false;
-}

--- a/src/commands.c
+++ b/src/commands.c
@@ -8,6 +8,7 @@
 /* ------------------------------------ Command Classification ------------------------------------ */
 
 #include <string.h>
+#include <strings.h>
 #include <ctype.h>
 #include "redisraft.h"
 
@@ -240,4 +241,20 @@ unsigned int CommandSpecGetAggregateFlags(RaftRedisCommandArray *array, unsigned
     }
 
     return flags;
+}
+
+bool IsKeyCommands(RedisRaftCtx *rr,
+                   RedisModuleCtx *ctx,
+                   RaftRedisCommandArray *cmds) {
+    for (int i = 0; i < cmds->len; i++) {
+        RaftRedisCommand *cmd = cmds->commands[i];
+
+        /* Iterate command keys */
+        int num_keys = 0;
+        RedisModule_GetCommandKeys(rr->ctx, cmd->argv, cmd->argc, &num_keys);
+        if (num_keys) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/commands.c
+++ b/src/commands.c
@@ -219,19 +219,6 @@ unsigned int CommandSpecGetAggregateFlags(RaftRedisCommandArray *array, unsigned
     for (int i = 0; i < array->len; i++) {
         /* we get the flag for the command that is asking, not the asking */
         RedisModuleString * cmd = array->commands[i]->argv[0];
-        size_t cmd_len;
-        const char * cmd_str = RedisModule_StringPtrLen(cmd, &cmd_len);
-
-        if (!strncasecmp("asking", cmd_str, cmd_len)) {
-            /* TODO: when asking <magic> support is added, need to adjust to argv[2] */
-            if (array->commands[i]->argc > 1) {
-                cmd = array->commands[i]->argv[1];
-            } else {
-                /* necessary to protect/ignore a bare "asking" command */
-                continue;
-            }
-        }
-
         const CommandSpec *cs = CommandSpecGet(cmd);
         if (cs) {
             flags |= cs->flags;

--- a/src/common.c
+++ b/src/common.c
@@ -66,7 +66,7 @@ void replyRedirect(RedisModuleCtx *ctx, unsigned int slot, NodeAddr *addr)
 {
     char buf[sizeof(addr->host) + 256];
 
-    snprintf(buf, sizeof(buf), "MOVED %d %s:%u", slot, addr->host, addr->port);
+    snprintf(buf, sizeof(buf), "MOVED %u %s:%u", slot, addr->host, addr->port);
     RedisModule_ReplyWithError(ctx, buf);
 }
 
@@ -117,7 +117,7 @@ static const char *err_clusterdown = "CLUSTERDOWN No raft leader";
  * Note: it's possible to have an elected but unknown leader node, in which
  * case NULL will also be returned.
  */
-raft_node_t *getLeaderNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
+raft_node_t *getLeaderRaftNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
 {
     raft_node_t *node = raft_get_leader_node(rr->raft);
     if (!node) {
@@ -127,47 +127,32 @@ raft_node_t *getLeaderNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
     return node;
 }
 
-/* Checks that we *have* a Raft leader and its identity.
+/* Returns the leader node (Node), or reply a -CLUSTERDOWN error
+ * and return NULL.
  *
- * If no leader is currently elected, replies a -CLUSTERDOWN error and
- * return RR_ERROR.
- *
- * If ret_leader is provided, it is used to return the current leader
- * by reference along with an RR_OK return value.
- *
- * If ret_leader is not provided and the current node is NOT the leader,
- * a -MOVED reply is generated with the current leader and RR_ERROR is
- * returned.
+ * Note: it's possible to have an elected but unknown leader node, in which
+ * case NULL will also be returned.
  */
-RRStatus checkLeader(RedisRaftCtx *rr, RedisModuleCtx *ctx, Node **ret_leader)
+Node *getLeaderNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
 {
-    Node *node = NULL;
-
-    if (raft_is_leader(rr->raft)) {
-        return RR_OK;
+    raft_node_t *raft_node = getLeaderRaftNodeOrReply(rr, ctx);
+    if (!raft_node) {
+        return NULL;
     }
 
-    raft_node_t *leader = raft_get_leader_node(rr->raft);
-    if (leader) {
-        node = raft_node_get_udata(leader);
-    }
-
+    Node *node = raft_node_get_udata(raft_node);
     if (!node) {
         RedisModule_ReplyWithError(ctx, err_clusterdown);
-        return RR_ERROR;
     }
 
-    if (ret_leader) {
-        *ret_leader = node;
-        return RR_OK;
-    }
+    return node;
+}
 
-    /* One anomaly here is that may redirect a client to the leader even for
-     * commands have no keys, which is something Redis Cluster never does. We
-     * still need to consider how this impacts clients which may not expect it.
-     */
-    replyRedirect(ctx, 0, &node->addr);
-    return RR_ERROR;
+
+/* Checks if the current cluster is the leader */
+bool isLeader(RedisRaftCtx *rr) {
+
+    return raft_is_leader(rr->raft);
 }
 
 /* Check that we're not in REDIS_RAFT_LOADING state.  If not, reply with -LOADING

--- a/src/common.c
+++ b/src/common.c
@@ -89,6 +89,11 @@ void replyCrossSlot(RedisModuleCtx *ctx)
     RedisModule_ReplyWithError(ctx, "CROSSSLOT Keys in request don't hash to the same slot");
 }
 
+void replyClusterDownWithNoRaftLeader(RedisModuleCtx *ctx)
+{
+    RedisModule_ReplyWithError(ctx, "CLUSTERDOWN No raft leader");
+}
+
 void replyWithFormatErrorString(RedisModuleCtx *ctx, const char * fmt, ...)
 {
     va_list ap;
@@ -109,8 +114,6 @@ void replyWithFormatErrorString(RedisModuleCtx *ctx, const char * fmt, ...)
 
 }
 
-static const char *err_clusterdown = "CLUSTERDOWN No raft leader";
-
 /* Returns the leader node (raft_node_t), or reply a -CLUSTERDOWN error
  * and return NULL.
  *
@@ -121,7 +124,7 @@ raft_node_t *getLeaderRaftNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
 {
     raft_node_t *node = raft_get_leader_node(rr->raft);
     if (!node) {
-        RedisModule_ReplyWithError(ctx, err_clusterdown);
+        replyClusterDownWithNoRaftLeader(ctx);
     }
 
     return node;
@@ -142,7 +145,7 @@ Node *getLeaderNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
 
     Node *node = raft_node_get_udata(raft_node);
     if (!node) {
-        RedisModule_ReplyWithError(ctx, err_clusterdown);
+        replyClusterDownWithNoRaftLeader(ctx);
     }
 
     return node;

--- a/src/common.c
+++ b/src/common.c
@@ -62,7 +62,7 @@ void replyRaftError(RedisModuleCtx *ctx, int error)
 }
 
 /* Create a -MOVED reply. */
-void replyRedirect(RedisModuleCtx *ctx, int slot, NodeAddr *addr)
+void replyRedirect(RedisModuleCtx *ctx, unsigned int slot, NodeAddr *addr)
 {
     char buf[sizeof(addr->host) + 256];
 
@@ -71,7 +71,7 @@ void replyRedirect(RedisModuleCtx *ctx, int slot, NodeAddr *addr)
 }
 
 /* Create a -ASK reply. */
-void replyAsk(RedisRaftCtx *rr, RedisModuleCtx *ctx, int slot) {
+void replyAsk(RedisRaftCtx *rr, RedisModuleCtx *ctx, unsigned int slot) {
     ShardGroup *sg = rr->sharding_info->importing_slots_map[slot];
     if (!sg) {
         RedisModule_ReplyWithError(ctx, "ERR no importing shard group to ask");
@@ -79,7 +79,7 @@ void replyAsk(RedisRaftCtx *rr, RedisModuleCtx *ctx, int slot) {
     }
 
     char buf[sizeof(sg->nodes[0].addr.host) + 256];
-    snprintf(buf, sizeof(buf), "ASK %d %s:%u", slot, sg->nodes[0].addr.host, sg->nodes[0].addr.port);
+    snprintf(buf, sizeof(buf), "ASK %u %s:%u", slot, sg->nodes[0].addr.host, sg->nodes[0].addr.port);
     RedisModule_ReplyWithError(ctx, buf);
 }
 

--- a/src/common.c
+++ b/src/common.c
@@ -148,13 +148,6 @@ Node *getLeaderNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
     return node;
 }
 
-
-/* Checks if the current cluster is the leader */
-bool isLeader(RedisRaftCtx *rr) {
-
-    return raft_is_leader(rr->raft);
-}
-
 /* Check that we're not in REDIS_RAFT_LOADING state.  If not, reply with -LOADING
  * and return an error.
  */

--- a/src/multi.c
+++ b/src/multi.c
@@ -86,13 +86,6 @@ bool MultiHandleCommand(RedisRaftCtx *rr,
     size_t cmd_len;
     const char *cmd_str = RedisModule_StringPtrLen(cmd->argv[0], &cmd_len);
 
-    if (cmd_len == 6 && !strncasecmp(cmd_str, "ASKING", 6)) {
-        /* TODO: will have to be > 2 in future with magic value in asking for argv[2] */
-        if (cmd->argc > 1) {
-            cmd_str = RedisModule_StringPtrLen(cmd->argv[1], &cmd_len);
-        }
-    }
-
     if (cmd_len == 5 && !strncasecmp(cmd_str, "MULTI", 5)) {
         if (multiState) {
             RedisModule_ReplyWithError(ctx, "ERR MULTI calls can not be nested");

--- a/src/multi.c
+++ b/src/multi.c
@@ -44,17 +44,7 @@ void MultiClientStateReset(ClientState * clientState)
 bool MultiHandleCommand(RedisRaftCtx *rr,
                         RedisModuleCtx *ctx, RaftRedisCommandArray *cmds)
 {
-    ClientState *clientState;
-
-    /* MULTI/EXEC bundling takes place only if we have a single command. If we
-     * have multiple commands we've received this as a RAFT.ENTRY input and
-     * bundling, probably through a proxy, and bundling was done before.
-     */
-    if (cmds->len != 1) {
-        return false;
-    }
-
-    clientState = ClientStateGet(rr, ctx);
+    ClientState *clientState = ClientStateGet(rr, ctx);
 
     /* Is this a MULTI command? */
     RaftRedisCommand *cmd = cmds->commands[0];

--- a/src/multi.c
+++ b/src/multi.c
@@ -34,12 +34,11 @@
 
 #include "redisraft.h"
 
-
 void ResetMultiClientState(ClientState * clientState)
 {
-    RaftRedisCommandArrayFree(&clientState->multiState.cmds);
-    clientState->multiState.active = false;
-    clientState->multiState.error = false;
+    RaftRedisCommandArrayFree(&clientState->multi_state.cmds);
+    clientState->multi_state.active = false;
+    clientState->multi_state.error = false;
 }
 
 bool MultiHandleCommand(RedisRaftCtx *rr,
@@ -55,7 +54,7 @@ bool MultiHandleCommand(RedisRaftCtx *rr,
         return false;
     }
 
-    clientState = GetClientState(rr, ctx);
+    clientState = ClientStateGet(rr, ctx);
 
     /* Is this a MULTI command? */
     RaftRedisCommand *cmd = cmds->commands[0];
@@ -63,26 +62,26 @@ bool MultiHandleCommand(RedisRaftCtx *rr,
     const char *cmd_str = RedisModule_StringPtrLen(cmd->argv[0], &cmd_len);
 
     if (cmd_len == 5 && !strncasecmp(cmd_str, "MULTI", 5)) {
-        if (clientState->multiState.active) {
+        if (clientState->multi_state.active) {
             RedisModule_ReplyWithError(ctx, "ERR MULTI calls can not be nested");
         } else {
-            clientState->multiState.active = 1;
+            clientState->multi_state.active = 1;
 
             /* We put the MULTI as the first command in the array, as we still
              * need to distinguish single-MULTI array from a single command.
              */
-            RaftRedisCommandArrayMove(&clientState->multiState.cmds, cmds);
+            RaftRedisCommandArrayMove(&clientState->multi_state.cmds, cmds);
             RedisModule_ReplyWithSimpleString(ctx, "OK");
         }
 
         return true;
     } else if (cmd_len == 4 && !strncasecmp(cmd_str, "EXEC", 4)) {
-        if (!clientState->multiState.active) {
+        if (!clientState->multi_state.active) {
             RedisModule_ReplyWithError(ctx, "ERR EXEC without MULTI");
             return true;
         }
 
-        if (clientState->multiState.error) {
+        if (clientState->multi_state.error) {
             ResetMultiClientState(clientState);
             RedisModule_ReplyWithError(ctx, "EXECABORT Transaction discarded because of previous errors.");
             return true;
@@ -90,12 +89,12 @@ bool MultiHandleCommand(RedisRaftCtx *rr,
 
         /* Just swap our commands with the EXEC command and proceed. */
         RaftRedisCommandArrayFree(cmds);
-        RaftRedisCommandArrayMove(cmds, &clientState->multiState.cmds);
+        RaftRedisCommandArrayMove(cmds, &clientState->multi_state.cmds);
         ResetMultiClientState(clientState);
 
         return false;
     } else if (cmd_len == 7 && !strncasecmp(cmd_str, "DISCARD", 7)) {
-        if (!clientState || !clientState->multiState.active) {
+        if (!clientState || !clientState->multi_state.active) {
             RedisModule_ReplyWithError(ctx, "ERR DISCARD without MULTI");
             return true;
         }
@@ -107,7 +106,7 @@ bool MultiHandleCommand(RedisRaftCtx *rr,
     }
 
     /* Are we in MULTI? */
-    if (clientState->multiState.active) {
+    if (clientState->multi_state.active) {
         /* We have to detect commands that are unsupported or must not be
          * intercepted and reject the transaction.
          */
@@ -115,12 +114,12 @@ bool MultiHandleCommand(RedisRaftCtx *rr,
 
         if (cmd_flags & CMD_SPEC_UNSUPPORTED) {
             RedisModule_ReplyWithError(ctx, "ERR not supported by RedisRaft");
-            clientState->multiState.error = true;
+            clientState->multi_state.error = true;
         } else if (cmd_flags & CMD_SPEC_DONT_INTERCEPT) {
             RedisModule_ReplyWithError(ctx, "ERR not supported by RedisRaft inside MULTI/EXEC");
-            clientState->multiState.error = true;
+            clientState->multi_state.error = true;
         } else {
-            RaftRedisCommandArrayMove(&clientState->multiState.cmds, cmds);
+            RaftRedisCommandArrayMove(&clientState->multi_state.cmds, cmds);
             RedisModule_ReplyWithSimpleString(ctx, "QUEUED");
         }
 

--- a/src/multi.c
+++ b/src/multi.c
@@ -34,7 +34,7 @@
 
 #include "redisraft.h"
 
-void MultiClientStateReset(ClientState * clientState)
+void MultiClientStateReset(ClientState *clientState)
 {
     RaftRedisCommandArrayFree(&clientState->multi_state.cmds);
     clientState->multi_state.active = false;

--- a/src/raft.c
+++ b/src/raft.c
@@ -1451,8 +1451,9 @@ RRStatus RedisRaftInit(RedisModuleCtx *ctx, RedisRaftCtx *rr, RedisRaftConfig *c
         rr->resp_call_fmt = "v";
     }
 
-    /* Client state for MULTI support */
+    /* Client state for MULTI/ASKING support */
     rr->multi_client_state = RedisModule_CreateDict(ctx);
+    rr->asking_client_state = RedisModule_CreateDict(ctx);
 
     /* Read configuration from Redis */
     if (ConfigReadFromRedis(rr) == RR_ERROR) {

--- a/src/raft.c
+++ b/src/raft.c
@@ -277,7 +277,7 @@ static RRStatus handleSharding(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisC
     }
 
     if (computeHashSlot(rr, ctx, cmds, &slot) != RR_OK) {
-        RedisModule_ReplyWithError(ctx, "CROSSSLOT Keys in request don't hash to the same slot");
+        replyCrossSlot(ctx);
         return RR_ERROR;
     }
 

--- a/src/raft.c
+++ b/src/raft.c
@@ -270,20 +270,20 @@ static RRStatus validateRaftRedisCommandArray(RedisRaftCtx *rr, RedisModuleCtx *
  */
 static RRStatus handleSharding(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds)
 {
-    unsigned int slot;
+    int slot;
 
     if (!isSharding(rr)) {
-        return RR_OK;
-    }
-
-    /* If commands have no keys, continue */
-    if (!IsKeyCommands(rr, ctx, cmds)) {
         return RR_OK;
     }
 
     if (computeHashSlot(rr, ctx, cmds, &slot) != RR_OK) {
         RedisModule_ReplyWithError(ctx, "CROSSSLOT Keys in request don't hash to the same slot");
         return RR_ERROR;
+    }
+
+    /* If commands have no keys, continue */
+    if (slot == -1) {
+        return RR_OK;
     }
 
     return validateRaftRedisCommandArray(rr, ctx, cmds, slot);

--- a/src/raft.c
+++ b/src/raft.c
@@ -1452,8 +1452,7 @@ RRStatus RedisRaftInit(RedisModuleCtx *ctx, RedisRaftCtx *rr, RedisRaftConfig *c
     }
 
     /* Client state for MULTI/ASKING support */
-    rr->multi_client_state = RedisModule_CreateDict(ctx);
-    rr->asking_client_state = RedisModule_CreateDict(ctx);
+    rr->client_state = RedisModule_CreateDict(ctx);
 
     /* Read configuration from Redis */
     if (ConfigReadFromRedis(rr) == RR_ERROR) {

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -663,9 +663,7 @@ static void handleRedisCommand(RedisRaftCtx *rr,
     }
 
     /* update cmds array with the client's saved "asking" state */
-    if (!cmds->asking) {
-        cmds->asking = getAskingState(rr, ctx);
-    }
+    cmds->asking = getAskingState(rr, ctx);
 
     /* Check if MULTI/EXEC bundling is required. */
     if (MultiHandleCommand(rr, ctx, cmds)) {

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -646,6 +646,8 @@ static void handleRedisCommand(RedisRaftCtx *rr,
         if (rr->config->quorum_reads) {
             RaftReq *req = RaftReqInit(ctx, RR_REDISCOMMAND);
             RaftRedisCommandArrayMove(&req->r.redis.cmds, cmds);
+            /* need to save asking flag when we move the cmds */
+            req->r.redis.cmds.asking = cmds->asking;
             raft_queue_read_request(rr->raft, handleReadOnlyCommand, req);
         } else {
             /* Wait until the new leader applies an entry from the current term.
@@ -665,6 +667,8 @@ static void handleRedisCommand(RedisRaftCtx *rr,
 
     RaftReq *req = RaftReqInit(ctx, RR_REDISCOMMAND);
     RaftRedisCommandArrayMove(&req->r.redis.cmds, cmds);
+    /* need to save asking flag when we move the cmds */
+    req->r.redis.cmds.asking = cmds->asking;
 
     raft_entry_t *entry = RaftRedisCommandArraySerialize(&req->r.redis.cmds);
     entry->id = rand();

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -679,6 +679,11 @@ static void handleRedisCommand(RedisRaftCtx *rr,
         return;
     }
 
+    /* reset asking state when we go to execute the command */
+    if (cmds->asking) {
+        setAskingState(rr, ctx, false);
+    }
+
     handleRedisCommandAppend(rr, ctx, cmds);
 }
 

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -576,7 +576,7 @@ static bool AskingHandleCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedis
         return true;
     }
 
-    ClientState *clientState = GetClientState(rr, ctx);
+    ClientState *clientState = ClientStateGet(rr, ctx);
     clientState->asking = true;
 
     RedisModule_ReplyWithSimpleString(ctx, "OK");
@@ -586,7 +586,7 @@ static bool AskingHandleCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedis
 
 static bool GetAskingState(RedisRaftCtx *rr, RedisModuleCtx *ctx)
 {
-    ClientState *clientState = GetClientState(rr, ctx);
+    ClientState *clientState = ClientStateGet(rr, ctx);
     return clientState->asking;
 }
 
@@ -1643,10 +1643,10 @@ void handleClientEvent(RedisModuleCtx *ctx,
     if (eid.id == REDISMODULE_EVENT_CLIENT_CHANGE) {
         switch (subevent) {
             case REDISMODULE_SUBEVENT_CLIENT_CHANGE_DISCONNECTED:
-                FreeClientState(rr, ci->id);
+                ClientStateFree(rr, ci->id);
                 break;
             case REDISMODULE_SUBEVENT_CLIENT_CHANGE_CONNECTED:
-                AllocClientState(rr, ci->id);
+                ClientStateAlloc(rr, ci->id);
                 break;
         }
     }
@@ -1774,7 +1774,7 @@ static void handleInfo(RedisModuleInfoCtx *ctx, int for_crash_report)
     RedisModule_InfoAddFieldULongLong(ctx, "snapshots_created", rr->snapshots_created);
 
     RedisModule_InfoAddSection(ctx, "clients");
-    RedisModule_InfoAddFieldULongLong(ctx, "clients_state_tracking", ClientStateCount(rr));
+    RedisModule_InfoAddFieldULongLong(ctx, "clients_state_tracking", ClientStatesCount(rr));
     RedisModule_InfoAddFieldULongLong(ctx, "proxy_reqs", rr->proxy_reqs);
     RedisModule_InfoAddFieldULongLong(ctx, "proxy_failed_reqs", rr->proxy_failed_reqs);
     RedisModule_InfoAddFieldULongLong(ctx, "proxy_failed_responses", rr->proxy_failed_responses);

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -715,6 +715,7 @@ static RRStatus handleNonLeaderCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, No
 
         if (res == RR_ERROR) {
             replyCrossSlot(ctx);
+            return RR_ERROR;
         }
 
         replyAsk(rr, ctx, (unsigned int) slot);

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -568,7 +568,7 @@ static bool handleInterceptedCommands(RedisRaftCtx *rr,
     return false;
 }
 
-static bool GetAskingState(RedisRaftCtx *rr, RedisModuleCtx *ctx)
+static bool getAskingState(RedisRaftCtx *rr, RedisModuleCtx *ctx)
 {
     ClientState *clientState = ClientStateGet(rr, ctx);
     return clientState->asking;
@@ -594,9 +594,8 @@ static void handleRedisCommand(RedisRaftCtx *rr,
         return;
     }
 
-    if (GetAskingState(rr, ctx)) {
-        cmds->asking = true;
-    }
+    /* update cmds array with the client's saved "asking" state */
+    cmds->asking = getAskingState(rr, ctx);
 
     /* Check if MULTI/EXEC bundling is required. */
     if (MultiHandleCommand(rr, ctx, cmds)) {

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -599,13 +599,13 @@ static void handleRedisCommand(RedisRaftCtx *rr,
         return;
     }
 
+    if (GetAskingState(rr, ctx)) {
+        cmds->asking = true;
+    }
+
     /* Check if MULTI/EXEC bundling is required. */
     if (MultiHandleCommand(rr, ctx, cmds)) {
         return;
-    }
-
-    if (GetAskingState(rr, ctx)) {
-        cmds->asking = true;
     }
 
     /* Handle intercepted commands. We do this also on non-leader nodes or if we
@@ -653,8 +653,6 @@ static void handleRedisCommand(RedisRaftCtx *rr,
         if (rr->config->quorum_reads) {
             RaftReq *req = RaftReqInit(ctx, RR_REDISCOMMAND);
             RaftRedisCommandArrayMove(&req->r.redis.cmds, cmds);
-            /* need to save asking flag when we move the cmds */
-            req->r.redis.cmds.asking = cmds->asking;
             raft_queue_read_request(rr->raft, handleReadOnlyCommand, req);
         } else {
             /* Wait until the new leader applies an entry from the current term.
@@ -674,8 +672,6 @@ static void handleRedisCommand(RedisRaftCtx *rr,
 
     RaftReq *req = RaftReqInit(ctx, RR_REDISCOMMAND);
     RaftRedisCommandArrayMove(&req->r.redis.cmds, cmds);
-    /* need to save asking flag when we move the cmds */
-    req->r.redis.cmds.asking = cmds->asking;
 
     raft_entry_t *entry = RaftRedisCommandArraySerialize(&req->r.redis.cmds);
     entry->id = rand();

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1754,7 +1754,6 @@ static void handleInfo(RedisModuleInfoCtx *ctx, int for_crash_report)
     RedisModule_InfoAddFieldULongLong(ctx, "snapshots_created", rr->snapshots_created);
 
     RedisModule_InfoAddSection(ctx, "clients");
-    RedisModule_InfoAddFieldULongLong(ctx, "clients_state_tracking", ClientStatesCount(rr));
     RedisModule_InfoAddFieldULongLong(ctx, "proxy_reqs", rr->proxy_reqs);
     RedisModule_InfoAddFieldULongLong(ctx, "proxy_failed_reqs", rr->proxy_failed_reqs);
     RedisModule_InfoAddFieldULongLong(ctx, "proxy_failed_responses", rr->proxy_failed_responses);

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -483,7 +483,6 @@ typedef struct {
 
 typedef struct {
     bool asking;        /* if this command array is an asking */
-    int slot;           /* redis key slot these commands are associated with */
     int size;           /* Size of allocated array */
     int len;            /* Number of elements in array */
     RaftRedisCommand **commands;
@@ -717,8 +716,9 @@ void joinLinkIdleCallback(Connection *conn);
 void joinLinkFreeCallback(void *privdata);
 const char *getStateStr(RedisRaftCtx *rr);
 void replyRaftError(RedisModuleCtx *ctx, int error);
-raft_node_t *getLeaderNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx);
-RRStatus checkLeader(RedisRaftCtx *rr, RedisModuleCtx *ctx, Node **ret_leader);
+raft_node_t *getLeaderRaftNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx);
+Node *getLeaderNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx);
+bool isLeader(RedisRaftCtx *rr);
 RRStatus checkRaftNotLoading(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 RRStatus checkRaftUninitialized(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 RRStatus checkRaftState(RedisRaftCtx *rr, RedisModuleCtx *ctx);
@@ -881,7 +881,7 @@ void ShardGroupFree(ShardGroup *sg);
 void ShardGroupTerm(ShardGroup *sg);
 ShardGroup *ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int base_argv_idx, int *num_elems);
 ShardGroup **ShardGroupsParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *len);
-RRStatus computeHashSlot(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds);
+RRStatus computeHashSlot(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds, unsigned int *slot);
 void ShardingHandleClusterCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommand *cmd);
 void ShardingInfoInit(RedisRaftCtx *rr);
 void ShardingInfoReset(RedisRaftCtx *rr);
@@ -911,6 +911,7 @@ void MigrateKeys(RedisRaftCtx *rr, RaftReq *req);
 RRStatus CommandSpecInit(RedisModuleCtx *ctx, RedisRaftConfig *config);
 unsigned int CommandSpecGetAggregateFlags(RaftRedisCommandArray *array, unsigned int default_flags);
 const CommandSpec *CommandSpecGet(const RedisModuleString *cmd);
+bool IsKeyCommands(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds);
 
 /* sort.c */
 void handleSort(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -335,7 +335,6 @@ typedef struct RedisRaftCtx {
     struct RaftReq *transfer_req;                /* RaftReq if a leader transfer is in progress */
     RedisModuleCommandFilter *registered_filter; /* Command filter is used for intercepting redis commands */
     struct ShardingInfo *sharding_info;          /* Information about sharding, when cluster mode is enabled */
-
     RedisModuleDict *client_state;               /* A dict that tracks different client states */
 
     /* General stats */
@@ -724,7 +723,7 @@ RRStatus checkRaftUninitialized(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 RRStatus checkRaftState(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 void replyRedirect(RedisModuleCtx *ctx, int slot, NodeAddr *addr);
 void replyCrossSlot(RedisModuleCtx *ctx);
-void replyWithFormatErrorString(RedisModuleCtx *ctx, const char * fmt, ...);
+void replyWithFormatErrorString(RedisModuleCtx *ctx, const char *fmt, ...);
 bool parseMovedReply(const char *str, NodeAddr *addr);
 void raftNodeToString(char *output, const char *dbid, raft_node_t *raft_node);
 void raftNodeIdToString(char *output, const char *dbid, raft_node_id_t raft_id);
@@ -789,8 +788,8 @@ void HandleAsking(RaftRedisCommandArray *cmds);
 void FreeImportKeys(ImportKeys *target);
 unsigned int keyHashSlot(const char *key, size_t keylen);
 unsigned int keyHashSlotRedisString(RedisModuleString *s);
-RRStatus parseHashSlots(char * slots, char * string);
-ClientState * ClientStateGet(RedisRaftCtx *rr, RedisModuleCtx * ctx);
+RRStatus parseHashSlots(char *slots, char *string);
+ClientState *ClientStateGet(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 uint64_t ClientStatesCount(RedisRaftCtx *rr);
 void ClientStateAlloc(RedisRaftCtx *rr, unsigned long long client_id);
 void ClientStateFree(RedisRaftCtx *rr, unsigned long long client_id);
@@ -813,8 +812,8 @@ long long int RaftLogRewrite(RedisRaftCtx *rr, const char *filename, raft_index_
 void RaftLogRemoveFiles(const char *filename);
 void RaftLogArchiveFiles(RedisRaftCtx *rr);
 RRStatus RaftLogRewriteSwitch(RedisRaftCtx *rr, RaftLog *new_log, unsigned long new_log_entries);
-int RaftMetaRead(RaftMeta *meta, const char* filename);
-int RaftMetaWrite(RaftMeta *meta, const char* filename, raft_term_t term, raft_node_id_t vote);
+int RaftMetaRead(RaftMeta *meta, const char *filename);
+int RaftMetaWrite(RaftMeta *meta, const char*filename, raft_term_t term, raft_node_id_t vote);
 
 typedef struct EntryCache {
     raft_index_t size;                  /* Size of ptrs */
@@ -918,7 +917,7 @@ const CommandSpec *CommandSpecGet(const RedisModuleString *cmd);
 void handleSort(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 /* multi.c */
-void ResetMultiClientState(ClientState * clientState);
+void MultiClientStateReset(ClientState *clientState);
 bool MultiHandleCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds);
 #endif  /* _REDISRAFT_H */
 
@@ -926,6 +925,6 @@ bool MultiHandleCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandA
 int calcIntSerializedLen(size_t val);
 int decodeInteger(const char *ptr, size_t sz, char expect_prefix, size_t *val);
 int encodeInteger(char prefix, char *ptr, size_t sz, unsigned long val);
-size_t calcSerializeStringSize(RedisModuleString * str);
+size_t calcSerializeStringSize(RedisModuleString *str);
 int decodeString(const char *p, size_t sz, RedisModuleString **str);
-int encodeString(char *p, size_t sz, RedisModuleString * str);
+int encodeString(char *p, size_t sz, RedisModuleString *str);

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -483,6 +483,7 @@ typedef struct {
 
 typedef struct {
     bool asking;        /* if this command array is an asking */
+    int slot;           /* redis key slot these commands are associated with */
     int size;           /* Size of allocated array */
     int len;            /* Number of elements in array */
     RaftRedisCommand **commands;
@@ -721,13 +722,13 @@ RRStatus checkLeader(RedisRaftCtx *rr, RedisModuleCtx *ctx, Node **ret_leader);
 RRStatus checkRaftNotLoading(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 RRStatus checkRaftUninitialized(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 RRStatus checkRaftState(RedisRaftCtx *rr, RedisModuleCtx *ctx);
-void replyRedirect(RedisModuleCtx *ctx, int slot, NodeAddr *addr);
+void replyRedirect(RedisModuleCtx *ctx, unsigned int slot, NodeAddr *addr);
 void replyCrossSlot(RedisModuleCtx *ctx);
 void replyWithFormatErrorString(RedisModuleCtx *ctx, const char *fmt, ...);
 bool parseMovedReply(const char *str, NodeAddr *addr);
 void raftNodeToString(char *output, const char *dbid, raft_node_t *raft_node);
 void raftNodeIdToString(char *output, const char *dbid, raft_node_id_t raft_id);
-void replyAsk(RedisRaftCtx *rr, RedisModuleCtx *ctx, int slot);
+void replyAsk(RedisRaftCtx *rr, RedisModuleCtx *ctx, unsigned int slot);
 
 /* node_addr.c */
 bool NodeAddrParse(const char *node_addr, size_t node_addr_len, NodeAddr *result);
@@ -784,7 +785,6 @@ RRStatus parseMemorySize(const char *value, unsigned long *result);
 RRStatus formatExactMemorySize(unsigned long value, char *buf, size_t buf_size);
 void handleRMCallError(RedisModuleCtx *reply_ctx, int ret_errno, const char *cmd, size_t cmdlen);
 void AddBasicLocalShardGroup(RedisRaftCtx *rr);
-void HandleAsking(RaftRedisCommandArray *cmds);
 void FreeImportKeys(ImportKeys *target);
 unsigned int keyHashSlot(const char *key, size_t keylen);
 unsigned int keyHashSlotRedisString(RedisModuleString *s);
@@ -881,7 +881,7 @@ void ShardGroupFree(ShardGroup *sg);
 void ShardGroupTerm(ShardGroup *sg);
 ShardGroup *ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int base_argv_idx, int *num_elems);
 ShardGroup **ShardGroupsParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *len);
-RRStatus computeHashSlot(RedisRaftCtx *rr, RaftRedisCommandArray *cmds, int *slot);
+RRStatus computeHashSlot(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds);
 void ShardingHandleClusterCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommand *cmd);
 void ShardingInfoInit(RedisRaftCtx *rr);
 void ShardingInfoReset(RedisRaftCtx *rr);

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -335,7 +335,9 @@ typedef struct RedisRaftCtx {
     struct RaftReq *transfer_req;                /* RaftReq if a leader transfer is in progress */
     RedisModuleCommandFilter *registered_filter; /* Command filter is used for intercepting redis commands */
     struct ShardingInfo *sharding_info;          /* Information about sharding, when cluster mode is enabled */
+
     RedisModuleDict *multi_client_state;         /* A dict that tracks multi state of the clients */
+    RedisModuleDict *asking_client_state;        /* A dict that tracks if a client is in an asking state */
 
     /* General stats */
     unsigned long client_attached_entries;       /* Number of log entries attached to user connections */

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -812,7 +812,7 @@ void RaftLogRemoveFiles(const char *filename);
 void RaftLogArchiveFiles(RedisRaftCtx *rr);
 RRStatus RaftLogRewriteSwitch(RedisRaftCtx *rr, RaftLog *new_log, unsigned long new_log_entries);
 int RaftMetaRead(RaftMeta *meta, const char *filename);
-int RaftMetaWrite(RaftMeta *meta, const char*filename, raft_term_t term, raft_node_id_t vote);
+int RaftMetaWrite(RaftMeta *meta, const char *filename, raft_term_t term, raft_node_id_t vote);
 
 typedef struct EntryCache {
     raft_index_t size;                  /* Size of ptrs */

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -790,7 +790,6 @@ unsigned int keyHashSlot(const char *key, size_t keylen);
 unsigned int keyHashSlotRedisString(RedisModuleString *s);
 RRStatus parseHashSlots(char *slots, char *string);
 ClientState *ClientStateGet(RedisRaftCtx *rr, RedisModuleCtx *ctx);
-uint64_t ClientStatesCount(RedisRaftCtx *rr);
 void ClientStateAlloc(RedisRaftCtx *rr, unsigned long long client_id);
 void ClientStateFree(RedisRaftCtx *rr, unsigned long long client_id);
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -708,7 +708,7 @@ typedef struct MultiState {
 } MultiState;
 
 typedef struct ClientState {
-    MultiState multiState;
+    MultiState multi_state;
     bool asking;
 } ClientState;
 
@@ -790,10 +790,10 @@ void FreeImportKeys(ImportKeys *target);
 unsigned int keyHashSlot(const char *key, size_t keylen);
 unsigned int keyHashSlotRedisString(RedisModuleString *s);
 RRStatus parseHashSlots(char * slots, char * string);
-ClientState * GetClientState(RedisRaftCtx *rr, RedisModuleCtx * ctx);
-uint64_t ClientStateCount(RedisRaftCtx *rr);
-void AllocClientState(RedisRaftCtx *rr, unsigned long long client_id);
-void FreeClientState(RedisRaftCtx *rr, unsigned long long client_id);
+ClientState * ClientStateGet(RedisRaftCtx *rr, RedisModuleCtx * ctx);
+uint64_t ClientStatesCount(RedisRaftCtx *rr);
+void ClientStateAlloc(RedisRaftCtx *rr, unsigned long long client_id);
+void ClientStateFree(RedisRaftCtx *rr, unsigned long long client_id);
 
 /* log.c */
 RaftLog *RaftLogCreate(const char *filename, const char *dbid, raft_term_t snapshot_term, raft_index_t snapshot_index, RedisRaftConfig *config);
@@ -918,6 +918,7 @@ const CommandSpec *CommandSpecGet(const RedisModuleString *cmd);
 void handleSort(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 /* multi.c */
+void ResetMultiClientState(ClientState * clientState);
 bool MultiHandleCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds);
 #endif  /* _REDISRAFT_H */
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -718,7 +718,6 @@ const char *getStateStr(RedisRaftCtx *rr);
 void replyRaftError(RedisModuleCtx *ctx, int error);
 raft_node_t *getLeaderRaftNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 Node *getLeaderNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx);
-bool isLeader(RedisRaftCtx *rr);
 RRStatus checkRaftNotLoading(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 RRStatus checkRaftUninitialized(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 RRStatus checkRaftState(RedisRaftCtx *rr, RedisModuleCtx *ctx);
@@ -881,7 +880,7 @@ void ShardGroupFree(ShardGroup *sg);
 void ShardGroupTerm(ShardGroup *sg);
 ShardGroup *ShardGroupParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int base_argv_idx, int *num_elems);
 ShardGroup **ShardGroupsParse(RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *len);
-RRStatus computeHashSlot(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds, unsigned int *slot);
+RRStatus computeHashSlot(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds, int *slot);
 void ShardingHandleClusterCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommand *cmd);
 void ShardingInfoInit(RedisRaftCtx *rr);
 void ShardingInfoReset(RedisRaftCtx *rr);
@@ -911,7 +910,6 @@ void MigrateKeys(RedisRaftCtx *rr, RaftReq *req);
 RRStatus CommandSpecInit(RedisModuleCtx *ctx, RedisRaftConfig *config);
 unsigned int CommandSpecGetAggregateFlags(RaftRedisCommandArray *array, unsigned int default_flags);
 const CommandSpec *CommandSpecGet(const RedisModuleString *cmd);
-bool IsKeyCommands(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds);
 
 /* sort.c */
 void handleSort(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -724,6 +724,7 @@ RRStatus checkRaftUninitialized(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 RRStatus checkRaftState(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 void replyRedirect(RedisModuleCtx *ctx, unsigned int slot, NodeAddr *addr);
 void replyCrossSlot(RedisModuleCtx *ctx);
+void replyClusterDownWithNoRaftLeader(RedisModuleCtx *ctx);
 void replyWithFormatErrorString(RedisModuleCtx *ctx, const char *fmt, ...);
 bool parseMovedReply(const char *str, NodeAddr *addr);
 void raftNodeToString(char *output, const char *dbid, raft_node_t *raft_node);

--- a/src/serialization.c
+++ b/src/serialization.c
@@ -103,7 +103,7 @@ static size_t calcSerializedSize(RaftRedisCommand *cmd)
 /* Serialize a number of RaftRedisCommand into a Raft entry */
 raft_entry_t *RaftRedisCommandArraySerialize(const RaftRedisCommandArray *source)
 {
-    size_t sz = calcIntSerializedLen(source->len);
+    size_t sz = calcIntSerializedLen(source->asking) + calcIntSerializedLen(source->len);
     size_t len;
     int n, i, j;
     char *p;
@@ -116,6 +116,11 @@ raft_entry_t *RaftRedisCommandArraySerialize(const RaftRedisCommandArray *source
     /* Prepare entry */
     raft_entry_t *ety = raft_entry_new(sz);
     p = ety->data;
+
+    /* Encode Asking */
+    n = encodeInteger('*', p, sz, source->asking);
+    RedisModule_Assert(n != -1);
+    p +=n; sz -= n;
 
     /* Encode count */
     n = encodeInteger('*', p, sz, source->len);
@@ -195,7 +200,15 @@ RRStatus RaftRedisCommandArrayDeserialize(RaftRedisCommandArray *target, const v
         RaftRedisCommandArrayFree(target);
     }
 
-    /* Read multibulk count */
+    /* Read asking */
+    size_t asking;
+    if ((n = decodeInteger(p, buf_size, '*', &asking)) < 0) {
+        return RR_ERROR;
+    }
+    p += n; buf_size -= n;
+    target->asking = asking;
+
+    /* Read command count */
     if ((n = decodeInteger(p, buf_size, '*', &commands_num)) < 0 ||
             !commands_num) {
         return RR_ERROR;

--- a/src/serialization.c
+++ b/src/serialization.c
@@ -47,6 +47,8 @@ void RaftRedisCommandArrayMove(RaftRedisCommandArray *target, RaftRedisCommandAr
 
     source->len = 0;
     memset(source->commands, 0, sizeof(RaftRedisCommand *) * source->size);
+
+    target->asking = source->asking;
 }
 
 /* Free a RaftRedisCommand */

--- a/src/util.c
+++ b/src/util.c
@@ -502,7 +502,7 @@ exit:
     return ret;
 }
 
-ClientState *ClientStateGet(RedisRaftCtx *rr, RedisModuleCtx * ctx)
+ClientState *ClientStateGet(RedisRaftCtx *rr, RedisModuleCtx *ctx)
 {
     unsigned long long client_id = RedisModule_GetClientId(ctx);
     return RedisModule_DictGetC(rr->client_state, &client_id, sizeof(client_id), NULL);

--- a/src/util.c
+++ b/src/util.c
@@ -502,31 +502,31 @@ exit:
     return ret;
 }
 
-ClientState * GetClientState(RedisRaftCtx *rr, RedisModuleCtx * ctx)
+ClientState * ClientStateGet(RedisRaftCtx *rr, RedisModuleCtx * ctx)
 {
     unsigned long long client_id = RedisModule_GetClientId(ctx);
     return RedisModule_DictGetC(rr->client_state, &client_id, sizeof(client_id), NULL);
 }
 
-uint64_t ClientStateCount(RedisRaftCtx *rr)
+uint64_t ClientStatesCount(RedisRaftCtx *rr)
 {
     return RedisModule_DictSize(rr->client_state);
 }
 
-void AllocClientState(RedisRaftCtx *rr, unsigned long long client_id)
+void ClientStateAlloc(RedisRaftCtx *rr, unsigned long long client_id)
 {
     ClientState *clientState = RedisModule_Calloc(sizeof(ClientState), 1);
     RedisModule_DictSetC(rr->client_state, &client_id, sizeof(client_id), clientState);
 }
 
-void FreeClientState(RedisRaftCtx *rr, unsigned long long client_id)
+void ClientStateFree(RedisRaftCtx *rr, unsigned long long client_id)
 {
     ClientState *state = NULL;
 
     if (RedisModule_DictDelC(rr->client_state, &client_id,
                              sizeof(client_id), &state) == REDISMODULE_OK) {
         if (state) {
-            RaftRedisCommandArrayFree(&state->multiState.cmds);
+            ResetMultiClientState(state);
             RedisModule_Free(state);
         }
     }

--- a/src/util.c
+++ b/src/util.c
@@ -502,7 +502,7 @@ exit:
     return ret;
 }
 
-ClientState * ClientStateGet(RedisRaftCtx *rr, RedisModuleCtx * ctx)
+ClientState *ClientStateGet(RedisRaftCtx *rr, RedisModuleCtx * ctx)
 {
     unsigned long long client_id = RedisModule_GetClientId(ctx);
     return RedisModule_DictGetC(rr->client_state, &client_id, sizeof(client_id), NULL);

--- a/src/util.c
+++ b/src/util.c
@@ -528,6 +528,6 @@ void ClientStateFree(RedisRaftCtx *rr, unsigned long long client_id)
     RedisModule_Assert(ret == REDISMODULE_OK && state != NULL);
 
     /* validated that state is not NULL above in the RM_Assert */
-    ResetMultiClientState(state);
+    MultiClientStateReset(state);
     RedisModule_Free(state);
 }

--- a/src/util.c
+++ b/src/util.c
@@ -508,11 +508,6 @@ ClientState * ClientStateGet(RedisRaftCtx *rr, RedisModuleCtx * ctx)
     return RedisModule_DictGetC(rr->client_state, &client_id, sizeof(client_id), NULL);
 }
 
-uint64_t ClientStatesCount(RedisRaftCtx *rr)
-{
-    return RedisModule_DictSize(rr->client_state);
-}
-
 void ClientStateAlloc(RedisRaftCtx *rr, unsigned long long client_id)
 {
     ClientState *clientState = RedisModule_Calloc(sizeof(ClientState), 1);

--- a/src/util.c
+++ b/src/util.c
@@ -516,18 +516,18 @@ uint64_t ClientStatesCount(RedisRaftCtx *rr)
 void ClientStateAlloc(RedisRaftCtx *rr, unsigned long long client_id)
 {
     ClientState *clientState = RedisModule_Calloc(sizeof(ClientState), 1);
-    RedisModule_DictSetC(rr->client_state, &client_id, sizeof(client_id), clientState);
+    int ret = RedisModule_DictSetC(rr->client_state, &client_id, sizeof(client_id), clientState);
+    RedisModule_Assert(ret == REDISMODULE_OK);
 }
 
 void ClientStateFree(RedisRaftCtx *rr, unsigned long long client_id)
 {
     ClientState *state = NULL;
 
-    if (RedisModule_DictDelC(rr->client_state, &client_id,
-                             sizeof(client_id), &state) == REDISMODULE_OK) {
-        if (state) {
-            ResetMultiClientState(state);
-            RedisModule_Free(state);
-        }
-    }
+    int ret = RedisModule_DictDelC(rr->client_state, &client_id, sizeof(client_id), &state);
+    RedisModule_Assert(ret == REDISMODULE_OK && state != NULL);
+
+    /* validated that state is not NULL above in the RM_Assert */
+    ResetMultiClientState(state);
+    RedisModule_Free(state);
 }

--- a/src/util.c
+++ b/src/util.c
@@ -384,22 +384,6 @@ void AddBasicLocalShardGroup(RedisRaftCtx *rr) {
     RedisModule_Assert(ret == RR_OK);
 }
 
-void HandleAsking(RaftRedisCommandArray *cmds)
-{
-    RaftRedisCommand *cmd = cmds->commands[0];
-    size_t cmd_len;
-    const char *cmd_str = RedisModule_StringPtrLen(cmd->argv[0], &cmd_len);
-
-    if (cmd_len == 6 && !strncasecmp(cmd_str, "ASKING", 6)) {
-        cmds->asking = true;
-        RedisModule_FreeString(NULL, cmds->commands[0]->argv[0]);
-        for (int i = 1; i < cmds->commands[0]->argc; i++) {
-            cmds->commands[0]->argv[i-1] = cmds->commands[0]->argv[i];
-        }
-        cmds->commands[0]->argc--;
-    }
-}
-
 void FreeImportKeys(ImportKeys *target) {
     if (target->num_keys) {
         if (target->key_names) {

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -23,4 +23,9 @@ def test_raft_import(cluster):
 
     assert cluster.execute('raft.import', '2', '0', 'key', serialized) == b'OK'
 
-    assert cluster.execute("asking", "get", "key") == b'value'
+    conn = cluster.leader_node().client.connection_pool.get_connection('deferred')
+    conn.send_command('ASKING')
+    assert conn.read_response() == b'OK'
+
+    conn.send_command('get', 'key')
+    assert conn.read_response() == b'value'

--- a/tests/integration/test_multi.py
+++ b/tests/integration/test_multi.py
@@ -84,31 +84,6 @@ def test_multi_exec(cluster):
     assert conn.execute('GET', 'key') == b'3'
 
 
-def test_multi_exec_state_cleanup(cluster):
-    """
-    MULTI/EXEC state is cleaned up on client disconnect
-    """
-
-    r1 = cluster.add_node()
-
-    # Normal flow, no disconnect
-    c1 = r1.client.connection_pool.get_connection('multi')
-    c1.send_command('MULTI')
-    assert c1.read_response() == b'OK'
-
-    c2 = r1.client.connection_pool.get_connection('multi')
-    c2.send_command('MULTI')
-    assert c2.read_response() == b'OK'
-
-    assert r1.info()['raft_clients_state_tracking'] == 3
-
-    c1.disconnect()
-    c2.disconnect()
-
-    time.sleep(1)   # Not ideal
-    assert r1.info()['raft_clients_state_tracking'] == 1
-
-
 def test_multi_exec_proxying(cluster):
     """
     Proxy a MULTI/EXEC sequence

--- a/tests/integration/test_multi.py
+++ b/tests/integration/test_multi.py
@@ -100,13 +100,13 @@ def test_multi_exec_state_cleanup(cluster):
     c2.send_command('MULTI')
     assert c2.read_response() == b'OK'
 
-    assert r1.info()['raft_clients_in_multi_state'] == 2
+    assert r1.info()['raft_clients_state_tracking'] == 3
 
     c1.disconnect()
     c2.disconnect()
 
     time.sleep(1)   # Not ideal
-    assert r1.info()['raft_clients_in_multi_state'] == 0
+    assert r1.info()['raft_clients_state_tracking'] == 1
 
 
 def test_multi_exec_proxying(cluster):

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -485,12 +485,21 @@ def test_shard_group_reshard_to_import(cluster):
     conn.send_command('get', 'key')
     assert conn.read_response() == b'value'
 
+    conn.send_command('ASKING')
+    assert conn.read_response() == b'OK'
+
     conn.send_command('get', 'key1')
     with raises(ResponseError, match="TRYAGAIN"):
         conn.read_response()
 
+    conn.send_command('ASKING')
+    assert conn.read_response() == b'OK'
+
     conn.send_command("del", "key")
     assert conn.read_response() == 1
+
+    conn.send_command('ASKING')
+    assert conn.read_response() == b'OK'
 
     conn.send_command("get", "key")
     with raises(ResponseError, match="TRYAGAIN"):

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -504,3 +504,34 @@ def test_shard_group_reshard_to_import(cluster):
     conn.send_command("get", "key")
     with raises(ResponseError, match="TRYAGAIN"):
         conn.read_response()
+
+
+def test_asking_follower(cluster):
+    cluster.create(3, raft_args={
+        'sharding': 'yes',
+        'external-sharding': 'yes'
+    })
+
+    cluster.execute("set", "key", "value")
+
+    assert cluster.execute(
+        'RAFT.SHARDGROUP', 'REPLACE',
+        1,
+        cluster.leader_node().info()["raft_dbid"],
+        '1', '3',
+        '0', '16383', '2',
+        '1234567890123456789012345678901234567890', cluster.node(1).address,
+        '1234567890123456789012345678901234567891', cluster.node(2).address,
+        '1234567890123456789012345678901234567892', cluster.node(3).address
+    ) == b'OK'
+
+    cluster.wait_for_unanimity()
+    cluster.node(2).wait_for_log_applied()
+
+    conn = cluster.node(2).client.connection_pool.get_connection('deferred')
+    conn.send_command('ASKING')
+    assert conn.read_response() == b'OK'
+
+    conn.send_command('get', 'key')
+    with raises(ResponseError, match="ASK"):
+        conn.read_response()

--- a/tests/test_serialization.c
+++ b/tests/test_serialization.c
@@ -41,7 +41,7 @@ static void test_serialize_redis_command(void **state)
     setupRedisCommand(RaftRedisCommandArrayExtend(&cmd_array), cmd2_argv, 2);
     setupRedisCommand(RaftRedisCommandArrayExtend(&cmd_array), cmd3_argv, 1);
     
-    const char *expected = "*3\n*3\n$3\nSET\n$3\nkey\n$5\nvalue\n*2\n$3\nGET\n$5\nmykey\n*1\n$4\nPING\n";
+    const char *expected = "*0\n*3\n*3\n$3\nSET\n$3\nkey\n$5\nvalue\n*2\n$3\nGET\n$5\nmykey\n*1\n$4\nPING\n";
 
     raft_entry_t *e = RaftRedisCommandArraySerialize(&cmd_array);
     assert_non_null(e);
@@ -65,7 +65,7 @@ static void test_deserialize_redis_command(void **state)
 
 static void test_deserialize_redis_command_array(void **state)
 {
-    const char *serialized = "*3\n*3\n$3\nSET\n$3\nkey\n$5\nvalue\n*2\n$3\nGET\n$5\nmykey\n*1\n$4\nPING\n";
+    const char *serialized = "*0\n*3\n*3\n$3\nSET\n$3\nkey\n$5\nvalue\n*2\n$3\nGET\n$5\nmykey\n*1\n$4\nPING\n";
     int serialized_len = strlen(serialized);
 
     RaftRedisCommandArray cmd_array = { 0 };

--- a/tests/test_util.c
+++ b/tests/test_util.c
@@ -11,6 +11,7 @@
 #include <setjmp.h>
 #include <unistd.h>
 #include <string.h>
+#include <strings.h>
 
 #include "cmocka.h"
 


### PR DESCRIPTION
Based on conversation the understanding of asking was incorrect, its an independent command that sets a flag on the client, this is to make it the same.

- saves client state when go into asking mode
- set RedisRaftCommandArray as asking if client put itself into asking state
- no longer have to parse multi specially
- serialize/deserialize the asking bool the log entry for RaftRedisCommandArray
- no longer parse asking in the apply path (as not appended to log as a command)