### PR TITLE
put username/password into conn, so can be set for migration as well

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -865,7 +865,9 @@ RRStatus ShardingInfoAddShardGroup(RedisRaftCtx *rr, ShardGroup *sg)
      * */
     /* TODO: perhaps should only be called if using built in sharding mechanism */
     if (!rr->config->external_sharding && sg->nodes_num > 0) {
-        sg->conn = ConnCreate(rr, sg, establishShardGroupConn, NULL);
+        char *username = rr->config->cluster_user;
+        char *password = rr->config->cluster_password;
+        sg->conn = ConnCreate(rr, sg, establishShardGroupConn, NULL, username, password);
     }
 
     return RR_OK;
@@ -1633,7 +1635,9 @@ void ShardGroupLink(RedisRaftCtx *rr,
     st->connect_callback = linkSendRequest;
     st->start = time(NULL);
     st->req = RaftReqInit(ctx, RR_SHARDGROUP_LINK);
-    st->conn = ConnCreate(rr, st, joinLinkIdleCallback, joinLinkFreeCallback);
+    char *username = rr->config->cluster_user;
+    char *password = rr->config->cluster_password;
+    st->conn = ConnCreate(rr, st, joinLinkIdleCallback, joinLinkFreeCallback, username, password);
 }
 
 void ShardGroupGet(RedisRaftCtx *rr, RedisModuleCtx *ctx)

--- a/src/join.c
+++ b/src/join.c
@@ -125,5 +125,7 @@ void JoinCluster(RedisRaftCtx *rr, NodeAddrListElement *el, RaftReq *req,
     /* We just create the connection with an idle callback, which will
      * shortly fire and handle connection setup.
      */
-    st->conn = ConnCreate(rr, st, joinLinkIdleCallback, joinLinkFreeCallback);
+    char *username = rr->config->cluster_user;
+    char *password = rr->config->cluster_password;
+    st->conn = ConnCreate(rr, st, joinLinkIdleCallback, joinLinkFreeCallback, username, password);
 }

--- a/src/node.c
+++ b/src/node.c
@@ -99,7 +99,9 @@ Node *NodeCreate(RedisRaftCtx *rr, int id, const NodeAddr *addr)
     node->addr.port = addr->port;
 
     LIST_INSERT_HEAD(&node_list, node, entries);
-    node->conn = ConnCreate(node->rr, node, nodeIdleCallback, nodeFreeCallback);
+    char *username = rr->config->cluster_user;
+    char *password = rr->config->cluster_password;
+    node->conn = ConnCreate(node->rr, node, nodeIdleCallback, nodeFreeCallback, username, password);
 
     return node;
 }

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -173,6 +173,8 @@ typedef struct Connection {
     unsigned long int connect_oks;      /* Successful connects */
     unsigned long int connect_errors;   /* Connection errors since last connection */
     struct timeval timeout;             /* Timeout to use if not null */
+    char * username;                    /* username to use if specified */
+    char * password;                    /* password to use if specified */
     void *privdata;                     /* User provided pointer */
 
     struct AddrinfoResult {
@@ -799,7 +801,7 @@ void archiveSnapshot(RedisRaftCtx *rr);
 RRStatus ProxyCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds, Node *leader);
 
 /* connection.c */
-Connection *ConnCreate(RedisRaftCtx *rr, void *privdata, ConnectionCallbackFunc idle_cb, ConnectionFreeFunc free_cb);
+Connection *ConnCreate(RedisRaftCtx *rr, void *privdata, ConnectionCallbackFunc idle_cb, ConnectionFreeFunc free_cb, char * username, char *password);
 RRStatus ConnConnect(Connection *conn, const NodeAddr *addr, ConnectionCallbackFunc connect_callback);
 void ConnAsyncTerminate(Connection *conn);
 void ConnMarkDisconnected(Connection *conn);


### PR DESCRIPTION
previously we assumed it be a single shared password in a redisraft cluster (or cluster of clusters), I think we should enable it to be configured, as don't think