### PR TITLE
Delete leftover callback in RaftLogLoadEntries()

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -445,7 +445,7 @@ RRStatus RaftLogReset(RaftLog *log, raft_index_t index, raft_term_t term)
     return RR_OK;
 }
 
-int RaftLogLoadEntries(RaftLog *log, int (*callback)(void *, raft_entry_t *, raft_index_t), void *callback_arg)
+int RaftLogLoadEntries(RaftLog *log)
 {
     int ret = 0;
 
@@ -492,18 +492,8 @@ int RaftLogLoadEntries(RaftLog *log, int (*callback)(void *, raft_entry_t *, raf
             break;
         }
 
-        int cb_ret = 0;
-        if (callback) {
-            callback(callback_arg, e, log->index);
-        }
-
         freeRawLogEntry(re);
         raft_entry_release(e);
-
-        if (cb_ret < 0) {
-            ret = cb_ret;
-            break;
-        }
     } while (1);
 
     if (ret > 0) {

--- a/src/raft.c
+++ b/src/raft.c
@@ -1356,7 +1356,7 @@ void addUsedNodeId(RedisRaftCtx *rr, raft_node_id_t node_id)
 
 RRStatus loadRaftLog(RedisRaftCtx *rr)
 {
-    int entries = RaftLogLoadEntries(rr->log, NULL, rr);
+    int entries = RaftLogLoadEntries(rr->log);
     if (entries < 0) {
         LOG_WARNING("Failed to read Raft log");
         return RR_ERROR;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -819,7 +819,7 @@ void RaftLogFree(RaftLog *raft_log);
 RaftLog *RaftLogOpen(const char *filename, RedisRaftConfig *config, int flags);
 void RaftLogClose(RaftLog *log);
 RRStatus RaftLogAppend(RaftLog *log, raft_entry_t *entry);
-int RaftLogLoadEntries(RaftLog *log, int (*callback)(void *, raft_entry_t *, raft_index_t), void *callback_arg);
+int RaftLogLoadEntries(RaftLog *log);
 RRStatus RaftLogWriteEntry(RaftLog *log, raft_entry_t *entry);
 RRStatus RaftLogSync(RaftLog *log, bool sync);
 raft_entry_t *RaftLogGet(RaftLog *log, raft_index_t idx);

--- a/tests/unit/test_log.c
+++ b/tests/unit/test_log.c
@@ -122,12 +122,12 @@ static void test_log_load_entries(void **state)
     assert_int_equal(RaftLogLoadEntries(log), 2);
 
     ety = RaftLogGet(log, 1);
-    assert_int_equal(ety->id , 3);
+    assert_int_equal(ety->id, 3);
     assert_memory_equal(ety->data, "value3", strlen("value3"));
     raft_entry_release(ety);
 
     ety = RaftLogGet(log, 2);
-    assert_int_equal(ety->id , 30);
+    assert_int_equal(ety->id, 30);
     assert_memory_equal(ety->data, "value30", strlen("value30"));
     raft_entry_release(ety);
 }


### PR DESCRIPTION
After changes in https://github.com/RedisLabs/redisraft/pull/479,
callback functionality is not required/used in `RaftLogEntries()`.

Previously, we were using the callback to rebuild configuration:
https://github.com/RedisLabs/redisraft/blob/27b03f072bee0a3e8b0746a842593594d1f2af2d/src/raft.c#L1397

With the above libraft changes, we've introduced `raft_restore_log()`
and moved that step into libraft. So, this callback in `RaftLogEntries()`
is not needed anymore.