### PR TITLE
RaftLogFirstIdx() should return snapshot_last_idx + 1

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -712,7 +712,7 @@ RRStatus RaftLogDelete(RaftLog *log, raft_index_t from_idx, raft_entry_notify_f 
 
 raft_index_t RaftLogFirstIdx(RaftLog *log)
 {
-    return log->snapshot_last_idx;
+    return log->snapshot_last_idx + 1;
 }
 
 raft_index_t RaftLogCurrentIdx(RaftLog *log)

--- a/tests/unit/test_log.c
+++ b/tests/unit/test_log.c
@@ -105,6 +105,8 @@ static void test_log_random_access_with_snapshot(void **state)
     __append_entry(log, 3);
     __append_entry(log, 30);
 
+    assert_int_equal(RaftLogFirstIdx(log), 101);
+
     /* Invalid out of bound reads */
     assert_null(RaftLogGet(log, 99));
     assert_null(RaftLogGet(log, 100));


### PR DESCRIPTION
RaftLogFirstIdx() should return the index of the first entry.
Log file might be empty, caller should check entry count before calling this function. 