### PR TITLE
Add a test for raft metadata restore

### DIFF
--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1724,6 +1724,7 @@ static void handleInfo(RedisModuleInfoCtx *ctx, int for_crash_report)
         voting = raft_node_is_voting(raft_get_my_node(rr->raft)) ? "yes" : "no";
     }
     RedisModule_InfoAddFieldCString(ctx, "is_voting", voting);
+    RedisModule_InfoAddFieldLongLong(ctx, "voted_for", rr->raft ? raft_get_voted_for(rr->raft) : -1);
     RedisModule_InfoAddFieldLongLong(ctx, "leader_id", rr->raft ? raft_get_leader_id(rr->raft) : -1);
     RedisModule_InfoAddFieldLongLong(ctx, "current_term", rr->raft ? raft_get_current_term(rr->raft) : 0);
     RedisModule_InfoAddFieldLongLong(ctx, "num_nodes", rr->raft ? raft_get_num_nodes(rr->raft) : 0);


### PR DESCRIPTION
Before https://github.com/RedisLabs/redisraft/pull/479, we wouldn't restore raft metadata from the disk correctly. This PR adds a test for it. 

Fixes: https://github.com/RedisLabs/redisraft/issues/477