### PR TITLE
Refactor

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -61,6 +61,28 @@ void replyRaftError(RedisModuleCtx *ctx, int error)
     }
 }
 
+/* Try to produce an error message which is similar to Redis */
+void replyRMCallError(RedisModuleCtx *ctx, int err, const char *cmd, size_t len)
+{
+    char buf[1024];
+    const char *msg;
+
+    switch (err) {
+        case ENOENT:
+            msg = "ERR unknown command `%.*s`";
+            break;
+        case EINVAL:
+            msg = "ERR wrong number of arguments for '%.*s' command";
+            break;
+        default:
+            msg = "ERR failed to execute command '%.*s'";
+            break;
+    }
+
+    snprintf(buf, sizeof(buf), msg, (int) len, cmd);
+    RedisModule_ReplyWithError(ctx, buf);
+}
+
 /* Create a -MOVED reply. */
 void replyRedirect(RedisModuleCtx *ctx, int slot, NodeAddr *addr)
 {

--- a/src/raft.c
+++ b/src/raft.c
@@ -165,7 +165,7 @@ void RaftExecuteCommandArray(RedisModuleCtx *ctx,
             if (reply) {
                 RedisModule_ReplyWithCallReply(reply_ctx, reply);
             } else {
-                handleRMCallError(reply_ctx, ret_errno, cmd, cmdlen);
+                replyRMCallError(reply_ctx, ret_errno, cmd, cmdlen);
             }
         }
 

--- a/src/raft.c
+++ b/src/raft.c
@@ -124,9 +124,10 @@ void RaftExecuteCommandArray(RedisModuleCtx *ctx,
                              RedisModuleCtx *reply_ctx,
                              RaftRedisCommandArray *array)
 {
-    int i;
+    RedisRaftCtx *rr = &redis_raft;
+    RedisModuleCallReply *reply;
 
-    for (i = 0; i < array->len; i++) {
+    for (int i = 0; i < array->len; i++) {
         RaftRedisCommand *c = array->commands[i];
 
         size_t cmdlen;
@@ -145,21 +146,21 @@ void RaftExecuteCommandArray(RedisModuleCtx *ctx,
             continue;
         }
 
-        enterRedisModuleCall();
-        int eval = 0;
-        int old_entered_eval = 0;
-        if ((cmdlen == 4 && !strncasecmp(cmd, "eval", 4)) || (cmdlen == 7 && !strncasecmp(cmd, "evalsha", 7))) {
-            old_entered_eval = redis_raft.entered_eval;
-            eval = 1;
-            redis_raft.entered_eval = 1;
+        int old_entered_eval = rr->entered_eval;
+
+        if ((cmdlen == 4 && !strncasecmp(cmd, "eval", 4)) ||
+            (cmdlen == 7 && !strncasecmp(cmd, "evalsha", 7))) {
+            rr->entered_eval = 1;
         }
-        RedisModuleCallReply *reply = RedisModule_Call(
-                ctx, cmd, redis_raft.resp_call_fmt, &c->argv[1], c->argc - 1);
+
+        enterRedisModuleCall();
+        reply = RedisModule_Call(ctx, cmd,
+                                 rr->resp_call_fmt, &c->argv[1], c->argc - 1);
         int ret_errno = errno;
         exitRedisModuleCall();
-        if (eval) {
-            redis_raft.entered_eval = old_entered_eval;
-        }
+
+        rr->entered_eval = old_entered_eval;
+
 
         if (reply_ctx) {
             if (reply) {

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -671,6 +671,7 @@ void joinLinkIdleCallback(Connection *conn);
 void joinLinkFreeCallback(void *privdata);
 const char *getStateStr(RedisRaftCtx *rr);
 void replyRaftError(RedisModuleCtx *ctx, int error);
+void replyRMCallError(RedisModuleCtx *ctx, int err, const char *cmd, size_t len);
 raft_node_t *getLeaderNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 RRStatus checkLeader(RedisRaftCtx *rr, RedisModuleCtx *ctx, Node **ret_leader);
 RRStatus checkRaftNotLoading(RedisRaftCtx *rr, RedisModuleCtx *ctx);
@@ -728,7 +729,6 @@ int stringmatchlen(const char *pattern, int patternLen, const char *string, int 
 int stringmatch(const char *pattern, const char *string, int nocase);
 RRStatus parseMemorySize(const char *value, unsigned long *result);
 RRStatus formatExactMemorySize(unsigned long value, char *buf, size_t buf_size);
-void handleRMCallError(RedisModuleCtx *reply_ctx, int ret_errno, const char *cmd, size_t cmdlen);
 void AddBasicLocalShardGroup(RedisRaftCtx *rr);
 
 /* log.c */

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -776,7 +776,7 @@ void ConfigSet(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, 
 void ConfigGet(RedisRaftCtx *rr, RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 RRStatus ConfigReadFromRedis(RedisRaftCtx *rr);
 RRStatus ConfigureRedis(RedisModuleCtx *ctx);
-void updateTLSConfig(RedisModuleCtx *ctx, RedisRaftConfig *config);
+void ConfigUpdateTLS(RedisModuleCtx *ctx, RedisRaftConfig *config);
 
 /* snapshot.c */
 extern RedisModuleTypeMethods RedisRaftTypeMethods;

--- a/src/sort.c
+++ b/src/sort.c
@@ -155,7 +155,7 @@ void handleSort(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     redis_raft.entered_eval = entered_eval;
 
     if (!reply) {
-        handleRMCallError(ctx, errno, cmd_str, cmd_len);
+        replyRMCallError(ctx, errno, cmd_str, cmd_len);
     } else {
         int reply_type = RedisModule_CallReplyType(reply);
         switch (reply_type) {

--- a/src/util.c
+++ b/src/util.c
@@ -307,28 +307,6 @@ RRStatus formatExactMemorySize(unsigned long value, char *buf, size_t size)
     return RR_OK;
 }
 
-/* Try to produce an error message which is similar to Redis */
-void handleRMCallError(RedisModuleCtx *ctx, int err, const char *cmd, size_t len)
-{
-    char buf[1024];
-    const char *fmt;
-
-    switch (err) {
-        case ENOENT:
-            fmt = "ERR unknown command `%.*s`";
-            break;
-        case EINVAL:
-            fmt = "ERR wrong number of arguments for '%.*s' command";
-            break;
-        default:
-            fmt = "ERR failed to execute command '%.*s'";
-            break;
-    }
-
-    snprintf(buf, sizeof(buf), fmt, (int) len, cmd);
-    RedisModule_ReplyWithError(ctx, buf);
-}
-
 /* This function assumes that the rr->config->slot_config has already been validated as valid */
 ShardGroup * CreateAndFillShard(RedisRaftCtx *rr)
 {


### PR DESCRIPTION
- Refactored TLS config code to avoid some if checks.
- Renamed a function name to follow coding convention of using uppercase letter for exported functions.
- Used stack allocated buffer to for RM_Call() error message.
- Simplified `entered_eval` logic in RaftExecuteCommandArray()