### PR TITLE
Delete unused raft_entry_resp_t parameters

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -376,8 +376,7 @@ RRStatus ShardGroupAppendLogEntry(RedisRaftCtx *rr, ShardGroup *sg, int type, vo
     RedisModule_Free(payload);
 
     /* Submit */
-    raft_entry_resp_t response;
-    int e = raft_recv_entry(rr->raft, entry, &response);
+    int e = raft_recv_entry(rr->raft, entry, NULL);
     raft_entry_release(entry);
 
     if (e != 0) {
@@ -412,8 +411,7 @@ RRStatus ShardGroupsAppendLogEntry(RedisRaftCtx *rr, int num_sg, ShardGroup **sg
     RedisModule_Free(buf);
 
     /* Submit */
-    raft_entry_resp_t response;
-    int e = raft_recv_entry(rr->raft, entry, &response);
+    int e = raft_recv_entry(rr->raft, entry, NULL);
     raft_entry_release(entry);
 
     if (e != 0) {

--- a/src/raft.c
+++ b/src/raft.c
@@ -923,9 +923,7 @@ static int raftNodeHasSufficientLogs(raft_server_t *raft, void *user_data, raft_
     cfgchange->id = node->id;
     cfgchange->addr = node->addr;
 
-    raft_entry_resp_t response;
-
-    int e = raft_recv_entry(raft, entry, &response);
+    int e = raft_recv_entry(raft, entry, NULL);
     raft_entry_release(entry);
 
     return e;
@@ -1412,14 +1410,13 @@ void RaftLibraryInit(RedisRaftCtx *rr, bool cluster_init)
             .addr = rr->config.addr,
         };
 
-        raft_entry_resp_t resp = {0};
         raft_entry_t *ety = raft_entry_new(sizeof(cfg));
 
         ety->id = rand();
         ety->type = RAFT_LOGTYPE_ADD_NODE;
         memcpy(ety->data, &cfg, sizeof(cfg));
 
-        if (raft_recv_entry(rr->raft, ety, &resp) != 0) {
+        if (raft_recv_entry(rr->raft, ety, NULL) != 0) {
             PANIC("Failed to init raft library");
         }
         raft_entry_release(ety);

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -139,7 +139,6 @@ static int cmdRaftNode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
             return REDISMODULE_OK;
         }
 
-        raft_entry_resp_t resp;
         RaftReq *req = RaftReqInit(ctx, RR_CFGCHANGE_ADDNODE);
 
         raft_entry_req_t *entry = raft_entry_new(sizeof(cfg));
@@ -148,7 +147,7 @@ static int cmdRaftNode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         memcpy(entry->data, &cfg, sizeof(cfg));
         entryAttachRaftReq(rr, entry, req);
 
-        int e = raft_recv_entry(rr->raft, entry, &resp);
+        int e = raft_recv_entry(rr->raft, entry, NULL);
         if (e != 0) {
             entryDetachRaftReq(rr, entry);
             replyRaftError(req->ctx, e);
@@ -182,7 +181,6 @@ static int cmdRaftNode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
             .id = (raft_node_id_t) node_id,
         };
 
-        raft_entry_resp_t resp;
         RaftReq *req = RaftReqInit(ctx, RR_CFGCHANGE_REMOVENODE);
 
         raft_entry_req_t *entry = raft_entry_new(sizeof(cfg));
@@ -191,7 +189,7 @@ static int cmdRaftNode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         memcpy(entry->data, &cfg, sizeof(cfg));
         entryAttachRaftReq(rr, entry, req);
 
-        int e = raft_recv_entry(rr->raft, entry, &resp);
+        int e = raft_recv_entry(rr->raft, entry, NULL);
         if (e != 0) {
             entryDetachRaftReq(rr, entry);
             replyRaftError(req->ctx, e);


### PR DESCRIPTION
Response parameter for `raft_recv_entry()` has become optional after https://github.com/RedisLabs/raft/pull/98