### PR TITLE
Fix snapshot test

### DIFF
--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -72,7 +72,7 @@ def test_raft_log_max_file_size(cluster):
         assert r1.client.set('testkey', 'x'*500)
 
     r1.wait_for_info_param('raft_snapshots_created', 1)
-    assert r1.info()['raft_log_entries'] < 10
+    assert r1.info()['raft_log_entries'] < r1.info()['raft_current_index']
 
 
 def test_raft_log_max_cache_size(cluster):


### PR DESCRIPTION
There is config entry and/or NOOP entry in the log. If these entries occupy more than 1 kb in the file, snapshot will start early and we may still have 10 entries in the log after a snapshot. In that case, assert fails. 

This assert is just extra check right now as we already check `raft_snapshots_created` param one line before to verify compaction. Anyway, I've changed assert to verify `log_entries` are less than `current_index` which happens only after a snapshot.

Fixes: https://github.com/RedisLabs/redisraft/issues/356