### PR TITLE
Set socket timeout for redis-py in tests

### DIFF
--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -130,6 +130,7 @@ class RedisRaft(object):
         client_key = os.getcwd() + '/tests/tls/client.key'
 
         self.client = redis.Redis(host='localhost', port=self.port,
+                                  socket_timeout=20,
                                   password=password,
                                   ssl=config.tls,
                                   ssl_certfile=client_cert,


### PR DESCRIPTION
If redis-py client fails to detect disconnection, the request will hang forever.
Socket timeout will fail the request if it takes longer than 20 seconds. 
This is a precaution to avoid hung tests.

Also, hopefully, it will give more info about https://github.com/RedisLabs/redisraft/issues/273 