### PR TITLE
Add flow control config for snapshot delivery

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -69,6 +69,8 @@ static const char *conf_ignored_commands           = "ignored-commands";
 static const char *conf_external_sharding          = "external-sharding";
 static const char *conf_append_req_max_count       = "append-req-max-count";
 static const char *conf_append_req_max_size        = "append-req-max-size";
+static const char *conf_snapshot_req_max_count     = "snapshot-req-max-count";
+static const char *conf_snapshot_req_max_size      = "snapshot-req-max-size";
 static const char *conf_scan_size                  = "scan-size";
 static const char *conf_tls_enabled                = "tls-enabled";
 static const char *conf_cluster_user               = "cluster-user";
@@ -546,6 +548,10 @@ static long long getNumeric(const char *name, void *privdata)
         return c->append_req_max_count;
     } else if (strcasecmp(name, conf_append_req_max_size) == 0) {
         return c->append_req_max_size;
+    } else if (strcasecmp(name, conf_snapshot_req_max_count) == 0) {
+        return c->snapshot_req_max_count;
+    } else if (strcasecmp(name, conf_snapshot_req_max_size) == 0) {
+        return c->snapshot_req_max_size;
     } else if (strcasecmp(name, conf_scan_size) == 0) {
         return c->scan_size;
     }
