### PR TITLE
Use SHUTDOWN command instead of exit()

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -42,10 +42,6 @@ static void replaceShardGroups(RedisRaftCtx *rr, raft_entry_t *entry);
 
 void shutdownAfterRemoval(RedisRaftCtx *rr)
 {
-    size_t len;
-    const char *err;
-    RedisModuleCallReply *reply;
-
     LOG_NOTICE("*** NODE REMOVED, SHUTTING DOWN.");
 
     if (rr->config.log_filename) {
@@ -55,11 +51,11 @@ void shutdownAfterRemoval(RedisRaftCtx *rr)
         archiveSnapshot(rr);
     }
 
-    reply = RedisModule_Call(rr->ctx, "SHUTDOWN", "cE", "NOW");
-    err = RedisModule_CallReplyStringPtr(reply, &len);
-    if (err) {
-        LOG_WARNING("Shutdown failure: %.*s", (int) len, err);
-    }
+    RedisModuleCallReply *r = RedisModule_Call(rr->ctx, "SHUTDOWN", "cE", "NOW");
+
+    size_t len;
+    const char *err = RedisModule_CallReplyStringPtr(r, &len);
+    LOG_WARNING("Shutdown failure: %.*s", (int) len, err);
 
     abort();
 }

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1531,6 +1531,17 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     return REDISMODULE_OK;
 }
 
+/* RAFT.NODESHUTDOWN [nodeid]
+ *
+ *    Shutdown the node.
+ *
+ *    When the leader appends removal entry of a follower, the leader will stop
+ *    replicating entries to that follower immediately. (In raft, config changes
+ *    take effect on append). The follower will never receive its own removal
+ *    entry, and it will not realize that it has been removed. RAFT.NODESHUTDOWN
+ *    is a best-effort message that is sent by the leader to the removed node
+ *    to indicate this config change.
+ */
 static int cmdRaftNodeShutdown(RedisModuleCtx *ctx,
                                RedisModuleString **argv, int argc)
 {


### PR DESCRIPTION
Calling `exit()` from modules is unexpected as Redis won't have a 
chance to do clean up: Closing the sockets, removing pid file etc.
Also, other modules won't get the shutdown callback.

Changing `exit()` to `SHUTDOWN` command to prevent these issues.