### PR TITLE
Update libraft

### DIFF
--- a/deps/raft/include/raft.h
+++ b/deps/raft/include/raft.h
@@ -264,7 +264,7 @@ typedef struct
     raft_index_t leader_commit;
 
     /** number of entries within this message */
-    int n_entries;
+    raft_index_t n_entries;
 
     /** array of pointers to entries within this message */
     raft_entry_req_t** entries;
@@ -638,6 +638,48 @@ typedef int (
     raft_node_t* node
     );
 
+/** Callback for fetching entries to send in a appendentries message.
+ *
+ *  This callback is useful when you want to limit appendentries message size.
+ *  Application is supposed to fill the `entries` array by using
+ *  raft_get_entry_from_idx() and raft_get_entries_from_idx() functions. If the
+ *  application wants to limit the appendentries message size, it can fill the
+ *  array partially. As this callback is inside a loop, the remaining entries
+ *  will be fetched and sent as another append entries message in the next
+ *  callback.
+ *
+ * @param[in] raft The Raft server making this callback.
+ * @param[in] user_data User data that is passed from Raft server.
+ * @param[in] node The node that we are sending this message to.
+ * @param[in] idx Index of first entry to fetch.
+ * @param[in] entries_n Length of entries (max. entries to fetch).
+ * @param[out] entries An initialized array of raft_entry_t*.
+ * @return Number of entries fetched
+ */
+typedef raft_index_t (
+*raft_get_entries_to_send_f
+)   (
+    raft_server_t *raft,
+    void *user_data,
+    raft_node_t *node,
+    raft_index_t idx,
+    raft_index_t entries_n,
+    raft_entry_t **entries
+    );
+
+/** Callback to retrieve monotonic timestamp in microseconds .
+ *
+ * @param[in] raft The Raft server making this callback
+ * @param[in] user_data User data that is passed from Raft server
+ * @return Timestamp in microseconds
+ */
+typedef raft_time_t (
+*raft_timestamp_f
+)   (
+    raft_server_t *raft,
+    void *user_data
+    );
+
 typedef struct
 {
     /** Callback for sending request vote messages */
@@ -703,6 +745,12 @@ typedef struct
 
     /** Callback for deciding whether to send raft_appendentries_req to a node. */
     raft_backpressure_f backpressure;
+
+    /** Callback for preparing entries to send in a raft_appendentries_req */
+    raft_get_entries_to_send_f get_entries_to_send;
+
+    /** Callback to retrieve monotonic timestamp in microseconds */
+    raft_timestamp_f timestamp;
 } raft_cbs_t;
 
 /** A generic notification callback used to allow Raft to notify caller
@@ -861,8 +909,8 @@ typedef struct raft_log_impl
      *  Caller must use raft_entry_release_list() when no longer requiring
      *    the returned entries.
      */
-    int (*get_batch) (void *log, raft_index_t idx, int entries_n,
-            raft_entry_t **entries);
+    raft_index_t (*get_batch) (void *log, raft_index_t idx,
+                              raft_index_t entries_n, raft_entry_t **entries);
 
     /** Get first entry's index.
      * @return
@@ -954,12 +1002,11 @@ raft_node_t* raft_add_non_voting_node(raft_server_t* me, void* udata, raft_node_
 void raft_remove_node(raft_server_t* me, raft_node_t* node);
 
 /** Process events that are dependent on time passing.
- * @param[in] msec_elapsed Time in milliseconds since the last call
  * @return
  *  0 on success;
  *  -1 on failure;
  *  RAFT_ERR_SHUTDOWN when server MUST shutdown */
-int raft_periodic(raft_server_t* me, int msec_elapsed);
+int raft_periodic(raft_server_t *me);
 
 /** Receive an appendentries message.
  *
@@ -1110,7 +1157,7 @@ int raft_is_candidate(raft_server_t* me);
 
 /**
  * @return currently elapsed timeout in milliseconds */
-int raft_get_timeout_elapsed(raft_server_t* me);
+raft_time_t raft_get_timeout_elapsed(raft_server_t* me);
 
 /**
  * @return index of last applied entry */
