### PR TITLE
[RR-94] Use Posix IO functions for the index file

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -594,7 +594,7 @@ static off_t seekEntry(RaftLog *log, raft_index_t idx)
 
     off_t offset;
 
-    char *data = (char*) &offset;
+    char *data = (char *) &offset;
     size_t len = sizeof(offset);
     off_t pos = (off_t) (sizeof(off_t) * relidx);
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -650,8 +650,7 @@ typedef struct RaftLog {
     size_t file_size;               /* File size at the time of last write */
     const char *filename;           /* Log file name */
     FILE *file;                     /* Log file */
-    FILE *idxfile;                  /* Index file */
-    off_t idxoffset;                /* Index file position */
+    int idxfile;                    /* Index file */
     raft_index_t fsync_index;       /* Last entry index included in the latest fsync() call */
     uint64_t fsync_count;           /* Count of fsync() calls */
     uint64_t fsync_max;             /* Slowest fsync() call in microseconds */

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -650,7 +650,7 @@ typedef struct RaftLog {
     size_t file_size;               /* File size at the time of last write */
     const char *filename;           /* Log file name */
     FILE *file;                     /* Log file */
-    int idxfile;                    /* Index file */
+    int idxfile;                    /* Index file descriptor */
     raft_index_t fsync_index;       /* Last entry index included in the latest fsync() call */
     uint64_t fsync_count;           /* Count of fsync() calls */
     uint64_t fsync_max;             /* Slowest fsync() call in microseconds */


### PR DESCRIPTION
Use Posix IO functions for the index file.

- Primary motivation is to avoid FILE API problems like 
https://github.com/RedisLabs/redisraft/pull/236.

- Also, we can get rid of performance workarounds that we introduced
in https://github.com/RedisLabs/redisraft/pull/208. 

   `pread()` and `pwrite()` allow us to write to the position we want.
So, we can avoid expensive `fseek()` / `lseek()` calls without tracking
file offset manually in the application. (See deleted `idxoffset` variable). 

TODO:
- Proper error check. e.g `close()` return value check.
  We can do this later with the other files as the last thing. 