### PR TITLE
Deleted leftover debug variable

### DIFF
--- a/src/sort.c
+++ b/src/sort.c
@@ -102,10 +102,9 @@ static void replySortedMap(RedisModuleCtx *ctx, RedisModuleCallReply *reply)
     char *key;
     size_t key_len;
     void *value;
-    size_t count = 0;
+
     RedisModuleDictIter *iter = RedisModule_DictIteratorStartC(dict, "^", NULL, 0);
     while ((key = RedisModule_DictNextC(iter, &key_len, &value)) != NULL) {
-        count++;
         RedisModule_ReplyWithStringBuffer(ctx, key, key_len);
         RedisModule_ReplyWithCallReply(ctx, value);
     }


### PR DESCRIPTION
It was introduced here: https://github.com/RedisLabs/redisraft/pull/298
Issue was fixed here: https://github.com/RedisLabs/redisraft/pull/351

