### PR TITLE
Remove obsolete comment about raft thread

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -787,13 +787,6 @@ raft_cbs_t redis_raft_callbacks = {
     .backpressure = raftBackpressure
 };
 
-/* ------------------------------------ Raft Thread ------------------------------------ */
-
-/*
- * Handling of the Redis Raft context, including its own thread and
- * async I/O loop.
- */
-
 RRStatus applyLoadedRaftLog(RedisRaftCtx *rr)
 {
     /* Make sure the log we're going to apply matches the RDB we've loaded */


### PR DESCRIPTION
Starting with https://github.com/RedisLabs/redisraft/pull/192, RedisRaft uses Redis' thread and event loop. 