### PR TITLE
Delete duplicate command filter registration

### DIFF
--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1881,15 +1881,14 @@ __attribute__((__unused__)) int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisMod
 
     /* Create a logging context */
     redisraft_log_ctx = RedisModule_GetDetachedThreadSafeContext(ctx);
+
     RedisModule_RegisterInfoFunc(ctx, handleInfo);
+    RedisModule_RegisterCommandFilter(ctx, interceptRedisCommands, 0);
 
     if (registerRaftCommands(ctx) == RR_ERROR) {
         LOG_WARNING("Failed to register commands");
         return REDISMODULE_ERR;
     }
-
-    redis_raft.cmd_filter = RedisModule_RegisterCommandFilter(ctx,
-        interceptRedisCommands, 0);
 
     if (RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ClientChange,
                 handleClientEvent) != REDISMODULE_OK) {
@@ -1914,8 +1913,6 @@ __attribute__((__unused__)) int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisMod
     if (RedisRaftInit(rr, ctx) == RR_ERROR) {
         return REDISMODULE_ERR;
     }
-
-    rr->cmd_filter = RedisModule_RegisterCommandFilter(ctx, interceptRedisCommands, 0);
 
     LOG_NOTICE("Raft module loaded, state is '%s'", getStateStr(rr));
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -385,7 +385,6 @@ typedef struct RedisRaftCtx {
     RaftSnapshotInfo snapshot_info;              /* Current snapshot info */
     struct RaftReq *transfer_req;                /* RaftReq if a leader transfer is in progress */
     struct RaftReq *migrate_req;                 /* RaftReq if a migration transfer is in progress */
-    RedisModuleCommandFilter *cmd_filter;        /* Command filter is used for intercepting redis commands */
     struct ShardingInfo *sharding_info;          /* Information about sharding, when cluster mode is enabled */
     RedisModuleDict *client_state;               /* A dict that tracks different client states */
 


### PR DESCRIPTION
Introduced by https://github.com/RedisLabs/redisraft/pull/360, the command filter will be registered twice as part of a rebase mistake. It is harmless but unnecessary. Also, as we are not using the command filter object itself, we don't need to keep a reference to it.