### PR TITLE
improved raft.import tests

### DIFF
--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -31,7 +31,7 @@ def test_raft_import(cluster):
     with raises(ResponseError, match='invalid term'):
         assert cluster.execute('raft.import', '1', '123', 'key', serialized)
     # not matched session migration key
-    with raises(ResponseError, match='invalid magic'):
+    with raises(ResponseError, match='invalid migration_session_key'):
         assert cluster.execute('raft.import', '2', '10', 'key', serialized)
     # repeated with correct values
     assert cluster.execute('raft.import', '2', '123', 'key', serialized) == b'OK'

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -21,6 +21,9 @@ def test_raft_import(cluster):
         '1234567890123456789012345678901234567890', '2.2.2.2:2222',
     ) == b'OK'
 
+    # Test that rexecuting raft.import continues to succeed
+    assert cluster.execute('raft.import', '2', '123', 'key', serialized) == b'OK'
+    assert cluster.execute('raft.import', '2', '123', 'key', serialized) == b'OK'
     assert cluster.execute('raft.import', '2', '123', 'key', serialized) == b'OK'
 
     conn = cluster.leader_node().client.connection_pool.get_connection('deferred')


### PR DESCRIPTION
previous test didn't repeatedly call raft.import, would have exposed issue josh ran into.

also test for incorect term and migration session key values.