### PR TITLE
[RR-116] Do not load snapshot inside the command callback

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -1200,6 +1200,11 @@ RRStatus loadRaftLog(RedisRaftCtx *rr);
 
 static void handleLoadingState(RedisRaftCtx *rr)
 {
+    if (rr->snapshot_load.pending) {
+        loadPendingSnapshot(rr);
+        return;
+    }
+
     if (!checkRedisLoading(rr)) {
         /* If Redis loaded a snapshot (RDB), log some information and configure the
          * raft library as necessary.

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1032,15 +1032,9 @@ static int cmdRaftSnapshot(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
 
     rr->snapshotreq_received++;
 
-    /* raft_recv_snapshot() might trigger loading the received RDB file.
-     * While loading, Redis may process incoming messages to reply -LOADING.
-     * So, we must block the leader's connection to prevent processing further
-     * messages, as we haven't replied to the current command yet. */
-    RedisModuleBlockedClient *c = RedisModule_BlockClient(ctx, NULL, 0, 0, 0);
-
     if (raft_recv_snapshot(rr->raft, node, &req, &resp) != 0) {
         RedisModule_ReplyWithError(ctx, "ERR operation failed");
-        goto out;
+        return REDISMODULE_OK;
     }
 
     RedisModule_ReplyWithArray(ctx, 5);
@@ -1050,8 +1044,6 @@ static int cmdRaftSnapshot(RedisModuleCtx *ctx, RedisModuleString **argv, int ar
     RedisModule_ReplyWithLongLong(ctx, resp.success);
     RedisModule_ReplyWithLongLong(ctx, resp.last_chunk);
 
-out:
-    RedisModule_UnblockClient(c, NULL);
     return REDISMODULE_OK;
 }
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -359,6 +359,12 @@ typedef struct RedisRaftConfig {
 
 } RedisRaftConfig;
 
+typedef struct SnapshotLoad {
+    bool pending;
+    raft_term_t term;
+    raft_index_t index;
+} SnapshotLoad;
+
 /* Global Raft context */
 typedef struct RedisRaftCtx {
     void *raft;                    /* Raft library context */
@@ -376,6 +382,7 @@ typedef struct RedisRaftCtx {
                                                     belong to the same snapshot */
     char incoming_snapshot_file[256];    /* File name for incoming snapshots. When received fully,
                                                     it will be renamed to the original rdb file */
+    SnapshotLoad snapshot_load;          /* Indicates we've received a snapshot waiting to be loaded */
     bool snapshot_in_progress;           /* Indicates we're creating a snapshot in the background */
     mstime_t curr_snapshot_start_time;   /* start time of the snapshot operation currently in progress */
     raft_index_t curr_snapshot_last_idx; /* Last included idx of the snapshot operation currently in progress */
@@ -850,6 +857,7 @@ void createOutgoingSnapshotMmap(RedisRaftCtx *ctx);
 RRStatus initiateSnapshot(RedisRaftCtx *rr);
 RRStatus finalizeSnapshot(RedisRaftCtx *rr, SnapshotResult *sr);
 void cancelSnapshot(RedisRaftCtx *rr, SnapshotResult *sr);
+void loadPendingSnapshot(RedisRaftCtx *rr);
 int pollSnapshotStatus(RedisRaftCtx *rr, SnapshotResult *sr);
 void configRaftFromSnapshotInfo(RedisRaftCtx *rr);
 int raftLoadSnapshot(raft_server_t *raft, void *udata, raft_term_t term, raft_index_t idx);

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -565,10 +565,10 @@ void loadPendingSnapshot(RedisRaftCtx *rr)
     rr->snapshots_received++;
     rr->state = REDIS_RAFT_UP;
 
-    rr->snapshot_load = (SnapshotLoad) {
+    rr->snapshot_load = (SnapshotLoad){
         .pending = false,
         .term = -1,
-        .index = -1
+        .index = -1,
     };
 }
 
@@ -614,7 +614,7 @@ int raftLoadSnapshot(raft_server_t *raft, void *user_data, raft_term_t term, raf
      * inside this command callback. It will be loaded inside the timer
      * callback. */
     rr->state = REDIS_RAFT_LOADING;
-    rr->snapshot_load = (SnapshotLoad) {
+    rr->snapshot_load = (SnapshotLoad){
         .pending = true,
         .term = term,
         .index = index,

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -535,6 +535,8 @@ void loadPendingSnapshot(void *user_data)
     RedisRaftCtx *rr = &redis_raft;
     SnapshotLoad *sl = user_data;
 
+    RedisModule_Assert(rr->state == REDIS_RAFT_LOADING);
+
     LOG_DEBUG("Beginning snapshot load, term=%lu, index=%lu",
               sl->term, sl->index);
 

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -578,6 +578,8 @@ void loadPendingSnapshot(RedisRaftCtx *rr)
     };
 }
 
+/* After a snapshot is received, replace it with the existing snapshot file
+ * and trigger the load operation which will be done inside periodic timer. */
 int raftLoadSnapshot(raft_server_t *raft, void *user_data, raft_term_t term,
                      raft_index_t index)
 {

--- a/tests/integration/test_fuzzing.py
+++ b/tests/integration/test_fuzzing.py
@@ -147,7 +147,10 @@ def test_stale_reads_on_restarts(cluster, workload):
     workload.stop()
 
 
-def test_snapshot_delivery_with_traffic(cluster):
+def test_snapshot_delivery_with_config_changes(cluster):
+    """
+    Test big snapshot delivery (~70 mb on disk) while adding/removing nodes
+    """
     cycles = 10
 
     cluster.create(1)

--- a/tests/integration/test_fuzzing.py
+++ b/tests/integration/test_fuzzing.py
@@ -147,6 +147,36 @@ def test_stale_reads_on_restarts(cluster, workload):
     workload.stop()
 
 
+def test_snapshot_delivery_with_traffic(cluster):
+    cycles = 10
+
+    cluster.create(1)
+    cluster.execute('set', 'x', '1')
+    cluster.execute('set', 'x', '1')
+
+    n1 = cluster.node(1)
+    n1.execute('raft.debug', 'exec', 'debug', 'populate', 2000000, 'a', 200)
+    n1.execute('raft.debug', 'compact')
+
+    cluster.add_node()
+    cluster.add_node()
+    cluster.add_node()
+    cluster.add_node()
+    cluster.wait_for_unanimity()
+
+    for i in range(cycles):
+        assert cluster.execute('INCRBY', 'counter', 1) == i + 1
+        try:
+            cluster.remove_node(cluster.random_node_id())
+        except ResponseError:
+            continue
+
+        cluster.add_node().wait_for_node_voting()
+
+    logging.info('All cycles finished')
+    assert int(cluster.execute('GET', 'counter')) == cycles
+
+
 @pytest.mark.slow
 def test_proxy_stability_under_load(cluster, workload):
     """


### PR DESCRIPTION
RedisRaft crashes while loading a big snapshot.

RedisRaft calls `rdbLoad()` function from Redis to load the received
snapshot file (RDB). This function is called inside a command callback.
`rdbLoad()` goes to networking and process events if loading the 
snapshot takes a while. If the current client that triggered command
callback disconnects, client struct can be freed before it returns
from `rdbLoad()` and from the callback. After that, a use-after-free
bug occurs and leads to crash.

Previously, there was a similar bug. Redis was trying to process
another message from the same client:
https://github.com/RedisLabs/redisraft/pull/450

Until this issue is fixed, as a workaround, we can delay loading the
snapshot and let the command callback return. Inside the timer callback,
we can load the snapshot. To do that, we need to set state to 
`REDIS_RAFT_LOADING`, so, other commands should be rejected until we
load the snapshot. 