### PR TITLE
Fix use-after-free bug for shardgroup replace

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1737,8 +1737,8 @@ void ShardGroupReplace(RedisRaftCtx *rr,
     ret = ShardGroupsAppendLogEntry(rr, num_elems, sg,
                                     RAFT_LOGTYPE_REPLACE_SHARDGROUPS, req);
     if (ret != RR_OK) {
-        RaftReqFree(req);
         RedisModule_ReplyWithError(req->ctx, "failed, please check logs.");
+        RaftReqFree(req);
         goto out;
     }
 


### PR DESCRIPTION
Fix use-after-free bug for shardgroup replace

It's unlikely to hit this path. Currently, only case is if leader receives a shardgroup replace command when leader transfer is in progress.