### PR TITLE
small change to enforce only a single concurrent migration

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -1536,6 +1536,7 @@ void RaftReqFree(RaftReq *req)
             RedisModule_Free(req->r.migrate_keys.keys_serialized);
             req->r.migrate_keys.keys_serialized = NULL;
         }
+        redis_raft.migrate_req = NULL;
     }
 
     if (req->ctx) {
@@ -1553,6 +1554,10 @@ RaftReq *RaftReqInit(RedisModuleCtx *ctx, enum RaftReqType type)
         req->ctx = RedisModule_GetThreadSafeContext(req->client);
     }
     req->type = type;
+
+    if (type == RR_MIGRATE_KEYS) {
+        redis_raft.migrate_req = req;
+    }
 
     TRACE("RaftReqInit: req=%p, type=%s, client=%p, ctx=%p",
           req, RaftReqTypeStr[req->type], req->client, req->ctx);

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -485,6 +485,11 @@ exit:
 
 static void handleMigrateCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommand *cmd)
 {
+    if (rr->migrate_req != NULL) {
+        RedisModule_ReplyWithError(ctx, "ERR RedisRaft only supports one concurrent migration currently");
+        return;
+    }
+
     if (checkLeader(rr, ctx, NULL) == RR_ERROR) {
         return;
     }

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -333,6 +333,7 @@ typedef struct RedisRaftCtx {
     RaftSnapshotInfo snapshot_info;              /* Current snapshot info */
     struct RaftReq *debug_req;                   /* Current RAFT.DEBUG request context, if processing one */
     struct RaftReq *transfer_req;                /* RaftReq if a leader transfer is in progress */
+    struct RaftReq *migrate_req;                 /* RaftReq if a migration transfer is in progress */
     RedisModuleCommandFilter *registered_filter; /* Command filter is used for intercepting redis commands */
     struct ShardingInfo *sharding_info;          /* Information about sharding, when cluster mode is enabled */
     RedisModuleDict *multi_client_state;         /* A dict that tracks multi state of the clients */


### PR DESCRIPTION
Prevents users from isusing multiple concurrent migration commands via simple tracking of creation/freeing of migration RaftReq objects.

closes #347 