### PR TITLE
Delete duplicate test

### DIFF
--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -172,22 +172,3 @@ def test_stale_reads_on_leader_election(cluster):
         assert val_read is not None
         assert val_written == int(val_read)
         time.sleep(1)
-
-
-@pytest.mark.slow
-def test_ae_limit(cluster):
-    """
-    Test handling delivery of a very large appendentries message,
-    if a follower joins after missing many log entries.
-    """
-
-    cluster.create(3)
-    cluster.node(3).terminate()
-
-    pipeline = cluster.node(1).client.pipeline(transaction=False)
-    for _ in range(300000):
-        pipeline.incr('mykey')
-    pipeline.execute()
-
-    cluster.node(3).start()
-    cluster.wait_for_unanimity()


### PR DESCRIPTION
This test requires thousands of entries in the log, so it's marked as slow.

We have better version of this test. This one is not resource hungry:
https://github.com/RedisLabs/redisraft/blob/7fee8f7d948e2e51c9bc28b08dcea5e6bf0d8d6f/tests/integration/test_sanity.py#L455

