### PR TITLE
Delete statements with no effect

### DIFF
--- a/src/serialization_utils.c
+++ b/src/serialization_utils.c
@@ -79,8 +79,6 @@ int decodeInteger(const char *ptr, size_t sz, char expect_prefix, size_t *val)
         }
     }
 
-    sz--;
-    ptr++;
     *val = tmp;
 
     return len + 1;


### PR DESCRIPTION
Delete statements with no effect in decodeInteger()