### PR TITLE
now that shardgroup replace requires session migration key, need it migration

### DIFF
--- a/src/migrate.c
+++ b/src/migrate.c
@@ -340,6 +340,7 @@ void MigrateKeys(RedisRaftCtx *rr, RaftReq *req)
     }
     req->r.migrate_keys.migrate_term = raft_get_current_term(rr->raft);
     if (getMigrationSessionKey(rr, req, &req->r.migrate_keys.migration_session_key) != RR_OK) {
+        RedisModule_ReplyWithError(req->ctx, "ERR failed to retrieve migration session key");
         goto exit;
     }
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -613,6 +613,7 @@ typedef struct RaftReq {
             RedisModuleString **keys_serialized;
             size_t num_serialized_keys;
             raft_term_t migrate_term;
+            unsigned long long migration_session_key;
         } migrate_keys;
     } r;
 } RaftReq;


### PR DESCRIPTION
we were setting it to 0 automatically, but that broke once the shardgroup replace pr went in.

this fetches the value for use during migration