### PR TITLE
Add test module support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,4 +284,24 @@ add_custom_command(TARGET valgrind-tests
 add_custom_target(tests)
 add_dependencies(tests integration-tests unit-tests)
 
+# ---------------------------- Test Modules ---------------------------------- #
+macro(build_test_module name)
+    add_library(${name} MODULE tests/integration/modules/${name}.c)
+    set_target_properties(${name} PROPERTIES PREFIX "")
+    target_include_directories(${name} PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/deps/common/>)
+    set_target_properties(${name} PROPERTIES
+            LIBRARY_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/tests/integration/modules")
+    set_property(TARGET ${name} APPEND PROPERTY
+            ADDITIONAL_CLEAN_FILES ${LIBRARY_OUTPUT_DIRECTORY}/$<TARGET_FILE_NAME:${name}>)
+endmacro()
+
+# Add new modules here.
+#
+# Example:
+# Module file path: tests/integration/modules/hellomodule.c
+# Output file path will be: tests/integration/modules/hellomodule.so
+build_test_module(hellomodule)
+# -------------------------- Test Modules End -------------------------------- #
+
 # ----------------------------- Test End ------------------------------------- #

--- a/tests/integration/modules/.clang-format
+++ b/tests/integration/modules/.clang-format
@@ -1,0 +1,127 @@
+---
+Language: Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments: None
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: Consecutive
+AlignEscapedNewlines: Right
+AlignOperands: Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: No
+BinPackArguments: true
+BinPackParameters: true
+
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: true
+  AfterNamespace: false
+  AfterObjCDeclaration: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakStringLiterals: false
+ColumnLimit: 0
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+ForEachMacros:
+  - LIST_FOREACH_SAFE
+  - STAILQ_FOREACH_SAFE
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^("[.a-zA-Z0-9_-]+\.h")'
+    Priority: 1
+
+  # Local headers: "foo/bar.h"
+  - Regex: '^("[.a-zA-Z0-9_/-]+\.h")'
+    Priority: 2
+
+  # C Header: <foo.h>, <net/foo.h>, etc
+  - Regex: '^(<[.a-zA-Z0-9_/-]+\.h>)'
+    Priority: 3
+
+IncludeIsMainRegex: '(test)?$'
+IndentPPDirectives: None
+IndentGotoLabels: false
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+# InsertBraces: true      Requires clang-format 15
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+
+PenaltyBreakAssignment: 10
+PenaltyBreakBeforeFirstCallParameter: 30
+PenaltyBreakComment: 100
+PenaltyBreakFirstLessLess: 0
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000
+PenaltyReturnTypeOnItsOwnLine: 60
+
+PPIndentWidth: -1
+PointerAlignment: Right
+
+# Requires clang-format 14 but somehow throws an error with clang 14 on Ubuntu.
+# QualifierOrder: ['static', 'inline', 'const', 'volatile', 'type']
+
+ReflowComments: false
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Always
+SortIncludes: CaseSensitive
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Latest
+TabWidth: 4
+UseTab: Never
+WhitespaceSensitiveMacros: [ 'STAILQ_HEAD', 'STAILQ_ENTRY', 'LIST_ENTRY' ]
+...

--- a/tests/integration/modules/hellomodule.c
+++ b/tests/integration/modules/hellomodule.c
@@ -1,0 +1,30 @@
+/*
+* This file is part of RedisRaft.
+*
+* Copyright (c) 2020-2022 Redis Ltd.
+*
+* RedisRaft is licensed under the Redis Source Available License (RSAL).
+*/
+
+#include "redismodule.h"
+
+int cmdHello(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
+{
+    RedisModule_ReplyWithSimpleString(ctx, "HELLO");
+    return REDISMODULE_OK;
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
+{
+    int rc = RedisModule_Init(ctx, "hellomodule", 1, REDISMODULE_APIVER_1);
+    if (rc != REDISMODULE_OK) {
+        return REDISMODULE_ERR;
+    }
+
+    rc = RedisModule_CreateCommand(ctx, "hellomodule", cmdHello, "write", 0, 0, 0);
+    if (rc != REDISMODULE_OK) {
+        return REDISMODULE_ERR;
+    }
+
+    return REDISMODULE_OK;
+}


### PR DESCRIPTION
Add test module support to use inside integration tests.

Module file (.c) should be added under `tests/integration/modules/`.

e.g hellomodule:

1- Create the module file: `tests/integration/modules/hellomodule.c`
2- Add one line into CmakeLists.txt: 

     build_test_module(hellomodule)

3- Output file after the build: `tests/integration/modules/hellomodule.so`