@@ -1143,6 +1190,14 @@ void raft_node_set_next_idx(raft_node_t* me, raft_index_t idx);
  * @param[in] idx The entry's index
  * @return entry from index */
 raft_entry_t* raft_get_entry_from_idx(raft_server_t* me, raft_index_t idx);
+
+/**
+ * @param[in] idx The entry's index
+ * @param[out] n_etys Number of returned entries
+ * @return entry batch from index. Caller must use raft_entry_release_list(). */
+raft_entry_t** raft_get_entries_from_idx(raft_server_t* me,
+                                         raft_index_t idx,
+                                         raft_index_t* n_etys);
 
 /**
  * @param[in] node The node's ID
@@ -1498,11 +1553,7 @@ extern const raft_log_impl_t raft_log_internal_impl;
 
 void raft_handle_append_cfg_change(raft_server_t* me, raft_entry_t* ety, raft_index_t idx);
 
-int raft_queue_read_request(raft_server_t* me, raft_read_request_callback_f cb, void *cb_arg);
-
-/** Attempt to process read queue.
- */
-void raft_process_read_queue(raft_server_t* me);
+int raft_recv_read_request(raft_server_t* me, raft_read_request_callback_f cb, void *cb_arg);
 
 /** Invoke a leadership transfer to targeted node
  *
@@ -1551,7 +1602,7 @@ raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me);
  *        HandleNetworkOperations();
  *
  *         for (int i = 0; i < new_readreq_count; i++)
- *             raft_queue_read_request(raft, read_requests[i]);
+ *             raft_recv_read_request(raft, read_requests[i]);
  *
  *         for (int i = 0; i < new_requests_count; i++)
  *             raft_recv_entry(raft, new_requests[i]);
@@ -1576,7 +1627,9 @@ raft_index_t raft_get_num_snapshottable_logs(raft_server_t* me);
  *
  * @param[in] sync_index Entry index of the last persisted entry. '0' to skip
  *                       updating persisted index.
- * @return    0 on success
+ * @return
+ *   0 on success
+ *   RAFT_ERR_SHUTDOWN when server MUST shutdown
  */
 int raft_flush(raft_server_t* me, raft_index_t sync_index);
 
@@ -1631,5 +1684,19 @@ raft_index_t raft_get_index_to_sync(raft_server_t *me);
  * @return        0 on success, RAFT_ERR_NOTFOUND if config is missing.
  */
 int raft_config(raft_server_t *me, int set, raft_config_e config, ...);
+
+/** Returns non-zero if there are read requests or entries ready to be executed.
+ *
+ *  If executing entries/read requests take longer than `request-timeout`,
+ *  raft_flush() will return early. In that case, application should call
+ *  raft_flush() again to continue operation later, preferably after processing
+ *  messages from the network. That way, server can send/receive heartbeat
+ *  messages and execute long running batch of operations without affecting
+ *  cluster availability.
+ *
+ *  @param[in] raft The Raft server
+ *  @return         0 if there is no pending operations, non-zero otherwise.
+ */
+int raft_pending_operations(raft_server_t *me);
 
 #endif /* RAFT_H_ */

--- a/deps/raft/include/raft_types.h
+++ b/deps/raft/include/raft_types.h
@@ -35,4 +35,9 @@ typedef int raft_node_id_t;
  */
 typedef unsigned long raft_msg_id_t;
 
+/**
+ * Time type.
+ */
+typedef long long raft_time_t;
+
 #endif  /* RAFT_DEFS_H_ */

--- a/deps/raft/src/raft_log.c
+++ b/deps/raft/src/raft_log.c
@@ -357,9 +357,12 @@ static raft_entry_t *log_get(void *log, raft_index_t idx)
     return e;
 }
 
