### PR TITLE
Increase no leader timeout in tests

### DIFF
--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -488,7 +488,7 @@ class RedisRaft(object):
 
 
 class Cluster(object):
-    noleader_timeout = 10
+    noleader_timeout = 30
 
     def __init__(self, config, base_port=5000, base_id=0, cluster_id=0):
         self.next_id = base_id + 1


### PR DESCRIPTION
Slow CI instances with heavy workload (e.g. with Address Sanitizer)
can cause failures due to low timeout. 

Increasing to 30 seconds to prevent these issues. 