### PR TITLE
Limit appendentries max size

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -67,7 +67,8 @@ static const char *conf_slot_config                = "slot-config";
 static const char *conf_shardgroup_update_interval = "shardgroup-update-interval";
 static const char *conf_ignored_commands           = "ignored-commands";
 static const char *conf_external_sharding          = "external-sharding";
-static const char *conf_max_append_req_in_flight   = "max-append-req-in-flight";
+static const char *conf_append_req_max_count       = "append-req-max-count";
+static const char *conf_append_req_max_size        = "append-req-max-size";
 static const char *conf_scan_size                  = "scan-size";
 static const char *conf_tls_enabled                = "tls-enabled";
 static const char *conf_cluster_user               = "cluster-user";
@@ -535,8 +536,10 @@ static long long getNumeric(const char *name, void *privdata)
         return (long long) c->log_max_cache_size;
     } else if (strcasecmp(name, conf_shardgroup_update_interval) == 0) {
         return c->shardgroup_update_interval;
-    } else if (strcasecmp(name, conf_max_append_req_in_flight) == 0) {
-        return c->max_appendentries_inflight;
+    } else if (strcasecmp(name, conf_append_req_max_count) == 0) {
+        return c->append_req_max_count;
+    } else if (strcasecmp(name, conf_append_req_max_size) == 0) {
+        return c->append_req_max_size;
     } else if (strcasecmp(name, conf_scan_size) == 0) {
         return c->scan_size;
     }
