### PR TITLE
happy path migrate test

### DIFF
--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -110,7 +110,20 @@ def test_happy_migrate(cluster_factory):
     assert conn.read_response() == b'value'
 
     conn.send_command('get', '{key}key1')
+    with raises(ResponseError, match="MOVED 12539 localhost:5001"):
+        conn.read_response()
+
+    conn.send_command('ASKING')
+    assert conn.read_response() == b'OK'
+    conn.send_command('get', '{key}key1')
     assert conn.read_response() == b'value1'
+
+    conn.send_command('get', 'key1')
+    with raises(ResponseError, match="MOVED 9189 localhost:5001"):
+        conn.read_response()
+
+    conn.send_command('ASKING')
+    assert conn.read_response() == b'OK'
     conn.send_command('get', 'key1')
     with raises(ResponseError, match="TRYAGAIN"):
         conn.read_response()

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -1,7 +1,6 @@
 from _pytest.python_api import raises
 from redis import ResponseError
 
-
 def test_raft_import(cluster):
     cluster.create(3, raft_args={'sharding': 'yes', 'external-sharding': 'yes'})
     assert cluster.execute('set', 'key', 'value')
@@ -47,3 +46,85 @@ def test_raft_import(cluster):
 
     conn.send_command('get', 'key')
     assert conn.read_response() == b'value'
+
+
+def test_happy_migrate(cluster_factory):
+    cluster1 = cluster_factory().create(1, raft_args={
+        'sharding': 'yes',
+        'external-sharding': 'yes'})
+    cluster2 = cluster_factory().create(1, raft_args={
+        'sharding': 'yes',
+        'external-sharding': 'yes'})
+
+    cluster1_dbid = cluster1.leader_node().info()["raft_dbid"]
+    cluster2_dbid = cluster2.leader_node().info()["raft_dbid"]
+
+    assert cluster1.execute('set', 'key', 'value')
+    assert cluster1.execute('get', 'key') == b'value'
+    assert cluster1.execute('set', '{key}key1', 'value1')
+    assert cluster1.execute('get', '{key}key1') == b'value1'
+
+    assert cluster1.execute(
+        'RAFT.SHARDGROUP', 'REPLACE',
+        '2',
+        cluster2_dbid,
+        '1', '1',
+        '0', '16383', '2',
+        '%s00000001' % cluster2_dbid, 'localhost:%s' % cluster2.node(1).port,
+        cluster1_dbid,
+        '1', '1',
+        '0', '16383', '3',
+        '%s00000001' % cluster1_dbid, 'localhost:%s' % cluster1.node(1).port,
+        ) == b'OK'
+
+    assert cluster2.execute(
+        'RAFT.SHARDGROUP', 'REPLACE',
+        '2',
+        cluster2_dbid,
+        '1', '1',
+        '0', '16383', '2',
+        '%s00000001' % cluster2_dbid, 'localhost:%s' % cluster2.node(1).port,
+        cluster1_dbid,
+        '1', '1',
+        '0', '16383', '3',
+        '%s00000001' % cluster1_dbid, 'localhost:%s' % cluster1.node(1).port,
+        ) == b'OK'
+
+    assert cluster1.execute("migrate", "", "", "", "", "", "keys", "key", "{key}key1") == b'OK'
+
+    with raises(ResponseError, match="ASK 12539 localhost"):
+        cluster1.execute("get", "key")
+
+    with raises(ResponseError, match="ASK 12539 localhost"):
+        cluster1.execute("get", "{key}key1")
+
+    with raises(ResponseError, match="MOVED 12539 localhost"):
+        # can't use cluster.execute() as that will try to handle the MOVED response itself
+        cluster2.leader_node().client.get("key")
+
+    conn = cluster2.leader_node().client.connection_pool.get_connection('deferred')
+    conn.send_command('ASKING')
+    assert conn.read_response() == b'OK'
+
+    conn.send_command('get', 'key')
+    assert conn.read_response() == b'value'
+
+    conn.send_command('get', '{key}key1')
+    assert conn.read_response() == b'value1'
+    conn.send_command('get', 'key1')
+    with raises(ResponseError, match="TRYAGAIN"):
+        conn.read_response()
+
+    assert cluster2.execute(
+        'RAFT.SHARDGROUP', 'REPLACE',
+        '1',
+        cluster2_dbid,
+        '1', '1',
+        '0', '16383', '1',
+        '%s00000001' % cluster2_dbid, 'localhost:%s' % cluster2.node(1).port,
+    ) == b'OK'
+
+    assert cluster2.execute("get", "key") == b'value'
+    assert cluster2.execute("get", "{key}key1") == b'value1'
+    assert cluster2.execute("get", "key1") is None
+

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -69,11 +69,11 @@ def test_happy_migrate(cluster_factory):
         '2',
         cluster2_dbid,
         '1', '1',
-        '0', '16383', '2',
+        '0', '16383', '2', '123',
         '%s00000001' % cluster2_dbid, 'localhost:%s' % cluster2.node(1).port,
         cluster1_dbid,
         '1', '1',
-        '0', '16383', '3',
+        '0', '16383', '3', '123',
         '%s00000001' % cluster1_dbid, 'localhost:%s' % cluster1.node(1).port,
         ) == b'OK'
 
@@ -82,11 +82,11 @@ def test_happy_migrate(cluster_factory):
         '2',
         cluster2_dbid,
         '1', '1',
-        '0', '16383', '2',
+        '0', '16383', '2', '123',
         '%s00000001' % cluster2_dbid, 'localhost:%s' % cluster2.node(1).port,
         cluster1_dbid,
         '1', '1',
-        '0', '16383', '3',
+        '0', '16383', '3', '123',
         '%s00000001' % cluster1_dbid, 'localhost:%s' % cluster1.node(1).port,
         ) == b'OK'
 
@@ -133,7 +133,7 @@ def test_happy_migrate(cluster_factory):
         '1',
         cluster2_dbid,
         '1', '1',
-        '0', '16383', '1',
+        '0', '16383', '1', "123",
         '%s00000001' % cluster2_dbid, 'localhost:%s' % cluster2.node(1).port,
     ) == b'OK'
 


### PR DESCRIPTION
implements setting up multiple clusters, creating keys on one, and migrating the keys to the other.

fixes some bugs along the way (setup raft.import incorrectly) and incorrect self check of importing cluster