### PR TITLE
Fix exception in integration test

### DIFF
--- a/tests/integration/test_membership.py
+++ b/tests/integration/test_membership.py
@@ -70,7 +70,9 @@ def test_single_voting_change_enforced(cluster):
     # cluster while in progress.
     def remove_node_blocked():
         cluster.node(1).client.execute_command('RAFT.NODE', 'REMOVE', '5')
-    Thread(target=remove_node_blocked, daemon=True).start()
+
+    t = Thread(target=remove_node_blocked)
+    t.start()
 
     time.sleep(0.2)
 
@@ -78,6 +80,12 @@ def test_single_voting_change_enforced(cluster):
         cluster.node(1).client.execute_command('RAFT.NODE', 'REMOVE', '4')
 
     assert cluster.node(1).info()['raft_num_nodes'] == 5
+
+    # Starting nodes again, so, blocked thread can join gracefully
+    cluster.node(2).start()
+    cluster.node(3).start()
+    cluster.node(4).start()
+    t.join()
 
 
 def test_removed_node_remains_dead(cluster):


### PR DESCRIPTION
https://github.com/RedisLabs/redisraft/runs/8101574661?check_suite_focus=true#step:9:164

```
test_membership.py::test_single_voting_change_enforced
  /opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/_pytest/threadexception.py:73: PytestUnhandledThreadExceptionWarning: Exception in thread Thread-731
  
  Traceback (most recent call last):
    File "/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/threading.py", line 980, in _bootstrap_inner
      self.run()
    File "/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/threading.py", line 917, in run
      self._target(*self._args, **self._kwargs)
    File "/home/runner/work/redisraft/redisraft/tests/integration/test_membership.py", line 72, in remove_node_blocked
      cluster.node(1).client.execute_command('RAFT.NODE', 'REMOVE', '5')
    File "/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/redis/client.py", line 878, in execute_command
      return self.parse_response(conn, command_name, **options)
    File "/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/redis/client.py", line 892, in parse_response
      response = connection.read_response()
    File "/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/redis/connection.py", line 734, in read_response
      response = self._parser.read_response()
    File "/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/redis/connection.py", line 316, in read_response
      response = self._buffer.readline()
    File "/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/redis/connection.py", line 248, in readline
      self._read_from_socket()
    File "/opt/hostedtoolcache/Python/3.9.13/x64/lib/python3.9/site-packages/redis/connection.py", line 193, in _read_from_socket
      raise ConnectionError(SERVER_CLOSED_CONNECTION_ERROR)
  redis.exceptions.ConnectionError: Connection closed by server.
```

Background thread throws an exception. 