### PR TITLE
Do not print TLS error string if a request fails

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1710,12 +1710,7 @@ static void linkHandleResponse(redisAsyncContext *c, void *r, void *privdata)
     JoinLinkState *state = ConnGetPrivateData(conn);
 
     if (!reply) {
-#ifndef HAVE_TLS
         LOG_WARNING("RAFT.SHARDGROUP GET failed: connection dropped.");
-#else
-        unsigned long e = ERR_peek_last_error();
-        LOG_WARNING("RAFT.SHARDGROUP GET failed: connection dropped: %s", ERR_reason_error_string(e));
-#endif
     } else if (reply->type == REDIS_REPLY_ERROR) {
         /* -MOVED? */
         if (strlen(reply->str) > 6 && !strncmp(reply->str, "MOVED ", 6)) {

--- a/src/join.c
+++ b/src/join.c
@@ -32,12 +32,7 @@ static void handleNodeAddResponse(redisAsyncContext *c, void *r, void *privdata)
     redisReply *reply = r;
 
     if (!reply) {
-#ifndef HAVE_TLS
         LOG_WARNING("RAFT.NODE ADD failed: connection dropped.");
-#else
-        unsigned long e = ERR_peek_last_error();
-        LOG_WARNING("RAFT.NODE ADD failed: connection dropped: %s", ERR_reason_error_string(e));
-#endif
         ConnMarkDisconnected(conn);
     } else if (reply->type == REDIS_REPLY_ERROR) {
         /* -MOVED? */


### PR DESCRIPTION
We should handle TLS connections similar to TCP. If a TCP connection
gets disconnected, we don't try to print details. It should be the same
for TLS connections. Otherwise, the error string might be misleading 
or wrong (if another OpenSSL function is called inside Hiredis just 
before we fetch the error). Also, it'll make the code harder to read if
we do that consistently for each request handling. 

The only moment we want to print TLS specific error message is when we 
fail to connect. We already print the error string from OpenSSL 
(hiredis gives it to us) if there is an error while initiating the 
connection.