### PR TITLE
Fix python warning about escape character

### DIFF
--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -42,13 +42,13 @@ def test_set_cluster_password(cluster):
 
 def test_set_cluster_id_too_short(cluster):
     cluster_id = "123456789012345678901234567890"
-    with raises(ResponseError, match='invalid cluster message \(cluster id length\)'):
+    with raises(ResponseError, match='invalid cluster message \\(cluster id length\\)'):
         cluster.create(3, cluster_id=cluster_id)
 
 
 def test_set_cluster_id_too_long(cluster):
     cluster_id = "1234567890123456789012345678901234"
-    with raises(ResponseError, match='invalid cluster message \(cluster id length\)'):
+    with raises(ResponseError, match='invalid cluster message \\(cluster id length\\)'):
         cluster.create(3, cluster_id=cluster_id)
 
 


### PR DESCRIPTION
```
tests/integration/test_sanity.py:45
  /home/runner/work/redisraft/redisraft/tests/integration/test_sanity.py:45: DeprecationWarning: invalid escape sequence \(
    with raises(ResponseError, match='invalid cluster message \(cluster id length\)'):

tests/integration/test_sanity.py:51
  /home/runner/work/redisraft/redisraft/tests/integration/test_sanity.py:51: DeprecationWarning: invalid escape sequence \(
    with raises(ResponseError, match='invalid cluster message \(cluster id length\)'):
```
