### PR TITLE
Use SEEK_SET to set position of the snapshot file

### DIFF
--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -139,7 +139,7 @@ int raftStoreSnapshotChunk(raft_server_t *raft, void *user_data,
         return -1;
     }
 
-    off_t ret_offset = lseek(fd, offset, SEEK_CUR);
+    off_t ret_offset = lseek(fd, (off_t) offset, SEEK_SET);
     if (ret_offset != (off_t) offset) {
         LOG_WARNING("lseek file:%s, error:%s \n", rr->incoming_snapshot_file,
                     strerror(errno));


### PR DESCRIPTION
Use `SEEK_SET` to set file position while storing snapshot chunks.

In `raftStoreSnapshotChunk()`, `offset` indicates position relative 
to the head of the file. 

Currently, we use `SEEK_CUR` which sets the position relative to the
current position. As we reopen file each time, current position is zero
and it works correctly but better to use `SEEK_SET` which sets position
relative to the head of the file. (Just to prevent future bugs). 