@@ -615,6 +621,10 @@ static int setNumeric(const char *name, long long val, void *priv,
         c->append_req_max_count = val;
     } else if (strcasecmp(name, conf_append_req_max_size) == 0) {
         c->append_req_max_size = val;
+    } else if (strcasecmp(name, conf_snapshot_req_max_count) == 0) {
+        c->snapshot_req_max_count = val;
+    } else if (strcasecmp(name, conf_snapshot_req_max_size) == 0) {
+        c->snapshot_req_max_size = val;
     } else if (strcasecmp(name, conf_scan_size) == 0) {
         c->scan_size = val;
     } else {
@@ -721,6 +731,8 @@ RRStatus ConfigInit(RedisRaftConfig *c, RedisModuleCtx *ctx)
     ret |= RedisModule_RegisterNumericConfig(ctx, conf_shardgroup_update_interval, 5000,             REDISMODULE_CONFIG_DEFAULT,   1, INT_MAX,   getNumeric, setNumeric, NULL, c);
     ret |= RedisModule_RegisterNumericConfig(ctx, conf_append_req_max_count,       2,                REDISMODULE_CONFIG_DEFAULT,   1, INT_MAX,   getNumeric, setNumeric, NULL, c);
     ret |= RedisModule_RegisterNumericConfig(ctx, conf_append_req_max_size,        2097152,          REDISMODULE_CONFIG_MEMORY,    1, INT_MAX,   getNumeric, setNumeric, NULL, c);
+    ret |= RedisModule_RegisterNumericConfig(ctx, conf_snapshot_req_max_count,     32,               REDISMODULE_CONFIG_DEFAULT,   1, INT_MAX,   getNumeric, setNumeric, NULL, c);
+    ret |= RedisModule_RegisterNumericConfig(ctx, conf_snapshot_req_max_size,      65536,            REDISMODULE_CONFIG_MEMORY,    1, INT_MAX,   getNumeric, setNumeric, NULL, c);
     ret |= RedisModule_RegisterNumericConfig(ctx, conf_log_max_cache_size,         64000000,         REDISMODULE_CONFIG_MEMORY,    0, LLONG_MAX, getNumeric, setNumeric, NULL, c);
     ret |= RedisModule_RegisterNumericConfig(ctx, conf_log_max_file_size,          128000000,        REDISMODULE_CONFIG_MEMORY,    0, LLONG_MAX, getNumeric, setNumeric, NULL, c);
     ret |= RedisModule_RegisterNumericConfig(ctx, conf_scan_size,                  1000,             REDISMODULE_CONFIG_DEFAULT,   1, LLONG_MAX, getNumeric, setNumeric, NULL, c);

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -998,6 +998,8 @@ static int cmdRaftSnapshot(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     raft_snapshot_resp_t resp = {0};
     raft_node_t *node = raft_get_node(rr->raft, (raft_node_id_t) src_node_id);
 
+    rr->snapshotreq_received++;
+
     if (raft_recv_snapshot(rr->raft, node, &req, &resp) != 0) {
         RedisModule_ReplyWithError(ctx, "ERR operation failed");
         return REDISMODULE_OK;
@@ -1763,6 +1765,7 @@ static void handleInfo(RedisModuleInfoCtx *ctx, int for_crash_report)
     RedisModule_InfoAddSection(ctx, "stats");
     RedisModule_InfoAddFieldULongLong(ctx, "appendreq_received", rr->appendreq_received);
     RedisModule_InfoAddFieldULongLong(ctx, "appendreq_with_entry_received", rr->appendreq_with_entry_received);
+    RedisModule_InfoAddFieldULongLong(ctx, "snapshotreq_received", rr->snapshotreq_received);
 }
 
 static int registerRaftCommands(RedisModuleCtx *ctx)

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -339,6 +339,8 @@ typedef struct RedisRaftConfig {
     int response_timeout;               /* Milliseconds to wait for a response to a Raft message */
     long long append_req_max_count;     /* Max in-flight appendreq message count between two nodes. */
     long long append_req_max_size;      /* Max appendreq message size in bytes. Just an approximation. */
+    long long snapshot_req_max_count;   /* Max in-flight snapshotreq message count between two nodes. */
+    long long snapshot_req_max_size;    /* Max snapshotreq message size in bytes. Just an approximation. */
     long long scan_size;                /* how many keys to fetch at a time internally for raft.scan */
 
     /* Cache and file compaction */
@@ -404,6 +406,7 @@ typedef struct RedisRaftCtx {
     unsigned long snapshots_created;             /* Number of snapshots created */
     unsigned long appendreq_received;            /* Number of received appendreq messages */
     unsigned long appendreq_with_entry_received; /* Number of received appendreq messages with at least one entry in them */
+    unsigned long snapshotreq_received;          /* Number of received snapshotreq messages */
 
     char *resp_call_fmt;                         /* Format string to use in RedisModule_Call(), Redis version-specific */
     int entered_eval;                            /* handling a lua script */

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -32,6 +32,8 @@ def test_config_sanity(cluster):
     verify('raft.shardgroup-update-interval', 999)
     verify('raft.append-req-max-count', 999)
     verify('raft.append-req-max-size', 999)
+    verify('raft.snapshot-req-max-count', 999)
+    verify('raft.snapshot-req-max-size', 999)
     verify('raft.log-max-cache-size', 999)
     verify('raft.log-max-file-size', 999)
     verify('raft.scan-size', 999)
@@ -141,6 +143,8 @@ def test_config_args(cluster):
                  'shardgroup-update-interval': 8009,
                  'append-req-max-count':       8010,
                  'append-req-max-size':        8099,
+                 'snapshot-req-max-count':     8111,
+                 'snapshot-req-max-size':      8112,
                  'log-max-cache-size':         8011,
                  'log-max-file-size':          8012,
                  'scan-size':                  8013,
@@ -199,6 +203,10 @@ def test_invalid_configs(cluster):
     verify_failure('raft.append-req-max-count', -1)
     verify_failure('raft.append-req-max-size', 0)
     verify_failure('raft.append-req-max-size', -1)
+    verify_failure('raft.snapshot-req-max-count', 0)
+    verify_failure('raft.snapshot-req-max-count', -1)
+    verify_failure('raft.snapshot-req-max-size', 0)
+    verify_failure('raft.snapshot-req-max-size', -1)
     verify_failure('raft.log-max-cache-size', -1)
     verify_failure('raft.log-max-file-size', -1)
     verify_failure('raft.scan-size', -1)


### PR DESCRIPTION
Add flow control config for snapshot delivery

Previously, snapshot delivery flow control options were hard-coded. This commit makes them configurable. 