### PR TITLE
Delete unused variables to silence linter warning

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -1620,23 +1620,19 @@ void replaceShardGroups(RedisRaftCtx *rr, raft_entry_t *entry)
     ShardingInfo *si = rr->sharding_info;
 
     if (si->shard_group_map != NULL) {
+        void *data;
         RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(si->shard_group_map, "^", NULL, 0);
 
-        char *key;
-        size_t key_len;
-        ShardGroup *data;
-
-        while ((key = RedisModule_DictNextC(iter, &key_len, (void **) &data)) != NULL) {
+        while (RedisModule_DictNextC(iter, NULL, &data) != NULL) {
             ShardGroupFree(data);
         }
         RedisModule_DictIteratorStop(iter);
         RedisModule_FreeDict(rr->ctx, si->shard_group_map);
-        si->shard_group_map = NULL;
     }
 
+    si->shard_group_map = RedisModule_CreateDict(rr->ctx);
     si->shard_groups_num = 0;
 
-    si->shard_group_map = RedisModule_CreateDict(rr->ctx);
     for (int i = 0; i <= REDIS_RAFT_HASH_MAX_SLOT; i++) {
         si->stable_slots_map[i] = NULL;
         si->importing_slots_map[i] = NULL;

--- a/src/raft.c
+++ b/src/raft.c
@@ -1620,14 +1620,15 @@ void replaceShardGroups(RedisRaftCtx *rr, raft_entry_t *entry)
     ShardingInfo *si = rr->sharding_info;
 
     if (si->shard_group_map != NULL) {
-        void *data;
+        ShardGroup *data;
         RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(si->shard_group_map, "^", NULL, 0);
 
-        while (RedisModule_DictNextC(iter, NULL, &data) != NULL) {
+        while (RedisModule_DictNextC(iter, NULL, (void **) &data) != NULL) {
             ShardGroupFree(data);
         }
         RedisModule_DictIteratorStop(iter);
         RedisModule_FreeDict(rr->ctx, si->shard_group_map);
+        si->shard_group_map = NULL;
     }
 
     si->shard_group_map = RedisModule_CreateDict(rr->ctx);


### PR DESCRIPTION
Delete unused variables and superfluous assignment to silence linter.