### PR TITLE
Move raftlib function into RaftLibraryInit()

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -1052,6 +1052,11 @@ void RaftLibraryInit(RedisRaftCtx *rr, bool cluster_init)
 {
     raft_node_t *node;
 
+    raft_set_heap_functions(RedisModule_Alloc,
+                            RedisModule_Calloc,
+                            RedisModule_Realloc,
+                            RedisModule_Free);
+
     rr->raft = raft_new_with_log(&RaftLogImpl, rr);
     if (!rr->raft) {
         PANIC("Failed to initialize Raft library");

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1723,11 +1723,6 @@ __attribute__((__unused__)) int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisMod
         return REDISMODULE_ERR;
     }
 
-    raft_set_heap_functions(RedisModule_Alloc,
-                            RedisModule_Calloc,
-                            RedisModule_Realloc,
-                            RedisModule_Free);
-
     if (RedisRaftInit(ctx, &redis_raft, &config) == RR_ERROR) {
         return REDISMODULE_ERR;
     }


### PR DESCRIPTION
Moved into the function that we initialize raft library.