### PR TITLE
Fix MacOS compile warnings for hiredis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,8 +101,15 @@ if (BUILD_TLS)
 endif()
 option(DISABLE_TESTS "Disable hiredis tests" ON)
 
+# Silence hiredis warnings on MacOS
+if (APPLE)
+    set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+    set(CMAKE_C_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+endif()
+
 add_subdirectory(deps/hiredis)
 set_property(TARGET hiredis_static PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 if (BUILD_TLS)
     set_property(TARGET hiredis_ssl_static PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()


### PR DESCRIPTION
Before the fix, there were compile warnings on MacOS: 

```
[  9%] Linking C static library libhiredis_static.a
/Applications/Xcode_13.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libhiredis_static.a(dict.c.o) has no symbols
/Applications/Xcode_13.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libhiredis_static.a(sockcompat.c.o) has no symbols
/Applications/Xcode_13.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libhiredis_static.a(dict.c.o) has no symbols
/Applications/Xcode_13.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libhiredis_static.a(sockcompat.c.o) has no symbols
```