-static int log_get_batch(void *log, raft_index_t idx, int entries_n, raft_entry_t **entries)
+static raft_index_t log_get_batch(void *log,
+                                  raft_index_t idx,
+                                  raft_index_t entries_n,
+                                  raft_entry_t **entries)
 {
-    long n, i;
+    raft_index_t n;
     raft_entry_t **r = raft_log_get_from_idx(log, idx, &n);
 
     if (!r || n < 1) {
@@ -369,11 +372,11 @@ static int log_get_batch(void *log, raft_index_t idx, int entries_n, raft_entry_
     if (n > entries_n)
         n = entries_n;
 
-    for (i = 0; i < n; i++) {
+    for (raft_index_t i = 0; i < n; i++) {
         entries[i] = r[i];
         raft_entry_hold(entries[i]);
     }
-    return (int) n;
+    return n;
 }
 
 static int log_pop(void *log, raft_index_t from_idx, raft_entry_notify_f cb, void *cb_arg)

--- a/deps/raft/src/raft_server_properties.c
+++ b/deps/raft/src/raft_server_properties.c
@@ -32,7 +32,7 @@ int raft_get_num_voting_nodes(raft_server_t* me)
     return num;
 }
 
-int raft_get_timeout_elapsed(raft_server_t* me)
+raft_time_t raft_get_timeout_elapsed(raft_server_t* me)
 {
     return me->timeout_elapsed;
 }
@@ -234,6 +234,7 @@ raft_term_t raft_get_snapshot_last_term(raft_server_t *me)
 
 void raft_set_snapshot_metadata(raft_server_t *me, raft_term_t term, raft_index_t idx)
 {
+    me->last_applied_term = term;
     me->last_applied_idx = idx;
     me->snapshot_last_term = term;
     me->snapshot_last_idx = idx;

--- a/deps/raft/tests/test_scenario.c
+++ b/deps/raft/tests/test_scenario.c
@@ -60,7 +60,7 @@ void TestRaft_scenario_leader_appears(CuTest * tc)
     }
 
     /* NOTE: important for 1st node to send vote request before others */
-    raft_periodic(r[0], 1000);
+    raft_periodic_internal(r[0], 1000);
 
     for (i = 0; i < 20; i++)
     {
@@ -74,7 +74,7 @@ one_more_time:
                 goto one_more_time;
 
         for (j = 0; j < 3; j++)
-            raft_periodic(r[j], 100);
+            raft_periodic_internal(r[j], 100);
     }
 
     int leaders = 0;

--- a/deps/raft/tests/test_snapshotting.c
+++ b/deps/raft/tests/test_snapshotting.c
@@ -353,7 +353,7 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
     CuAssertIntEquals(tc, 2, raft_get_commit_idx(r));
     CuAssertIntEquals(tc, 2, raft_get_last_applied_idx(r));
     CuAssertIntEquals(tc, 1, raft_get_last_log_term(r));
-    CuAssertIntEquals(tc, 0, raft_periodic(r, 1000));
+    CuAssertIntEquals(tc, 0, raft_periodic_internal(r, 1000));
 
 
     /* the above test returns correct term as didn't snapshot all entries, makes sure works if we snapshot all */
@@ -363,7 +363,7 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted(CuTest * tc)
     raft_recv_entry(r, ety, &cr);
 
     raft_set_commit_idx(r, 4);
-    CuAssertIntEquals(tc, 0, raft_periodic(r, 1000));
+    CuAssertIntEquals(tc, 0, raft_periodic_internal(r, 1000));
     CuAssertIntEquals(tc, 2, raft_get_log_count(r));
     CuAssertIntEquals(tc, 4, raft_get_commit_idx(r));
     CuAssertIntEquals(tc, 3, r->log_impl->first_idx(r->log));
@@ -416,7 +416,7 @@ void TestRaft_leader_snapshot_end_succeeds_if_log_compacted2(CuTest * tc)
     CuAssertIntEquals(tc, 1, raft_get_log_count(r));
     CuAssertIntEquals(tc, 2, raft_get_commit_idx(r));
     CuAssertIntEquals(tc, 2, raft_get_last_applied_idx(r));
-    CuAssertIntEquals(tc, 0, raft_periodic(r, 1000));
+    CuAssertIntEquals(tc, 0, raft_periodic_internal(r, 1000));
 }
 
 void TestRaft_joinee_needs_to_get_snapshot(CuTest * tc)
@@ -479,7 +479,7 @@ void TestRaft_follower_load_from_snapshot(CuTest * tc)
     CuAssertIntEquals(tc, 5, raft_get_commit_idx(r));
     CuAssertIntEquals(tc, 5, raft_get_last_applied_idx(r));
 
-    CuAssertIntEquals(tc, 0, raft_periodic(r, 1000));
+    CuAssertIntEquals(tc, 0, raft_periodic_internal(r, 1000));
 
     /* current idx means snapshot was unnecessary */
     ety = __MAKE_ENTRY(2, 1, "entry");

--- a/src/log.c
+++ b/src/log.c
@@ -1000,10 +1000,10 @@ static raft_entry_t *logImplGet(void *rr_, raft_index_t idx)
     return ety;
 }
 
