### PR TITLE
Use RM_FreeString() for a RedisModuleString

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -221,7 +221,7 @@ static void populateCommandSpecFromRedis(RedisModuleCtx *ctx)
         RedisModuleString *name_str = RedisModule_CreateStringFromCallReply(name);
         CommandSpec *cs = getOrCreateCommandSpec(name_str, true);
         RedisModule_Assert(cs != NULL);
-        RedisModule_Free(name_str);
+        RedisModule_FreeString(NULL, name_str);
 
         cs->flags |= cmdspec_flags;
     }


### PR DESCRIPTION
Use RM_FreeString() for a RedisModuleString

It's not a problem here but just a precaution, we should free `RedisModuleString` with `RM_FreeString()`. Otherwise, as `RM_Free()` is not doing reference count check, it might cause leaks/crashes if there is a reference to the string somewhere else. 