### PR TITLE
Delete duplicate error reply on migration

### DIFF
--- a/src/migrate.c
+++ b/src/migrate.c
@@ -205,7 +205,6 @@ static void raftAppendRaftUnlockDeleteEntry(RedisRaftCtx *rr, RaftReq *req)
 
     int e = raft_recv_entry(rr->raft, entry, NULL);
     if (e != 0) {
-        RedisModule_ReplyWithError(req->ctx, "ERR Unable to unlock/delete migrated keys, try again");
         replyRaftError(req->ctx, e);
         entryDetachRaftReq(rr, entry);
         raft_entry_release(entry);


### PR DESCRIPTION
We already reply in the next line according to `raft_recv_entry()` result. 
Duplicate reply breaks the protocol. 