### PR TITLE
Build Redis with -rdynamic for MacOS daily build

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -137,7 +137,7 @@ jobs:
           ref: 'unstable'
           path: 'redis'
       - name: Build Redis
-        run: cd redis && make -j 4
+        run: cd redis && make -j 4 REDIS_LDFLAGS=-rdynamic
       - name: Setup Python for testing
         uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
RedisRaft calls `rdbLoad()` and `rdbSave()` functions from Redis. 
These functions are not part of the module API. Redis is built with
`-flto` flag after a recent change. This flag strips symbols of these
functions from the global symbol table. On Linux, Redis is built 
with `-rdynamic` linker flag(defined inside Redis' makefile) which 
prevents this issue but on other OSes, RedisRaft module load fails
(may fail) as there are unsatisfied links.

Added `-rdynamic` to Redis build flags for MacOS daily to fix the issue 
temporarily. This flag will prevent compiler to strip function names from 
the symbol table. 

Proper fix would be adding a proper module API for these functions.
After this change, we can remove this flag. 