@@ -602,8 +605,10 @@ static int setNumeric(const char *name, long long val, void *priv,
         c->log_max_file_size = val;
     } else if (strcasecmp(name, conf_shardgroup_update_interval) == 0) {
         c->shardgroup_update_interval = (int) val;
-    } else if (strcasecmp(name, conf_max_append_req_in_flight) == 0) {
-        c->max_appendentries_inflight = (int) val;
+    } else if (strcasecmp(name, conf_append_req_max_count) == 0) {
+        c->append_req_max_count = val;
+    } else if (strcasecmp(name, conf_append_req_max_size) == 0) {
+        c->append_req_max_size = val;
     } else if (strcasecmp(name, conf_scan_size) == 0) {
         c->scan_size = val;
     } else {
@@ -708,7 +713,8 @@ RRStatus ConfigInit(RedisRaftConfig *c, RedisModuleCtx *ctx)
     ret |= RedisModule_RegisterNumericConfig(ctx, conf_proxy_response_timeout,     10000,            REDISMODULE_CONFIG_DEFAULT,   1, INT_MAX,   getNumeric, setNumeric, NULL, c);
     ret |= RedisModule_RegisterNumericConfig(ctx, conf_reconnect_interval,         100,              REDISMODULE_CONFIG_DEFAULT,   1, INT_MAX,   getNumeric, setNumeric, NULL, c);
     ret |= RedisModule_RegisterNumericConfig(ctx, conf_shardgroup_update_interval, 5000,             REDISMODULE_CONFIG_DEFAULT,   1, INT_MAX,   getNumeric, setNumeric, NULL, c);
-    ret |= RedisModule_RegisterNumericConfig(ctx, conf_max_append_req_in_flight,   2,                REDISMODULE_CONFIG_DEFAULT,   1, INT_MAX,   getNumeric, setNumeric, NULL, c);
+    ret |= RedisModule_RegisterNumericConfig(ctx, conf_append_req_max_count,       2,                REDISMODULE_CONFIG_DEFAULT,   1, INT_MAX,   getNumeric, setNumeric, NULL, c);
+    ret |= RedisModule_RegisterNumericConfig(ctx, conf_append_req_max_size,        2097152,          REDISMODULE_CONFIG_MEMORY,    1, INT_MAX,   getNumeric, setNumeric, NULL, c);
     ret |= RedisModule_RegisterNumericConfig(ctx, conf_log_max_cache_size,         64000000,         REDISMODULE_CONFIG_MEMORY,    0, LLONG_MAX, getNumeric, setNumeric, NULL, c);
     ret |= RedisModule_RegisterNumericConfig(ctx, conf_log_max_file_size,          128000000,        REDISMODULE_CONFIG_MEMORY,    0, LLONG_MAX, getNumeric, setNumeric, NULL, c);
     ret |= RedisModule_RegisterNumericConfig(ctx, conf_scan_size,                  1000,             REDISMODULE_CONFIG_DEFAULT,   1, LLONG_MAX, getNumeric, setNumeric, NULL, c);

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -901,6 +901,9 @@ static int cmdRaftAppendEntries(RedisModuleCtx *ctx, RedisModuleString **argv, i
         msg.entries[i] = e;
     }
 
+    rr->appendreq_received++;
+    rr->appendreq_with_entry_received += (msg.n_entries > 0) ? 1 : 0;
+
     raft_appendentries_resp_t resp = {0};
     raft_node_t *node = raft_get_node(rr->raft, src_node_id);
 
@@ -1756,6 +1759,10 @@ static void handleInfo(RedisModuleInfoCtx *ctx, int for_crash_report)
     RedisModule_InfoAddFieldULongLong(ctx, "proxy_failed_reqs", rr->proxy_failed_reqs);
     RedisModule_InfoAddFieldULongLong(ctx, "proxy_failed_responses", rr->proxy_failed_responses);
     RedisModule_InfoAddFieldULongLong(ctx, "proxy_outstanding_reqs", rr->proxy_outstanding_reqs);
+
+    RedisModule_InfoAddSection(ctx, "stats");
+    RedisModule_InfoAddFieldULongLong(ctx, "appendreq_received", rr->appendreq_received);
+    RedisModule_InfoAddFieldULongLong(ctx, "appendreq_with_entry_received", rr->appendreq_with_entry_received);
 }
 
 static int registerRaftCommands(RedisModuleCtx *ctx)

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -337,7 +337,8 @@ typedef struct RedisRaftConfig {
     int reconnect_interval;             /* Milliseconds to wait to reconnect to a node if connection drops */
     int proxy_response_timeout;         /* Milliseconds to wait for a response to a proxy request */
     int response_timeout;               /* Milliseconds to wait for a response to a Raft message */
-    int max_appendentries_inflight;     /* Max appendreq count in flight between nodes. */
+    long long append_req_max_count;     /* Max in-flight appendreq message count between two nodes. */
+    long long append_req_max_size;      /* Max appendreq message size in bytes. Just an approximation. */
     long long scan_size;                /* how many keys to fetch at a time internally for raft.scan */
 
     /* Cache and file compaction */

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -402,6 +402,9 @@ typedef struct RedisRaftCtx {
     unsigned long proxy_outstanding_reqs;        /* Number of proxied requests pending */
     unsigned long snapshots_loaded;              /* Number of snapshots loaded */
     unsigned long snapshots_created;             /* Number of snapshots created */
+    unsigned long appendreq_received;            /* Number of received appendreq messages */
+    unsigned long appendreq_with_entry_received; /* Number of received appendreq messages with at least one entry in them */
+
     char *resp_call_fmt;                         /* Format string to use in RedisModule_Call(), Redis version-specific */
     int entered_eval;                            /* handling a lua script */
     RedisModuleDict *locked_keys;                /* keys thar have been locked for migration */

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -30,7 +30,8 @@ def test_config_sanity(cluster):
     verify('raft.proxy-response-timeout', 999)
     verify('raft.reconnect-interval', 999)
     verify('raft.shardgroup-update-interval', 999)
-    verify('raft.max-append-req-in-flight', 999)
+    verify('raft.append-req-max-count', 999)
+    verify('raft.append-req-max-size', 999)
     verify('raft.log-max-cache-size', 999)
     verify('raft.log-max-file-size', 999)
     verify('raft.scan-size', 999)
@@ -138,7 +139,8 @@ def test_config_args(cluster):
                  'proxy-response-timeout':     8007,
                  'reconnect-interval':         8008,
                  'shardgroup-update-interval': 8009,
-                 'max-append-req-in-flight':   8010,
+                 'append-req-max-count':       8010,
+                 'append-req-max-size':        8099,
                  'log-max-cache-size':         8011,
                  'log-max-file-size':          8012,
                  'scan-size':                  8013,
@@ -193,8 +195,10 @@ def test_invalid_configs(cluster):
     verify_failure('raft.reconnect-interval', -1)
     verify_failure('raft.shardgroup-update-interval', 0)
     verify_failure('raft.shardgroup-update-interval', -1)
-    verify_failure('raft.max-append-req-in-flight', 0)
-    verify_failure('raft.max-append-req-in-flight', -1)
+    verify_failure('raft.append-req-max-count', 0)
+    verify_failure('raft.append-req-max-count', -1)
+    verify_failure('raft.append-req-max-size', 0)
+    verify_failure('raft.append-req-max-size', -1)
     verify_failure('raft.log-max-cache-size', -1)
     verify_failure('raft.log-max-file-size', -1)
     verify_failure('raft.scan-size', -1)


### PR DESCRIPTION
Add support to limit appendentries message size

Currently, there is no limit on appendentries payload size. If there are many entries to be sent to the followers, we create a huge appendentries message. This might cause performance issues or even OOM.

Using the callback `get_entries_to_send()` introduced in https://github.com/RedisLabs/raft/pull/101, this PR adds support to limit appendentries message size. Rather than creating a single large appendentries message, RedisRaft will send multiple smaller appendentries messages. 

Configuration parameter changes: 
- Added `append-req-max-size` configuration. RedisRaft will try to create append req messages smaller than this limit. This is just a best-effort limit. (e.g if a single entry is larger than the limit, the message will be larger than the limit. ) 
- Renamed existing configuration parameter `max-append-req-in-flight` to `append-req-max-count` (just for clarity and to have common prefix in related configs). 

Info output changes:
- Added `stats` sections and two other metrics, required for testing but can be useful in general:
```
# raft_stats
raft_appendreq_received:0               /* Number of received appendreq messages */
raft_appendreq_with_entry_received:0    /* Number of received appendreq messages with at least one entry */
```

Fixes: https://github.com/RedisLabs/redisraft/issues/240