### PR TITLE
Throttle applying entries if execution is slow

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -560,6 +560,7 @@ RRStatus RaftLogSync(RaftLog *log, bool sync)
     log->fsync_count++;
     log->fsync_total += took;
     log->fsync_max = MAX(took, log->fsync_max);
+    log->fsync_index = log->index;
 
     return RR_OK;
 }

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1763,6 +1763,7 @@ static void handleInfo(RedisModuleInfoCtx *ctx, int for_crash_report)
     RedisModule_InfoAddSection(ctx, "stats");
     RedisModule_InfoAddFieldULongLong(ctx, "appendreq_received", rr->appendreq_received);
     RedisModule_InfoAddFieldULongLong(ctx, "appendreq_with_entry_received", rr->appendreq_with_entry_received);
+    RedisModule_InfoAddFieldULongLong(ctx, "exec_throttled", rr->exec_throttled);
 }
 
 static int registerRaftCommands(RedisModuleCtx *ctx)

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -404,6 +404,8 @@ typedef struct RedisRaftCtx {
     unsigned long snapshots_created;             /* Number of snapshots created */
     unsigned long appendreq_received;            /* Number of received appendreq messages */
     unsigned long appendreq_with_entry_received; /* Number of received appendreq messages with at least one entry in them */
+    unsigned long exec_throttled;                /* Number of command executions throttled due to slow execution */
+
 
     char *resp_call_fmt;                         /* Format string to use in RedisModule_Call(), Redis version-specific */
     int entered_eval;                            /* handling a lua script */
@@ -645,6 +647,7 @@ typedef struct RaftLog {
     FILE                *file;
     FILE                *idxfile;
     off_t               idxoffset;              /* Index file position */
+    raft_index_t        fsync_index;            /* Last entry index included in the latest fsync() call */
     uint64_t            fsync_count;            /* Count of fsync() calls */
     uint64_t            fsync_max;              /* Slowest fsync() call in microseconds */
     uint64_t            fsync_total;            /* Total time fsync() calls consumed in microseconds */


### PR DESCRIPTION
Throttle applying entries if execution is slow

With https://github.com/RedisLabs/raft/pull/106, if applying batch of entries takes some time longer than half of the request timeout, execution of entries are throttled. This way, server will not be blocked and no request timeouts / election timeouts will occur. 

Fixes https://github.com/RedisLabs/redisraft/issues/217