### PR TITLE
Fix CMake TLS build comment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 #        mkdir build && cd build && cmake .. -DSANITIZER=address
 #        make && make tests
 # TLS:
-#        mkdir build && cd build && cmake .. -DBUILD_TLS=1
+#        mkdir build && cd build && cmake .. -DBUILD_TLS=1 -DPYTEST_OPTS="--tls -v"
 #        make && make tests
 
 cmake_policy(SET CMP0048 NEW)


### PR DESCRIPTION
Fixed CMake TLS build comment.

`--tls` config is required for Pytest.