### PR TITLE
add injected error for testing migration.

### DIFF
--- a/src/clientstate.c
+++ b/src/clientstate.c
@@ -27,11 +27,11 @@ void ClientStateFree(RedisRaftCtx *rr, unsigned long long client_id)
 
     int ret = RedisModule_DictDelC(rr->client_state, &client_id, sizeof(client_id), &state);
     RedisModule_Assert(ret == REDISMODULE_OK);
-    RedisModule_Assert(state != NULL);
 
-    /* validated that state is not NULL above in the RM_Assert */
-    ClientStateResetMulti(state);
-    RedisModule_Free(state);
+    if (state != NULL) {
+        ClientStateResetMulti(state);
+        RedisModule_Free(state);
+    }
 }
 
 void ClientStateResetMulti(ClientState *client_state)

--- a/src/clientstate.c
+++ b/src/clientstate.c
@@ -25,8 +25,7 @@ void ClientStateFree(RedisRaftCtx *rr, unsigned long long client_id)
 {
     ClientState *state = NULL;
 
-    int ret = RedisModule_DictDelC(rr->client_state, &client_id, sizeof(client_id), &state);
-    RedisModule_Assert(ret == REDISMODULE_OK);
+    RedisModule_DictDelC(rr->client_state, &client_id, sizeof(client_id), &state);
 
     if (state != NULL) {
         ClientStateResetMulti(state);

--- a/src/clientstate.c
+++ b/src/clientstate.c
@@ -26,7 +26,8 @@ void ClientStateFree(RedisRaftCtx *rr, unsigned long long client_id)
     ClientState *state = NULL;
 
     int ret = RedisModule_DictDelC(rr->client_state, &client_id, sizeof(client_id), &state);
-    RedisModule_Assert(ret == REDISMODULE_OK && state != NULL);
+    RedisModule_Assert(ret == REDISMODULE_OK);
+    RedisModule_Assert(state != NULL);
 
     /* validated that state is not NULL above in the RM_Assert */
     ClientStateResetMulti(state);

--- a/src/migrate.c
+++ b/src/migrate.c
@@ -192,7 +192,7 @@ fail:
 
 static void raftAppendRaftUnlockDeleteEntry(RedisRaftCtx *rr, RaftReq *req)
 {
-    if (rr->migration_debug == RAFT_DEBUG_MIGRATION_EMULATE_UNLOCK_FAILED) {
+    if (rr->migration_debug == DEBUG_MIGRATION_EMULATE_UNLOCK_FAILED) {
         RedisModule_ReplyWithError(req->ctx, "ERR Unable to unlock/delete migrated keys, try again");
         RaftReqFree(req);
         return;
@@ -265,14 +265,14 @@ static void transferKeys(Connection *conn)
         return;
     }
 
-    /* raft.import term migration_session_key <key1_name> <key1_serialized> ... <keyn_name> <keyn_serialized> */
-    if (rr->migration_debug == RAFT_DEBUG_MIGRATION_EMULATE_IMPORT_FAILED) {
+    if (rr->migration_debug == DEBUG_MIGRATION_EMULATE_IMPORT_FAILED) {
         ConnAsyncTerminate(conn);
         RedisModule_ReplyWithError(req->ctx, "ERR failed to submit RAFT.IMPORT command, try again");
         RaftReqFree(req);
         return;
     }
 
+    /* raft.import term migration_session_key <key1_name> <key1_serialized> ... <keyn_name> <keyn_serialized> */
     int argc = 3 + (req->r.migrate_keys.num_serialized_keys * 2);
     char **argv = RedisModule_Calloc(argc, sizeof(char *));
     size_t *argv_len = RedisModule_Calloc(argc, sizeof(size_t));
@@ -336,7 +336,7 @@ static RRStatus getMigrationSessionKey(RedisRaftCtx *rr, RaftReq *req, unsigned 
 
 void MigrateKeys(RedisRaftCtx *rr, RaftReq *req)
 {
-    if (rr->migration_debug == RAFT_DEBUG_MIGRATION_EMULATE_CONNECT_FAILED) {
+    if (rr->migration_debug == DEBUG_MIGRATION_EMULATE_CONNECT_FAILED) {
         RedisModule_ReplyWithError(req->ctx, "ERR failed to connect to import cluster, try again");
         goto exit;
     }

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1478,7 +1478,7 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
             RedisModule_ReplyWithError(ctx, "ERR invalid migration debug value");
             return REDISMODULE_OK;
         }
-        if (val < 0 || val >= RAFT_DEBUG_MIGRATION_MAX) {
+        if (val < 0 || val >= DEBUG_MIGRATION_MAX) {
             RedisModule_ReplyWithError(ctx, "ERR invalid migration debug value");
             return REDISMODULE_OK;
         }

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1472,6 +1472,18 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 
         rr->debug_delay_apply = val;
         RedisModule_ReplyWithSimpleString(ctx, "OK");
+    } else if (!strncasecmp(cmd, "migration_debug", cmdlen) && argc == 3) {
+        long long val;
+        if (RedisModule_StringToLongLong(argv[2], &val) != REDISMODULE_OK) {
+            RedisModule_ReplyWithError(ctx, "ERR invalid migration debug value");
+            return REDISMODULE_OK;
+        }
+        if (val < 0 || val >= RAFT_DEBUG_MIGRATION_MAX) {
+            RedisModule_ReplyWithError(ctx, "ERR invalid migration debug value");
+            return REDISMODULE_OK;
+        }
+        rr->migration_debug = val;
+        return REDISMODULE_OK;
     } else {
         RedisModule_ReplyWithError(ctx, "ERR invalid debug subcommand");
     }

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1294,6 +1294,9 @@ static int cmdRaftShardGroup(RedisModuleCtx *ctx, RedisModuleString **argv, int 
  *
  * RAFT.DEBUG DELAY_APPLY <val>
  *     Sleep <val> microseconds before executing a command
+ *
+ * RAFT.DEBUG MIGRATION_DEBUG [fail_connect|fail_import|fail_unlock]
+ *     Inject errors at specific places in migration flow to test consistency
  * Reply:
  *     +OK
  */
@@ -1473,15 +1476,21 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         rr->debug_delay_apply = val;
         RedisModule_ReplyWithSimpleString(ctx, "OK");
     } else if (!strncasecmp(cmd, "migration_debug", cmdlen) && argc == 3) {
-        long long val;
-        if (RedisModule_StringToLongLong(argv[2], &val) != REDISMODULE_OK) {
+        MigrationDebug val;
+
+        size_t len;
+        const char *str = RedisModule_StringPtrLen(argv[2], &len);
+        if (!strncasecmp(str, "fail_connect", len)) {
+            val = DEBUG_MIGRATION_EMULATE_CONNECT_FAILED;
+        } else if (!strncasecmp(str, "fail_import", len)) {
+            val = DEBUG_MIGRATION_EMULATE_IMPORT_FAILED;
+        } else if (!strncasecmp(str, "fail_unlock", len)) {
+            val = DEBUG_MIGRATION_EMULATE_UNLOCK_FAILED;
+        } else {
             RedisModule_ReplyWithError(ctx, "ERR invalid migration debug value");
             return REDISMODULE_OK;
         }
-        if (val < 0 || val >= DEBUG_MIGRATION_MAX) {
-            RedisModule_ReplyWithError(ctx, "ERR invalid migration debug value");
-            return REDISMODULE_OK;
-        }
+
         rr->migration_debug = val;
 
         RedisModule_ReplyWithSimpleString(ctx, "OK");

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1483,6 +1483,8 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
             return REDISMODULE_OK;
         }
         rr->migration_debug = val;
+
+        RedisModule_ReplyWithSimpleString(ctx, "OK");
         return REDISMODULE_OK;
     } else {
         RedisModule_ReplyWithError(ctx, "ERR invalid debug subcommand");

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1295,7 +1295,7 @@ static int cmdRaftShardGroup(RedisModuleCtx *ctx, RedisModuleString **argv, int 
  * RAFT.DEBUG DELAY_APPLY <val>
  *     Sleep <val> microseconds before executing a command
  *
- * RAFT.DEBUG MIGRATION_DEBUG [fail_connect|fail_import|fail_unlock]
+ * RAFT.DEBUG MIGRATION_DEBUG [fail_connect|fail_import|fail_unlock|none]
  *     Inject errors at specific places in migration flow to test consistency
  * Reply:
  *     +OK
@@ -1486,6 +1486,8 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
             val = DEBUG_MIGRATION_EMULATE_IMPORT_FAILED;
         } else if (!strncasecmp(str, "fail_unlock", len)) {
             val = DEBUG_MIGRATION_EMULATE_UNLOCK_FAILED;
+        } else if (!strncasecmp(str, "none", len)) {
+            val = DEBUG_MIGRATION_NONE;
         } else {
             RedisModule_ReplyWithError(ctx, "ERR invalid migration debug value");
             return REDISMODULE_OK;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -347,7 +347,7 @@ typedef struct RedisRaftCtx {
     /* Debug - Testing */
     struct RaftReq *debug_req;                   /* Current RAFT.DEBUG request context, if processing one */
     long long debug_delay_apply;                 /* If not zero, sleep microseconds before the execution of a command */
-    migration_debug migration_debug;             /* for debugging migration, places to inject error */
+    MigrationDebug migration_debug;             /* for debugging migration, places to inject error */
 
     /* General stats */
     unsigned long client_attached_entries;       /* Number of log entries attached to user connections */

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -308,6 +308,13 @@ void fsyncThreadStart(FsyncThread *th, void (*on_complete)(void *result));
 void fsyncThreadAddTask(FsyncThread *th, int fd, raft_index_t requested_index);
 void fsyncThreadWaitUntilCompleted(FsyncThread *th);
 
+typedef enum {
+    RAFT_DEBUG_MIGRATION_NONE                    = 0,
+    RAFT_DEBUG_MIGRATION_EMULATE_CONNECT_FAILED,
+    RAFT_DEBUG_MIGRATION_EMULATE_IMPORT_FAILED,
+    RAFT_DEBUG_MIGRATION_EMULATE_UNLOCK_FAILED,
+    RAFT_DEBUG_MIGRATION_MAX,
+} migration_debug;
 
 /* Global Raft context */
 typedef struct RedisRaftCtx {
@@ -341,6 +348,7 @@ typedef struct RedisRaftCtx {
     /* Debug - Testing */
     struct RaftReq *debug_req;                   /* Current RAFT.DEBUG request context, if processing one */
     long long debug_delay_apply;                 /* If not zero, sleep microseconds before the execution of a command */
+    migration_debug migration_debug;             /* for debugging migration, places to inject error */
 
     /* General stats */
     unsigned long client_attached_entries;       /* Number of log entries attached to user connections */

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -309,12 +309,12 @@ void fsyncThreadAddTask(FsyncThread *th, int fd, raft_index_t requested_index);
 void fsyncThreadWaitUntilCompleted(FsyncThread *th);
 
 typedef enum {
-    RAFT_DEBUG_MIGRATION_NONE                    = 0,
-    RAFT_DEBUG_MIGRATION_EMULATE_CONNECT_FAILED,
-    RAFT_DEBUG_MIGRATION_EMULATE_IMPORT_FAILED,
-    RAFT_DEBUG_MIGRATION_EMULATE_UNLOCK_FAILED,
-    RAFT_DEBUG_MIGRATION_MAX,
-} migration_debug;
+    DEBUG_MIGRATION_NONE                    = 0,
+    DEBUG_MIGRATION_EMULATE_CONNECT_FAILED,
+    DEBUG_MIGRATION_EMULATE_IMPORT_FAILED,
+    DEBUG_MIGRATION_EMULATE_UNLOCK_FAILED,
+    DEBUG_MIGRATION_MAX,
+} MigrationDebug;
 
 /* Global Raft context */
 typedef struct RedisRaftCtx {
@@ -338,7 +338,6 @@ typedef struct RedisRaftCtx {
     int snapshot_child_fd;                       /* Pipe connected to snapshot child process */
     SnapshotFile outgoing_snapshot_file;         /* Snapshot file memory map to send to followers */
     RaftSnapshotInfo snapshot_info;              /* Current snapshot info */
-
     struct RaftReq *transfer_req;                /* RaftReq if a leader transfer is in progress */
     struct RaftReq *migrate_req;                 /* RaftReq if a migration transfer is in progress */
     RedisModuleCommandFilter *registered_filter; /* Command filter is used for intercepting redis commands */

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -166,11 +166,11 @@ def test_sad_path_migrate(cluster_factory):
         '2',
         cluster2_dbid,
         '1', '1',
-        '0', '16383', '2',
+        '0', '16383', '2', '123',
         '%s00000001' % cluster2_dbid, 'localhost:%s' % cluster2.node(1).port,
         cluster1_dbid,
         '1', '1',
-        '0', '16383', '3',
+        '0', '16383', '3', '123',
         '%s00000001' % cluster1_dbid, 'localhost:%s' % cluster1.node(1).port,
         ) == b'OK'
 
@@ -179,11 +179,11 @@ def test_sad_path_migrate(cluster_factory):
         '2',
         cluster2_dbid,
         '1', '1',
-        '0', '16383', '2',
+        '0', '16383', '2', '123',
         '%s00000001' % cluster2_dbid, 'localhost:%s' % cluster2.node(1).port,
         cluster1_dbid,
         '1', '1',
-        '0', '16383', '3',
+        '0', '16383', '3', '123',
         '%s00000001' % cluster1_dbid, 'localhost:%s' % cluster1.node(1).port,
         ) == b'OK'
 

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -214,10 +214,10 @@ def test_sad_path_migrate(cluster_factory):
         conn.send_command('get', key_name)
         assert conn.read_response() == value
 
-    cluster1.execute("raft.debug", "migration_debug", 1)
+    cluster1.execute("raft.debug", "migration_debug", 'fail_connect')
     validate_failed_migration("key1", b'value1', 9189, "failed to connect to import cluster, try again")
-    cluster1.execute("raft.debug", "migration_debug", 2)
+    cluster1.execute("raft.debug", "migration_debug", 'fail_import')
     validate_failed_migration("key2", b'value2', 4998, "failed to submit RAFT.IMPORT command, try again")
-    cluster1.execute("raft.debug", "migration_debug", 3)
+    cluster1.execute("raft.debug", "migration_debug", 'fail_unlock')
     validate_failed_migration("key3", b'value3', 935, "Unable to unlock/delete migrated keys, try again")
 

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -219,4 +219,5 @@ def test_sad_path_migrate(cluster_factory):
     cluster1.execute("raft.debug", "migration_debug", 2)
     validate_failed_migration("key2", b'value2', 4998, "failed to submit RAFT.IMPORT command, try again")
     cluster1.execute("raft.debug", "migration_debug", 3)
-    validate_failed_migration("key3", b'value3', 456, "def")
+    validate_failed_migration("key3", b'value3', 935, "Unable to unlock/delete migrated keys, try again")
+

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -199,7 +199,7 @@ def test_sad_path_migrate(cluster_factory):
             cluster2.leader_node().client.get(key_name)
 
         # remove injected error, should pass
-        cluster1.execute("raft.debug", "migration_debug", 0)
+        cluster1.execute("raft.debug", "migration_debug", 'none')
         assert cluster1.execute("migrate", "", "", "", "", "", "keys", key_name) == b'OK'
 
         # validate state


### PR DESCRIPTION
add an emulated

"connection failure" error
"raft.import" failure
"leadership loss" failure

depends on #370 