### PR TITLE
Populate command specs by Redis introspection.

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -51,7 +51,7 @@ static CommandSpec *getOrCreateCommandSpec(const RedisModuleString *cmd, bool cr
 }
 
 /* Use COMMAND to fetch all Redis commands and update the CommandSpec. */
-static void CommandSpecPopulateFromRedis(RedisModuleCtx *ctx)
+static void populateCommandSpecFromRedis(RedisModuleCtx *ctx)
 {
     RedisModuleCallReply *reply = NULL;
 
@@ -252,7 +252,7 @@ RRStatus CommandSpecInit(RedisModuleCtx *ctx, RedisRaftConfig *config)
         RedisModule_Free(temp);
     }
 
-    CommandSpecPopulateFromRedis(ctx);
+    populateCommandSpecFromRedis(ctx);
     return RR_OK;
 }
 


### PR DESCRIPTION
After this change, only `CMD_SPEC_UNSUPPORTED` and `CMD_SPEC_DONT_INTERCEPT` are explicitly specified for core Redis commands. The other flags are derived on the fly from Redis command introspection.