### PR TITLE
Fix Terraform warning

### DIFF
--- a/utils/deploy-aws/main.tf
+++ b/utils/deploy-aws/main.tf
@@ -133,7 +133,7 @@ resource "null_resource" "instances_yml" {
 
 # Run Ansible to deploy cluster and control nodes
 resource "null_resource" "ansible" {
-  depends_on = ["aws_instance.control", "aws_instance.node"]
+  depends_on = [aws_instance.control, aws_instance.node]
   provisioner "local-exec" {
     command = "ansible-playbook --extra-vars @ansible/instances.yml ansible/site.yml"
   }


### PR DESCRIPTION
Fixed Terraform warning.

```
╷
│ Warning: Quoted references are deprecated
│ 
│   on main.tf line 136, in resource "null_resource" "ansible":
│  136:   depends_on = ["aws_instance.control", "aws_instance.node"]
│ 
│ In this context, references are expected literally rather than in quotes. Terraform 0.11 and earlier required quotes, but quoted references are now deprecated and will be removed in a
│ future version of Terraform. Remove the quotes surrounding this reference to silence this warning.
│ 
│ (and one more similar warning elsewhere)
╵

```