### PR TITLE
two small fixes found during creation of happy path test

### DIFF
--- a/src/migrate.c
+++ b/src/migrate.c
@@ -264,7 +264,7 @@ static void transferKeys(Connection *conn)
     argv_len[1] = n;
     argv[2] = RedisModule_Alloc(32);
     // FIXME needs to be taken from sg (in raft.import pr))
-    n = snprintf(argv[1], 32, "%llu", (long long unsigned) 0);
+    n = snprintf(argv[2], 32, "%llu", (long long unsigned) 0);
     argv_len[2] = n;
 
     for (size_t i = 0; i < req->r.migrate_keys.num_keys; i++) {

--- a/src/raft.c
+++ b/src/raft.c
@@ -417,7 +417,7 @@ static void lockKeys(RedisRaftCtx *rr, raft_entry_t *entry)
         goto error;
     }
 
-    if (!si->importing_slots_map[slot]->local) {
+    if (si->importing_slots_map[slot]->local) {
         if (req) {
             RedisModule_ReplyWithError(req->ctx, "ERR trying to import keys into self RedisCluster");
         }


### PR DESCRIPTION
1) was inserting "magic" into wrong argv position
2) test if "targeted" cluster for migrating was local (and hence invalid) was inverted.