-static int logImplGetBatch(void *rr_, raft_index_t idx, int entries_n, raft_entry_t **entries)
+static raft_index_t logImplGetBatch(void *rr_, raft_index_t idx, raft_index_t entries_n, raft_entry_t **entries)
 {
     RedisRaftCtx *rr = (RedisRaftCtx *) rr_;
-    int n = 0;
+    raft_index_t n = 0;
     raft_index_t i = idx;
 
     while (n < entries_n) {
@@ -1020,7 +1020,7 @@ static int logImplGetBatch(void *rr_, raft_index_t idx, int entries_n, raft_entr
         i++;
     }
 
-    RAFTLOG_TRACE("GetBatch(idx=%lu entries_n=%d) -> %d", idx, entries_n, n);
+    RAFTLOG_TRACE("GetBatch(idx=%lu entries_n=%ld) -> %ld", idx, entries_n, n);
     return n;
 }
 

--- a/tests/integration/test_multi.py
+++ b/tests/integration/test_multi.py
@@ -65,7 +65,7 @@ def test_multi_exec(cluster):
 
     # MULTI does not go itself to the log
     assert conn.execute('MULTI') == b'OK'
-    assert r1.info()['raft_current_index'] == 1
+    assert r1.info()['raft_current_index'] == 2
 
     # MULTI cannot be nested
     with raises(ResponseError, match='.*MULTI calls can not be nested'):
@@ -77,9 +77,9 @@ def test_multi_exec(cluster):
     assert conn.execute('INCR', 'key') == b'QUEUED'
 
     # More validations
-    assert r1.info()['raft_current_index'] == 1
-    assert conn.execute('EXEC') == [1, 2, 3]
     assert r1.info()['raft_current_index'] == 2
+    assert conn.execute('EXEC') == [1, 2, 3]
+    assert r1.info()['raft_current_index'] == 3
 
     assert conn.execute('GET', 'key') == b'3'
 
@@ -95,7 +95,7 @@ def test_multi_exec_proxying(cluster):
 
     # Basic sanity
     n2 = cluster.node(2)
-    assert n2.info()['raft_current_index'] == 5
+    assert n2.info()['raft_current_index'] == 6
     conn = RawConnection(n2.client)
 
     assert conn.execute('MULTI') == b'OK'
@@ -103,7 +103,7 @@ def test_multi_exec_proxying(cluster):
     assert conn.execute('INCR', 'key') == b'QUEUED'
     assert conn.execute('INCR', 'key') == b'QUEUED'
     assert conn.execute('EXEC') == [1, 2, 3]
-    assert n2.info()['raft_current_index'] == 6
+    assert n2.info()['raft_current_index'] == 7
 
 
 def test_multi_mixed_ro_rw(cluster_factory):

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -64,7 +64,7 @@ def test_add_node_as_a_single_leader(cluster):
     # Do some basic sanity
     r1 = cluster.add_node()
     assert r1.client.set('key', 'value')
-    assert r1.info()['raft_current_index'] == 2
+    assert r1.info()['raft_current_index'] == 3
 
 
 def test_node_joins_and_gets_data(cluster):
@@ -167,13 +167,13 @@ def test_readonly_commands(cluster):
     assert cluster.leader == 1
 
     # Write something
-    assert cluster.node(1).current_index() == 5
-    assert cluster.node(1).client.set('key', 'value')
     assert cluster.node(1).current_index() == 6
+    assert cluster.node(1).client.set('key', 'value')
+    assert cluster.node(1).current_index() == 7
 
     # Read something, log should not grow
     assert cluster.node(1).client.get('key') == b'value'
-    assert cluster.node(1).current_index() == 6
+    assert cluster.node(1).current_index() == 7
 
     # Tear down cluster, reads should hang
     cluster.node(2).terminate()
@@ -251,13 +251,13 @@ def test_interception_does_not_affect_lua(cluster):
     """
 
     r1 = cluster.add_node()
-    assert r1.info()['raft_current_index'] == 1
+    assert r1.info()['raft_current_index'] == 2
     assert r1.client.execute_command('EVAL', """
 redis.call('SET','key1','value1');
 redis.call('SET','key2','value2');
 redis.call('SET','key3','value3');
 return 1234;""", '0') == 1234
-    assert r1.info()['raft_current_index'] == 2
+    assert r1.info()['raft_current_index'] == 3
     assert r1.client.get('key1') == b'value1'
     assert r1.client.get('key2') == b'value2'
     assert r1.client.get('key3') == b'value3'
@@ -286,7 +286,7 @@ def test_proxying_with_interception(cluster):
     assert cluster.node(1).client.rpush('list-a', 'x') == 3
 
     time.sleep(1)
-    assert cluster.node(1).info()['raft_current_index'] == 8
+    assert cluster.node(1).info()['raft_current_index'] == 9
 
 
 def test_rolled_back_reply(cluster):

--- a/tests/integration/test_snapshots.py
+++ b/tests/integration/test_snapshots.py
@@ -94,10 +94,10 @@ def test_log_fixup_after_snapshot_delivery(cluster):
 
     # node 2 must get a snapshot to sync, make sure this happens and that
     # the log is ok.
-    cluster.node(2).wait_for_current_index(8)
+    cluster.node(2).wait_for_current_index(9)
     log = RaftLog(cluster.node(2).raftlog)
     log.read()
-    assert log.header().snapshot_index() == 8
+    assert log.header().snapshot_index() == 9
 
 
 def test_cfg_node_added_from_snapshot(cluster):
@@ -130,15 +130,15 @@ def test_index_correct_right_after_snapshot(cluster):
     for _ in range(10):
         cluster.node(1).client.incr('counter')
     info = cluster.node(1).info()
-    assert info['raft_current_index'] == 11
+    assert info['raft_current_index'] == 12
 
     # Make sure log is compacted
     assert cluster.node(1).client.execute_command(
         'RAFT.DEBUG', 'COMPACT') == b'OK'
     info = cluster.node(1).info()
     assert info['raft_log_entries'] == 0
-    assert info['raft_current_index'] == 11
-    assert info['raft_commit_index'] == 11
+    assert info['raft_current_index'] == 12
+    assert info['raft_commit_index'] == 12
 
 
 def test_cfg_node_removed_from_snapshot(cluster):
@@ -203,8 +203,8 @@ def test_uncommitted_log_rewrite(cluster):
     conn = cluster.node(1).client.connection_pool.get_connection('RAFT')
     conn.send_command('SET', 'key2', 'value2')  # Entry idx 7
 
-    assert cluster.node(1).current_index() == 7
-    assert cluster.node(1).commit_index() == 6
+    assert cluster.node(1).current_index() == 8
+    assert cluster.node(1).commit_index() == 7
     assert cluster.node(1).client.execute_command(
         'RAFT.DEBUG', 'COMPACT') == b'OK'
     assert cluster.node(1).info()['raft_log_entries'] == 1
@@ -216,8 +216,8 @@ def test_uncommitted_log_rewrite(cluster):
     cluster.node(1).kill()
     cluster.node(1).start()
     cluster.node(1).wait_for_info_param('raft_state', 'up')
-    assert cluster.node(1).current_index() == 7
-    assert cluster.node(1).commit_index() == 6
+    assert cluster.node(1).current_index() == 8
+    assert cluster.node(1).commit_index() == 7
     assert cluster.node(1).info()['raft_log_entries'] == 1
 
 


### PR DESCRIPTION
- Upgraded libraft.
- API changes required minor fixes. 
- Latest libraft writes NOOP entry to the log even if the term is 1. This change required fixes in tests.
