### PR TITLE
[RR-94] Use POSIX IO functions for the log file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ add_library(redisraft MODULE
         src/config.c
         src/connection.c
         src/entrycache.c
+        src/file.c
         src/fsync.c
         src/join.c
         src/log.c
@@ -235,6 +236,7 @@ add_executable(main
         src/config.c
         src/connection.c
         src/entrycache.c
+        src/file.c
         src/fsync.c
         src/join.c
         src/log.c
@@ -253,6 +255,7 @@ add_executable(main
         src/threadpool.c
         src/util.c
         tests/unit/main.c
+        tests/unit/test_file.c
         tests/unit/test_log.c
         tests/unit/test_serialization.c
         tests/unit/test_util.c)

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -6,6 +6,7 @@
  * RedisRaft is licensed under the Redis Source Available License (RSAL).
  */
 
+#include "log.h"
 #include "redisraft.h"
 
 #include <stdlib.h>

--- a/src/file.c
+++ b/src/file.c
@@ -1,0 +1,291 @@
+#include "file.h"
+
+#include "redisraft.h"
+
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+void FileInit(File *file)
+{
+    *file = (File){
+        .fd = -1,
+        .wpos = file->buf,
+    };
+}
+
+int FileTerm(File *file)
+{
+    int rc;
+
+    if (file->fd == -1) {
+        return RR_OK;
+    }
+
+    rc = FileFlush(file);
+
+    if (close(file->fd) != 0) {
+        return RR_ERROR;
+    }
+    file->fd = -1;
+
+    return rc;
+}
+
+int FileOpen(File *file, const char *filename, int flags)
+{
+    int fd;
+    struct stat st;
+
+    /* Currently, only O_APPEND mode is supported. */
+    RedisModule_Assert(flags & O_APPEND);
+
+    fd = open(filename, flags, S_IWUSR | S_IRUSR);
+    if (fd < 0) {
+        return RR_ERROR;
+    }
+
+    if (stat(filename, &st) != 0) {
+        close(fd);
+        return RR_ERROR;
+    }
+
+    file->woffset = st.st_size;
+    file->fd = fd;
+
+    return RR_OK;
+}
+
+/* Flush buffer to the file. */
+int FileFlush(File *file)
+{
+    char *wbegin = file->buf;
+
+    if (file->wpos == file->buf) {
+        return RR_OK;
+    }
+
+    while (true) {
+        size_t count = file->wpos - wbegin;
+        if (count == 0) {
+            break;
+        }
+
+        ssize_t wr = write(file->fd, wbegin, count);
+        if (wr < 0) {
+            return RR_ERROR;
+        }
+
+        wbegin += wr;
+    }
+
+    /* Clear read and write buffers */
+    file->wpos = file->buf;
+    file->rpos = file->rend = NULL;
+
+    return RR_OK;
+}
+
+int FileFsync(File *file)
+{
+    return fsync(file->fd) == 0 ? RR_OK : RR_ERROR;
+}
+
+/* Set read position of the file. Required before read functions. */
+int FileSetReadOffset(File *file, size_t offset)
+{
+    if (FileFlush(file) != RR_OK) {
+        return RR_ERROR;
+    }
+
+    /* Dismiss buffers. */
+    file->wpos = file->buf;
+    file->rpos = file->rend = NULL;
+
+    off_t ret = lseek(file->fd, (off_t) offset, SEEK_SET);
+    if (ret != (off_t) offset) {
+        return RR_ERROR;
+    }
+
+    file->roffset = offset;
+
+    return RR_OK;
+}
+
+/* Similar to fgets(), reads a line into `buf`, at most `cap` bytes.
+ * Returns the number of bytes read, -1 on error. */
+ssize_t FileGets(File *file, void *buf, size_t cap)
+{
+    size_t remaining = cap;
+    char *dest = buf;
+
+    /* Flush data first if we are switching from write-mode to read-mode. */
+    if (FileFlush(file) != RR_OK) {
+        return -1;
+    }
+
+    while (true) {
+        ssize_t count = file->rend - file->rpos;
+        if (count != 0) {
+            /* Exhaust the buffer first */
+            char *pos = memchr(file->rpos, '\n', count);
+            size_t len = pos ? pos - file->rpos + 1 : count;
+            if (len > remaining) {
+                return -1;
+            }
+
+            memcpy(dest, file->rpos, len);
+            file->rpos += len;
+            file->roffset += len;
+            dest += len;
+            remaining -= len;
+
+            if (pos) {
+                return (ssize_t) (cap - remaining);
+            }
+        }
+
+        ssize_t bytes = read(file->fd, file->buf, sizeof(file->buf));
+        if (bytes <= 0) {
+            return -1;
+        }
+
+        file->rpos = file->buf;
+        file->rend = file->buf + bytes;
+    }
+}
+
+/* Similar to fread(), reads data into `buf`, at most `cap` bytes.
+ * Returns the number of bytes read, -1 on error. */
+ssize_t FileRead(File *file, void *buf, size_t cap)
+{
+    size_t remaining = (ssize_t) cap;
+    char *dest = buf;
+
+    /* Flush data first if we are switching from write-mode to read-mode. */
+    if (FileFlush(file) != RR_OK) {
+        return -1;
+    }
+
+    size_t count = file->rend - file->rpos;
+    if (count) {
+        /* Exhaust the file buffer first. */
+        count = MIN(count, remaining);
+        memcpy(dest, file->rpos, count);
+        remaining -= count;
+        dest += count;
+        file->rpos += count;
+        file->roffset += count;
+    }
+
+    if (remaining == 0) {
+        return (ssize_t) cap;
+    }
+
+    /* Try to fill user buffer and file buffer in a single readv() call. */
+    while (true) {
+        struct iovec iov[2] = {
+            {.iov_base = dest,      .iov_len = remaining        },
+            {.iov_base = file->buf, .iov_len = sizeof(file->buf)},
+        };
+
+        ssize_t rd = readv(file->fd, iov, 2);
+        if (rd < 0) {
+            return -1;
+        } else if (rd == 0) {
+            return (ssize_t) (cap - remaining);
+        }
+
+        if (rd >= (ssize_t) iov[0].iov_len) {
+            file->roffset += iov[0].iov_len;
+            file->rpos = file->buf;
+            file->rend = file->buf + (rd - iov[0].iov_len);
+
+            return (ssize_t) cap;
+        }
+
+        remaining -= rd;
+        dest += count;
+        file->roffset += rd;
+    }
+}
+
+/* Similar to fwrite(), write data from `buf` into the file.
+ * Return the number of written bytes, -1 on error. */
+ssize_t FileWrite(File *file, void *buf, size_t len)
+{
+    /* Clear read buffer positions as we are in write mode now. */
+    file->rpos = file->rend = NULL;
+
+    size_t cap = file->buf + sizeof(file->buf) - file->wpos;
+    if (cap >= len) {
+        /* Data can fit into the file buffer. */
+        memcpy(file->wpos, buf, len);
+        file->wpos += len;
+        file->woffset += len;
+
+        return (ssize_t) len;
+    }
+
+    /* We have some data in the file buffer and need to write it first before
+     * the user buffer. We'll write both buffers with a single writev() call.
+     * We'll loop until all data is written in case of a partial write. */
+    struct iovec iovs[2] = {
+        {.iov_base = file->buf, .iov_len = file->wpos - file->buf},
+        {.iov_base = buf,       .iov_len = len                   }
+    };
+
+    struct iovec *iov = iovs;
+    size_t rem = iov[0].iov_len + iov[1].iov_len;
+    int iovcnt = 2;
+    ssize_t count;
+
+    while (true) {
+        count = writev(file->fd, iov, iovcnt);
+        if (count < 0) {
+            return -1;
+        }
+
+        if ((size_t) count == rem) {
+            file->wpos = file->buf;
+            file->woffset += len;
+            return (ssize_t) len;
+        }
+
+        rem -= count;
+        if ((size_t) count > iov[0].iov_len) {
+            count -= (ssize_t) iov[0].iov_len;
+            iov++;
+            iovcnt--;
+        }
+
+        iov[0].iov_base = (char *) iov[0].iov_base + count;
+        iov[0].iov_len -= count;
+    }
+}
+
+size_t FileSize(File *file)
+{
+    return file->woffset;
+}
+
+size_t FileGetReadOffset(File *file)
+{
+    return file->roffset;
+}
+
+int FileTruncate(File *file, size_t len)
+{
+    if (FileFlush(file) != RR_OK ||
+        ftruncate(file->fd, (off_t) len) != 0) {
+        return RR_ERROR;
+    }
+
+    file->woffset = len;
+    file->roffset = 0;
+    file->rpos = file->rend = NULL;
+
+    return RR_OK;
+}

--- a/src/file.c
+++ b/src/file.c
@@ -75,6 +75,7 @@ int FileFlush(File *file)
 
         ssize_t wr = write(file->fd, wbegin, count);
         if (wr < 0) {
+            LOG_WARNING("error, fd:%d, write:%s", file->fd, strerror(errno));
             return RR_ERROR;
         }
 
@@ -90,7 +91,11 @@ int FileFlush(File *file)
 
 int FileFsync(File *file)
 {
-    return fsync(file->fd) == 0 ? RR_OK : RR_ERROR;
+    int rc = fsync(file->fd);
+    if (rc != 0) {
+        LOG_WARNING("error fd:%d, fsync:%s", file->fd, strerror(errno));
+    }
+    return rc == 0 ? RR_OK : RR_ERROR;
 }
 
 /* Set read position of the file. Required before read functions. */

--- a/src/file.h
+++ b/src/file.h
@@ -1,0 +1,48 @@
+#ifndef REDISRAFT_FILE_H
+#define REDISRAFT_FILE_H
+
+#include <stdlib.h>
+#include <sys/types.h>
+
+/* File implementation with a userspace buffer.
+ *
+ * Main differences over the standard library FILE implementation:
+ *
+ * * Works with O_APPEND mode only. It is a deliberate decision to keep the
+ *   implementation simple.
+ * * The standard library FILE API requires extra care when you want to use it
+ *   together with POSIX IO functions, e.g., need fflush() before ftruncate().
+ *   This implementation tries to do these things automatically.
+ * * Tracks read/write offset internally. Getting read/write offset is fast
+ *   as it doesn't make a system call for them.
+ * * This implementation is not thread-safe while the standard library
+ *   implementation is.
+ */
+
+typedef struct File {
+    int fd;         /* File descriptor */
+    char *rpos;     /* In read mode, current read position of the buffer. */
+    char *rend;     /* In read mode, end position of the buffer. */
+    size_t roffset; /* Read offset relative to the head of the file. */
+    char *wpos;     /* In write mode, current write position of the buffer. */
+    size_t woffset; /* Write offset relative to the head of the file. */
+    char buf[4096]; /* Userspace buffer. */
+} File;
+
+void FileInit(File *file);
+int FileTerm(File *file);
+
+int FileOpen(File *file, const char *filename, int flags);
+int FileFlush(File *file);
+int FileFsync(File *file);
+
+int FileSetReadOffset(File *file, size_t offset);
+size_t FileGetReadOffset(File *file);
+
+ssize_t FileGets(File *file, void *buf, size_t cap);
+ssize_t FileRead(File *file, void *buf, size_t cap);
+ssize_t FileWrite(File *file, void *buf, size_t len);
+size_t FileSize(File *file);
+int FileTruncate(File *file, size_t len);
+
+#endif

--- a/src/log.h
+++ b/src/log.h
@@ -1,0 +1,55 @@
+#ifndef REDISRAFT_LOG_H
+#define REDISRAFT_LOG_H
+
+#include "file.h"
+#include "raft.h"
+#include "redisraft.h"
+
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+extern raft_log_impl_t LogImpl;
+
+typedef struct Log {
+    uint32_t version;               /* Log file format version */
+    char dbid[RAFT_DBID_LEN + 1];   /* DB unique ID */
+    raft_node_id_t node_id;         /* Node ID */
+    raft_term_t snapshot_last_term; /* Last term included in snapshot */
+    raft_index_t snapshot_last_idx; /* Last index included in snapshot */
+    raft_index_t num_entries;       /* Entries in log */
+    raft_index_t index;             /* Index of last entry */
+    char filename[PATH_MAX];        /* Log file name */
+    char idxfilename[PATH_MAX];     /* Index file name */
+    File file;                      /* Log file */
+    File idxfile;                   /* Index file descriptor */
+    raft_index_t fsync_index;       /* Last entry index included in the latest fsync() call */
+    uint64_t fsync_count;           /* Count of fsync() calls */
+    uint64_t fsync_max;             /* Slowest fsync() call in microseconds */
+    uint64_t fsync_total;           /* Total time fsync() calls consumed in microseconds */
+} Log;
+
+Log *LogCreate(const char *filename, const char *dbid,
+               raft_term_t snapshot_term, raft_index_t snapshot_index,
+               raft_node_id_t node_id);
+void LogFree(Log *raft_log);
+Log *LogOpen(const char *filename, bool keep_index);
+int LogAppend(Log *log, raft_entry_t *entry);
+int LogLoadEntries(Log *log);
+int LogSync(Log *log, bool sync);
+raft_entry_t *LogGet(Log *log, raft_index_t idx);
+int LogDelete(Log *log, raft_index_t from_idx);
+int LogReset(Log *log, raft_index_t index, raft_term_t term);
+raft_index_t LogCount(Log *log);
+raft_index_t LogFirstIdx(Log *log);
+raft_index_t LogCurrentIdx(Log *log);
+size_t LogFileSize(Log *log);
+void LogArchiveFiles(Log *log);
+
+long long int LogRewrite(RedisRaftCtx *rr, const char *filename,
+                         raft_index_t last_idx, raft_term_t last_term);
+int LogRewriteSwitch(RedisRaftCtx *rr, Log *new_log,
+                     raft_index_t new_log_entries);
+
+#endif

--- a/src/util.c
+++ b/src/util.c
@@ -6,6 +6,7 @@
  * RedisRaft is licensed under the Redis Source Available License (RSAL).
  */
 
+#include "log.h"
 #include "redisraft.h"
 
 #include "common/crc16.h"

--- a/tests/unit/main.c
+++ b/tests/unit/main.c
@@ -14,6 +14,7 @@
 
 #include "cmocka.h"
 
+extern struct CMUnitTest file_tests[];
 extern struct CMUnitTest log_tests[];
 extern struct CMUnitTest util_tests[];
 extern struct CMUnitTest serialization_tests[];
@@ -62,6 +63,8 @@ int main(int argc, char *argv[])
                             __raft_realloc_stub, __raft_free_stub);
 
     return _cmocka_run_group_tests(
+               "file", file_tests, tests_count(file_tests), NULL, NULL) ||
+           _cmocka_run_group_tests(
                "log", log_tests, tests_count(log_tests), NULL, NULL) ||
            _cmocka_run_group_tests(
                "util", util_tests, tests_count(util_tests), NULL, NULL) ||

--- a/tests/unit/test_file.c
+++ b/tests/unit/test_file.c
@@ -1,0 +1,243 @@
+/*
+* This file is part of RedisRaft.
+*
+* Copyright (c) 2020-2021 Redis Ltd.
+*
+* RedisRaft is licensed under the Redis Source Available License (RSAL).
+*/
+
+#include "../src/redisraft.h"
+
+#include <fcntl.h>
+#include <stddef.h>
+
+#include "cmocka.h"
+
+#define FILENAME "test.file"
+
+static void test_file_write_pos(void **state)
+{
+    int rc;
+    ssize_t wr, rd;
+    char tmp[8192] = {50};
+    char *str = "test";
+    File file;
+
+    unlink(FILENAME);
+
+    FileInit(&file);
+
+    rc = FileOpen(&file, FILENAME, O_CREAT | O_RDWR | O_APPEND);
+    assert_int_equal(rc, RR_OK);
+    assert_int_equal(FileSize(&file), 0);
+    assert_int_equal(FileTruncate(&file, -1), RR_ERROR);
+
+    /* Test short write */
+    wr = FileWrite(&file, str, strlen(str));
+    assert_int_equal(wr, strlen(str));
+    assert_int_equal(FileSize(&file), strlen(str));
+
+    rc = FileTerm(&file);
+    assert_int_equal(rc, RR_OK);
+
+    rc = FileOpen(&file, FILENAME, O_RDWR | O_APPEND);
+    assert_int_equal(rc, RR_OK);
+    assert_int_equal(FileSize(&file), strlen(str));
+
+    /* Test large write */
+    wr = FileWrite(&file, tmp, sizeof(tmp));
+    assert_int_equal(wr, sizeof(tmp));
+    assert_int_equal(FileSize(&file), sizeof(tmp) + strlen(str));
+
+    rc = FileTerm(&file);
+    assert_int_equal(rc, RR_OK);
+
+    rc = FileOpen(&file, FILENAME, O_RDWR | O_APPEND);
+    assert_int_equal(rc, RR_OK);
+    assert_int_equal(FileSize(&file), sizeof(tmp) + strlen(str));
+
+    rd = FileRead(&file, tmp, sizeof(tmp));
+    assert_int_equal(rd, sizeof(tmp));
+    assert_int_equal(FileGetReadOffset(&file), sizeof(tmp));
+    assert_int_equal(FileSize(&file), sizeof(tmp) + strlen(str));
+
+    rc = FileTerm(&file);
+    assert_int_equal(rc, RR_OK);
+}
+
+static void test_file_read_pos(void **state)
+{
+    int rc;
+    char tmp[8192] = {50};
+    File file;
+
+    unlink(FILENAME);
+
+    FileInit(&file);
+
+    rc = FileOpen(&file, FILENAME, O_CREAT | O_RDWR | O_APPEND);
+    assert_int_equal(rc, RR_OK);
+    assert_int_equal(FileGetReadOffset(&file), 0);
+    assert_int_equal(FileRead(&file, tmp, sizeof(tmp)), 0);
+
+    FileWrite(&file, tmp, sizeof(tmp));
+
+    /* Test reads less than page size (4096). */
+    FileSetReadOffset(&file, 0);
+    assert_int_equal(FileRead(&file, tmp, 100), 100);
+    assert_int_equal(FileGetReadOffset(&file), 100);
+
+    /* Test reads larger than page size (4096). */
+    FileSetReadOffset(&file, 0);
+    assert_int_equal(FileRead(&file, tmp, 8000), 8000);
+    assert_int_equal(FileGetReadOffset(&file), 8000);
+
+    /* Test reads less than buffer size */
+    FileTruncate(&file, 100);
+    FileSetReadOffset(&file, 0);
+    assert_int_equal(FileRead(&file, tmp, 8000), 100);
+    assert_int_equal(FileGetReadOffset(&file), 100);
+
+    FileTerm(&file);
+}
+
+static void test_file_fgets(void **state)
+{
+    int rc;
+    char tmp[8192] = {50};
+    File file;
+
+    unlink(FILENAME);
+
+    FileInit(&file);
+
+    rc = FileOpen(&file, FILENAME, O_CREAT | O_RDWR | O_APPEND);
+    assert_int_equal(rc, RR_OK);
+    assert_int_equal(FileGets(&file, tmp, sizeof(tmp)), -1);
+
+    FileWrite(&file, tmp, sizeof(tmp));
+    FileSetReadOffset(&file, 0);
+    assert_int_equal(FileGets(&file, tmp, 100), -1);
+
+    /* Test reads less than page size (4096)
+     * Line length will be 4001. */
+    FileTruncate(&file, 4000);
+    FileWrite(&file, "\n", 1);
+    FileSetReadOffset(&file, 0);
+
+    memset(tmp, 0, sizeof(tmp));
+    assert_int_equal(FileGets(&file, tmp, 4000), -1);
+
+    memset(tmp, 0, sizeof(tmp));
+    assert_int_equal(FileGets(&file, tmp, 4001), 4001);
+
+    memset(tmp, 0, sizeof(tmp));
+    FileTruncate(&file, 0);
+
+    /* Test reads larger than page size (4096)
+     * Line length will be 5001. */
+    FileWrite(&file, tmp, 5000);
+    FileWrite(&file, "\n", 1);
+
+    FileSetReadOffset(&file, 0);
+    assert_int_equal(FileGets(&file, tmp, 5000), -1);
+
+    FileSetReadOffset(&file, 0);
+    assert_int_equal(FileGets(&file, tmp, 5001), 5001);
+
+    FileTerm(&file);
+}
+
+static void test_file_persistence(void **state)
+{
+    char read[720], orig[720];
+    File file;
+
+    unlink(FILENAME);
+
+    for (int i = 0; i < sizeof(orig); i++) {
+        orig[i] = rand() & 255;
+    }
+
+    /* Write some random bytes to the file in a loop */
+    FileInit(&file);
+    FileOpen(&file, FILENAME, O_CREAT | O_RDWR | O_APPEND);
+
+    for (int i = 0; i < 34; i++) {
+        FileWrite(&file, orig, sizeof(orig));
+    }
+    FileTerm(&file);
+
+    /* Read bytes in a loop and verify correctness */
+    FileOpen(&file, FILENAME, O_RDWR | O_APPEND);
+    FileSetReadOffset(&file, 0);
+
+    for (int i = 0; i < 17; i++) {
+        ssize_t ret;
+        size_t half = sizeof(read) / 2;
+
+        ret = FileRead(&file, read, half);
+        assert_int_equal(ret, half);
+        assert_memory_equal(orig, read, half);
+
+        ret = FileRead(&file, read, half);
+        assert_int_equal(ret, half);
+        assert_memory_equal(&orig[half], read, half);
+    }
+
+    FileTerm(&file);
+}
+
+static void test_file_boundaries(void **state)
+{
+    char read[720], orig[720];
+    ssize_t ret;
+    File file;
+
+    unlink(FILENAME);
+
+    for (int i = 0; i < sizeof(orig); i++) {
+        orig[i] = rand() & 255;
+    }
+
+    FileInit(&file);
+    FileOpen(&file, FILENAME, O_CREAT | O_RDWR | O_APPEND);
+
+    /* Test write with buffer len zero */
+    ret = FileWrite(&file, orig, 0);
+    assert_int_equal(ret, 0);
+    assert_int_equal(FileSize(&file), 0);
+
+    /* Test read with buffer len zero */
+    FileSetReadOffset(&file, 0);
+    ret = FileRead(&file, read, 0);
+    assert_int_equal(ret, 0);
+    assert_int_equal(FileGetReadOffset(&file), 0);
+
+    /* Test read with buffer len zero after write*/
+    FileWrite(&file, orig, sizeof(orig));
+    FileSetReadOffset(&file, 0);
+    ret = FileRead(&file, read, 0);
+    assert_int_equal(ret, 0);
+    assert_int_equal(FileGetReadOffset(&file), 0);
+
+    /* Fill the internal file buffer */
+    ret = FileRead(&file, read, 1);
+    assert_int_equal(ret, 1);
+
+    /* Read the remaining bytes */
+    ret = FileRead(&file, &read[1], sizeof(read));
+    assert_int_equal(ret, sizeof(read) - 1);
+
+    assert_memory_equal(read, orig, sizeof(orig));
+    FileTerm(&file);
+}
+
+const struct CMUnitTest file_tests[] = {
+    cmocka_unit_test(test_file_write_pos),
+    cmocka_unit_test(test_file_read_pos),
+    cmocka_unit_test(test_file_fgets),
+    cmocka_unit_test(test_file_persistence),
+    cmocka_unit_test(test_file_boundaries),
+    {.test_func = NULL},
+};


### PR DESCRIPTION
Added new `File` implementation to have more control on IO operations.

New `File` implementation uses POSIX IO functions and provides its 
own userspace buffer. Control over IO operations and system calls 
will enable us to reason about crash-safety easily. 

Also, new implementation will allow us to avoid 
  - Correctness issues like: https://github.com/RedisLabs/redisraft/pull/236
  - Performance issues like: https://github.com/RedisLabs/redisraft/pull/208

As part of this PR:
- Implemented log file and index file with the new File implementation. 
- Refactored log file implementation. 

TODO:
- Proper error check. It's missing in certain cases. We can do it in 
  a follow-up PR. (Most probably, after implementing multi-file log)
- Proper debug logging. Ignoring for now, we can do this as the last thing.
- Delete rewrite related functions. (After implementing multi-file log).
