### PR TITLE
Delete unnecessary replyRMCallError() function

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -64,28 +64,6 @@ void replyRaftError(RedisModuleCtx *ctx, int error)
     }
 }
 
-/* Try to produce an error message which is similar to Redis */
-void replyRMCallError(RedisModuleCtx *ctx, int err, const char *cmd, size_t len)
-{
-    char buf[1024];
-    const char *msg;
-
-    switch (err) {
-        case ENOENT:
-            msg = "ERR unknown command `%.*s`";
-            break;
-        case EINVAL:
-            msg = "ERR wrong number of arguments for '%.*s' command";
-            break;
-        default:
-            msg = "ERR failed to execute command '%.*s'";
-            break;
-    }
-
-    snprintf(buf, sizeof(buf), msg, (int) len, cmd);
-    RedisModule_ReplyWithError(ctx, buf);
-}
-
 /* Create a -MOVED reply. */
 void replyRedirect(RedisModuleCtx *ctx, unsigned int slot, NodeAddr *addr)
 {

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -753,7 +753,6 @@ void raftNodeToString(char *output, const char *dbid, raft_node_t *raft_node);
 void raftNodeIdToString(char *output, const char *dbid, raft_node_id_t raft_id);
 /* common.c - common reply function */
 void replyRaftError(RedisModuleCtx *ctx, int error);
-void replyRMCallError(RedisModuleCtx *ctx, int err, const char *cmd, size_t len);
 void replyRedirect(RedisModuleCtx *ctx, unsigned int slot, NodeAddr *addr);
 void replyAsk(RedisModuleCtx *ctx, unsigned int slot, NodeAddr *addr);
 void replyCrossSlot(RedisModuleCtx *ctx);

--- a/src/sort.c
+++ b/src/sort.c
@@ -130,26 +130,22 @@ void handleSort(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     enterRedisModuleCall();
     int entered_eval = redis_raft.entered_eval;
     redis_raft.entered_eval = 0;
-    RedisModuleCallReply *reply = RedisModule_Call(redis_raft.ctx, cmd_str, "3v", &argv[1], argc - 1);
+    RedisModuleCallReply *reply = RedisModule_Call(redis_raft.ctx, cmd_str, "3vE", &argv[1], argc - 1);
     exitRedisModuleCall();
     redis_raft.entered_eval = entered_eval;
 
-    if (!reply) {
-        replyRMCallError(ctx, errno, cmd_str, cmd_len);
-    } else {
-        int reply_type = RedisModule_CallReplyType(reply);
-        switch (reply_type) {
-            case REDISMODULE_REPLY_ARRAY:
-            case REDISMODULE_REPLY_SET:
-                replySortedArray(ctx, reply);
-                break;
-            case REDISMODULE_REPLY_MAP:
-                replySortedMap(ctx, reply);
-                break;
-            default:
-                RedisModule_ReplyWithCallReply(ctx, reply);
-        }
-
-        RedisModule_FreeCallReply(reply);
+    int reply_type = RedisModule_CallReplyType(reply);
+    switch (reply_type) {
+        case REDISMODULE_REPLY_ARRAY:
+        case REDISMODULE_REPLY_SET:
+            replySortedArray(ctx, reply);
+            break;
+        case REDISMODULE_REPLY_MAP:
+            replySortedMap(ctx, reply);
+            break;
+        default:
+            RedisModule_ReplyWithCallReply(ctx, reply);
     }
+
+    RedisModule_FreeCallReply(reply);
 }


### PR DESCRIPTION
When we pass `E` to `RM_Call()`, it will return the error as reply. 
Then, we don't need to check for NULL reply and generate error
string from `errno`. 

Added `E` to last `RM_Call()` usage without that flag and deleted 
replyRMCallError() function. 