### PR TITLE
RR-24 CLUSTER SHARDS implementation

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1569,11 +1569,11 @@ static void addClusterShardsReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
             if (type != SLOTRANGE_TYPE_STABLE && type != SLOTRANGE_TYPE_MIGRATING) {
                 continue;
             }
-            slot_count += 2;
+            slot_count += 1;
             RedisModule_ReplyWithLongLong(ctx, sg->slot_ranges[i].start_slot);
             RedisModule_ReplyWithLongLong(ctx, sg->slot_ranges[i].end_slot);
         }
-        RedisModule_ReplySetArrayLength(ctx, slot_count);
+        RedisModule_ReplySetArrayLength(ctx, slot_count * 2);
 
         RedisModule_ReplyWithCString(ctx, "nodes");
         if (sg->local) {

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1554,7 +1554,7 @@ static void addClusterShardsReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
 
         int slot_count = 0;
         RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
-        for (unsigned int i=0; i < sg->slot_ranges_num; i++) {
+        for (unsigned int i = 0; i < sg->slot_ranges_num; i++) {
             /* we only include slot ranges for a shard that are stable / migration */
             SlotRangeType type = sg->slot_ranges[i].type;
             if (type != SLOTRANGE_TYPE_STABLE && type != SLOTRANGE_TYPE_MIGRATING) {

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1483,11 +1483,127 @@ static void addClusterSlotsReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
     RedisModule_ReplySetArrayLength(ctx, num_slots);
 }
 
+static void addClusterShardsNodeReply(RedisModuleCtx *ctx, char *id, uint16_t port, char *host, char *role, int offset, char *health)
+{
+    RedisModule_ReplyWithMap(ctx, 6);
+    RedisModule_ReplyWithCString(ctx, "id");
+    RedisModule_ReplyWithCString(ctx, id);
+    RedisModule_ReplyWithCString(ctx, "port");
+    RedisModule_ReplyWithLongLong(ctx, port);
+    RedisModule_ReplyWithCString(ctx, "ip");
+    RedisModule_ReplyWithCString(ctx, host);
+    RedisModule_ReplyWithCString(ctx, "role");
+    RedisModule_ReplyWithCString(ctx, role);
+    RedisModule_ReplyWithCString(ctx, "replication-offset");
+    RedisModule_ReplyWithLongLong(ctx, offset);
+    RedisModule_ReplyWithCString(ctx, "health");
+    RedisModule_ReplyWithCString(ctx, health);
+}
+
+static int addClusterShardsLocalNodeReply(RedisRaftCtx *rr, RedisModuleCtx *ctx, raft_node_t *raft_node, raft_node_t *leader)
+{
+    Node *node = raft_node_get_udata(raft_node);
+    NodeAddr *addr;
+
+    char *role = (raft_node_get_id(raft_node) == raft_get_leader_id(rr->raft)) ? "primary" : "replica";
+    int self = (raft_node_get_id(raft_node) == raft_get_nodeid(rr->raft));
+
+    /* Stale nodes should not exist but we prefer to be defensive.
+     * Our own node doesn't have a connection so we don't expect a Node object.
+     */
+    if (node) {
+        addr = &node->addr;
+    } else if (self) {
+        addr = &rr->config.addr;
+    } else {
+        return 0;
+    }
+
+    char node_id[RAFT_SHARDGROUP_NODEID_LEN + 1];
+    raftNodeToString(node_id, rr->log->dbid, raft_node);
+
+    addClusterShardsNodeReply(ctx, node_id, addr->port, addr->host, role, 0, "online");
+
+    return 1;
+}
+
+static void addClusterShardsReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
+{
+    raft_node_t *leader_node = getLeaderRaftNodeOrReply(rr, ctx);
+    if (!leader_node) {
+        return;
+    }
+
+    ShardingInfo *si = rr->sharding_info;
+    if (!si->shard_group_map) {
+        RedisModule_ReplyWithNullArray(ctx);
+        return;
+    }
+
+    int shard_count = 0;
+    size_t key_len;
+    ShardGroup *sg;
+
+    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
+    RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(si->shard_group_map, "^", NULL, 0);
+    while (RedisModule_DictNextC(iter, &key_len, (void **) &sg) != NULL) {
+        shard_count++;
+
+        RedisModule_ReplyWithMap(ctx, 2);
+        RedisModule_ReplyWithCString(ctx, "slots");
+
+        int slot_count = 0;
+        RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
+        for (unsigned int i=0; i < sg->slot_ranges_num; i++) {
+            /* we only include slot ranges for a shard that are stable / migration */
+            SlotRangeType type = sg->slot_ranges[i].type;
+            if (type != SLOTRANGE_TYPE_STABLE && type != SLOTRANGE_TYPE_MIGRATING) {
+                continue;
+            }
+            slot_count += 2;
+            RedisModule_ReplyWithLongLong(ctx, sg->slot_ranges[i].start_slot);
+            RedisModule_ReplyWithLongLong(ctx, sg->slot_ranges[i].end_slot);
+        }
+        RedisModule_ReplySetArrayLength(ctx, slot_count);
+
+        RedisModule_ReplyWithCString(ctx, "nodes");
+        if (sg->local) {
+            int node_count = 0;
+            RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
+
+            for (int j = 0; j < raft_get_num_nodes(rr->raft); j++) {
+                raft_node_t *raft_node = raft_get_node_from_idx(rr->raft, j);
+                if (!raft_node_is_active(raft_node)) {
+                    continue;
+                }
+                node_count += addClusterShardsLocalNodeReply(rr, ctx, raft_node, leader_node);
+            }
+            RedisModule_ReplySetArrayLength(ctx, node_count);
+        } else {
+            RedisModule_ReplyWithArray(ctx, sg->nodes_num);
+            for (unsigned int j = 0; j < sg->nodes_num; j++) {
+                char *node_id = sg->nodes[j].node_id;
+                uint16_t port = sg->nodes[j].addr.port;
+                char *host = sg->nodes[j].addr.host;
+                char *role = (j == 0) ? "primary" : "replica";
+                int offset = 0;
+                char *health = "online";
+
+                addClusterShardsNodeReply(ctx, node_id, port, host, role, offset, health);
+            }
+        }
+    }
+
+    RedisModule_DictIteratorStop(iter);
+    RedisModule_ReplySetArrayLength(ctx, shard_count);
+}
+
 /* Process CLUSTER commands, as intercepted earlier by the Raft module.
  *
  * Currently only supports:
  *   - SLOTS.
  *   - NODES.
+ *   - SHARDS,
  */
 void ShardingHandleClusterCommand(RedisRaftCtx *rr,
                                   RedisModuleCtx *ctx, RaftRedisCommand *cmd)
@@ -1508,6 +1624,8 @@ void ShardingHandleClusterCommand(RedisRaftCtx *rr,
         addClusterSlotsReply(rr, ctx);
     } else if (cmd_len == 5 && !strncasecmp(cmd_str, "NODES", 5)) {
         addClusterNodesReply(rr, ctx);
+    } else if (cmd_len == 6 && !strncasecmp(cmd_str, "SHARDS", 6)) {
+        addClusterShardsReply(rr, ctx);
     } else {
         RedisModule_ReplyWithError(ctx, "ERR Unknown subcommand.");
     }

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -1029,13 +1029,17 @@ def test_cluster_shards_for_empty_slot_sg(cluster):
         assert cluster_shards[0][1] == []
         assert cluster_shards[0][2] == b'nodes'
         assert len(cluster_shards[0][3]) == 1
-        assert len(cluster_shards[0][3][0]) == 12
+        assert len(cluster_shards[0][3][0]) == 16
         assert cluster_shards[0][3][0][0] == b'id'
         assert cluster_shards[0][3][0][1] == node_id_1
         assert cluster_shards[0][3][0][2] == b'port'
         assert cluster_shards[0][3][0][3] == 1111
         assert cluster_shards[0][3][0][4] == b'ip'
-        assert cluster_shards[0][3][0][5] == b'1.1.1.1'
+        assert cluster_shards[0][3][0][5] == b''
+        assert cluster_shards[0][3][0][6] == b'hostname'
+        assert cluster_shards[0][3][0][7] == b'1.1.1.1'
+        assert cluster_shards[0][3][0][8] == b'endpoint'
+        assert cluster_shards[0][3][0][9] == b'1.1.1.1'
 
     validate_shards(cluster.node(1).client.execute_command('CLUSTER', 'SHARDS'))
 
@@ -1067,17 +1071,17 @@ def test_cluster_shards_for_single_slot_range_sg_multiple_nodes(cluster):
         assert cluster_shards[0][1][1] == 2000
         assert cluster_shards[0][2] == b'nodes'
         assert len(cluster_shards[0][3]) == 3
-        assert len(cluster_shards[0][3][0]) == 12
+        assert len(cluster_shards[0][3][0]) == 16
         for i in range(len(cluster_shards[0][3])):
             if cluster_shards[0][3][i][1] == node_id_1:
                 assert cluster_shards[0][3][i][3] == 1111
-                assert cluster_shards[0][3][i][5] == b'1.1.1.1'
+                assert cluster_shards[0][3][i][7] == b'1.1.1.1'
             elif cluster_shards[0][3][i][1] == node_id_2:
                 assert cluster_shards[0][3][i][3] == 2222
-                assert cluster_shards[0][3][i][5] == b'2.2.2.2'
+                assert cluster_shards[0][3][i][7] == b'2.2.2.2'
             elif cluster_shards[0][3][i][1] == node_id_3:
                 assert cluster_shards[0][3][i][3] == 3333
-                assert cluster_shards[0][3][i][5] == b'3.3.3.3'
+                assert cluster_shards[0][3][i][7] == b'3.3.3.3'
             else:
                 assert False, "didn't match %s" % cluster_shards
 
@@ -1121,30 +1125,28 @@ def test_cluster_shards_for_single_slot_range_sg(cluster):
                 if shard[1][0] == 0:
                     assert shard[1][1] == 500
                     assert len(shard[3]) == 1
-                    assert len(shard[3][0]) == 12
+                    assert len(shard[3][0]) == 16
                     assert shard[3][0][0] == b'id'
                     assert shard[3][0][1] == stable_node_id
                     assert shard[3][0][2] == b'port'
                     assert shard[3][0][3] == 1111
-                    assert shard[3][0][4] == b'ip'
-                    assert shard[3][0][5] == b'1.1.1.1'
+                    assert shard[3][0][7] == b'1.1.1.1'
                 elif shard[1][0] == 501:
                     assert len(shard[1]) == 2
                     assert shard[1][1] == 16383
                     assert len(shard[3]) == 1
-                    assert len(shard[3][0]) == 12
+                    assert len(shard[3][0]) == 16
                     assert shard[3][0][0] == b'id'
                     assert shard[3][0][1] == migrating_node_id
                     assert shard[3][0][2] == b'port'
                     assert shard[3][0][3] == 3333
-                    assert shard[3][0][4] == b'ip'
-                    assert shard[3][0][5] == b'3.3.3.3'
+                    assert shard[3][0][7] == b'3.3.3.3'
             elif len(shard[1]) == 0:
                 assert len(shard[3]) == 1
-                assert len(shard[3][0]) == 12
+                assert len(shard[3][0]) == 16
                 assert shard[3][0][1] == importing_node_id
                 assert shard[3][0][3] == 2222
-                assert shard[3][0][5] == b'2.2.2.2'
+                assert shard[3][0][7] == b'2.2.2.2'
             else:
                 assert False, "didn't match %s" % shard
 


### PR DESCRIPTION
implements cluster shards, only outputs "slot ranges" for migrating/stable slots.

outputs all ndoes, currently treats every node as always "healthy" (unsure how to determine otherwise, perhaps if we would record no response within an election timeout, but might need more support for librafT), as wll as every node being fully in sync (offset == 0, as also unsure how to translate that)