### PR TITLE
Fix crossslot command crash

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -281,7 +281,9 @@ static RRStatus handleSharding(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisC
     }
 
     if (HashSlotCompute(rr, cmds, &slot) != RR_OK) {
-        replyCrossSlot(ctx);
+        if (ctx) {
+            replyCrossSlot(ctx);
+        }
         return RR_ERROR;
     }
 

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -72,6 +72,9 @@ def test_cross_slot_violation(cluster):
     with raises(ResponseError, match='CROSSSLOT'):
         txn.execute()
 
+    # Wait followers just to be sure crossslot command does not cause a problem.
+    cluster.wait_for_unanimity()
+
 
 def test_shard_group_sanity(cluster):
     # Create a cluster with just a single slot


### PR DESCRIPTION
If node is a follower or replaying logs, client context will be NULL. Replying to a NULL context is causing a crash. 