### PR TITLE
Delete unnecessary addUsedNodeId() call

### DIFF
--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1056,7 +1056,6 @@ static void clusterInit(const char *cluster_id)
         PANIC("Failed to initialize Raft log");
     }
 
-    addUsedNodeId(rr, rr->config.id);
     RaftLibraryInit(rr, true);
     initSnapshotTransferData(rr);
     AddBasicLocalShardGroup(rr);


### PR DESCRIPTION
`addUsedNodeId()` call before initializing Raft library is redundant. 

Inside `RaftLibraryInit()`, we add our own node to the raft library. It triggers `notify_membership_event()` callback where we save used node ids. So, node id will be saved there already. 