### PR TITLE
Add runslow option to pytest

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -41,6 +41,23 @@ def pytest_addoption(parser):
     parser.addoption(
         '--tls', default=False, action='store_true',
         help='Use tls')
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
 
 
 def create_config(pytest_config):

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -2,6 +2,4 @@
 log_file=tests/tmp/tests.log
 log_file_format=%(message)s
 log_file_level=debug
-optional_tests=
-  slow: slow tests
 timeout=600

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,4 +1,3 @@
 redis==3.4.1
 pytest==7.1.2
-pytest-optional-tests==0.1.1
 pytest-timeout==1.3.4


### PR DESCRIPTION
Problem: https://github.com/RedisLabs/redisraft/runs/8068394104?check_suite_focus=true#step:9:153

Deleted optional_tests package.
Added `--runslow` command line parameter to run slow tests.