### PR TITLE
fix crash on shardgroup replace command

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -985,7 +985,7 @@ ShardGroup **ShardGroupsParse(RedisModuleCtx *ctx,
     argc--;
     int argv_idx = 1;
 
-    int created_shard_count = 0;
+    unsigned int created_shard_count = 0;
     for (int i = 0; i < num_shards; i++) {
         ShardGroup *sg;
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -214,13 +214,10 @@ ShardGroup *ShardGroupCreate() {
     return sg;
 }
 
+/* Unlike C heap function, this should only be passed non NULL (valid) pointers */
 void ShardGroupFree(ShardGroup *sg) {
-    if (!sg) {
-        /* FIXME: Would it be good to have a non fatal backtrace be printed here.
-         * Calling ShardGroupFree on a a null seems to be a logic error
-         */
-        return;
-    }
+    RedisModule_Assert(sg != NULL);
+
     ShardGroupTerm(sg);
     RedisModule_Free(sg);
 }
@@ -988,7 +985,7 @@ ShardGroup **ShardGroupsParse(RedisModuleCtx *ctx,
     argc--;
     int argv_idx = 1;
 
-    unsigned int shard_count = 0;
+    int created_shard_count = 0;
     for (int i = 0; i < num_shards; i++) {
         ShardGroup *sg;
 
@@ -997,8 +994,8 @@ ShardGroup **ShardGroupsParse(RedisModuleCtx *ctx,
             goto fail;
         }
 
-        shard_count++;
         shards[i] = sg;
+        created_shard_count++;
 
         argv += num_argv_entries;
         argc -= num_argv_entries;
@@ -1071,7 +1068,7 @@ ShardGroup **ShardGroupsParse(RedisModuleCtx *ctx,
 fail:
     *len = 0;
 
-    for (unsigned int j = 0; j < shard_count; j++) {
+    for (unsigned int j = 0; j < created_shard_count; j++) {
         ShardGroupFree(shards[j]);
     }
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -215,6 +215,12 @@ ShardGroup *ShardGroupCreate() {
 }
 
 void ShardGroupFree(ShardGroup *sg) {
+    if (!sg) {
+        /* FIXME: Would it be good to have a non fatal backtrace be printed here.
+         * Calling ShardGroupFree on a a null seems to be a logic error
+         */
+        return;
+    }
     ShardGroupTerm(sg);
     RedisModule_Free(sg);
 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -982,8 +982,8 @@ ShardGroup **ShardGroupsParse(RedisModuleCtx *ctx,
     argc--;
     int argv_idx = 1;
 
-    int i;
-    for (i = 0; i < num_shards; i++) {
+    unsigned int shard_count = 0;
+    for (int i = 0; i < num_shards; i++) {
         ShardGroup *sg;
 
         int num_argv_entries;
@@ -991,6 +991,7 @@ ShardGroup **ShardGroupsParse(RedisModuleCtx *ctx,
             goto fail;
         }
 
+        shard_count++;
         shards[i] = sg;
 
         argv += num_argv_entries;
@@ -1064,7 +1065,7 @@ ShardGroup **ShardGroupsParse(RedisModuleCtx *ctx,
 fail:
     *len = 0;
 
-    for (int j = 0; j <= i; j++) {
+    for (unsigned int j = 0; j < shard_count; j++) {
         ShardGroupFree(shards[j]);
     }
 

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -12,6 +12,36 @@ from pytest import raises
 from .sandbox import assert_after
 
 
+def test_invalid_shardgroup_replace(cluster):
+    cluster.create(3, raft_args={'sharding': 'yes'})
+    c = cluster.node(1).client
+
+    # not enough entries 1 shard
+    with raises(ResponseError, match="wrong number of arguments for 'raft.shardgroup"):
+        c.execute_command(
+            'RAFT.SHARDGROUP', 'REPLACE',
+            '1',
+            cluster.leader_node().info()['raft_dbid'],
+            '1', '1',
+            '0', '16383', '1',
+            '1234567890123456789012345678901234567890', '2.2.2.2:2222',
+        )
+
+    # not enough entries 2 shard
+    with raises(ResponseError, match="wrong number of arguments for 'raft.shardgroup"):
+        c.execute_command(
+            'RAFT.SHARDGROUP', 'REPLACE',
+            '2',
+            '12345678901234567890123456789012',
+            '0', '1',
+            '1234567890123456789012345678901234567890', '2.2.2.2:2222',
+            cluster.leader_node().info()['raft_dbid'],
+            '1', '1',
+            '0', '16383', '1',
+            '1234567890123456789012345678901234567890', '2.2.2.2:2222',
+        )
+
+
 def test_cross_slot_violation(cluster):
     cluster.create(3, raft_args={'sharding': 'yes'})
     c = cluster.node(1).client


### PR DESCRIPTION
was freeing non existent shardgroups as wasn't tracking them correctly when added

+ add tests to validate that invalid shardgroups error out correctly