### PR TITLE
Use memset() instead of deprecated bzero()

### DIFF
--- a/tests/unit/test_util.c
+++ b/tests/unit/test_util.c
@@ -28,7 +28,7 @@ static void test_parse_slots(void **state)
     for (size_t i = 1; i < REDIS_RAFT_HASH_SLOTS; i++) {
         assert_int_equal(slots[i], 0);
     }
-    bzero(slots, REDIS_RAFT_HASH_SLOTS);
+    memset(slots, 0, sizeof(slots));
     parseHashSlots(slots, "0-10");
     for (size_t i = 0; i < 11; i++) {
         assert_int_equal(slots[i], 1);
@@ -36,7 +36,7 @@ static void test_parse_slots(void **state)
     for (size_t i = 11; i < REDIS_RAFT_HASH_SLOTS; i++) {
         assert_int_equal(slots[i], 0);
     }
-    bzero(slots, REDIS_RAFT_HASH_SLOTS);
+    memset(slots, 0, sizeof(slots));
     parseHashSlots(slots, "0,5-10,16,58-62,100");
     assert_int_equal(slots[0], 1);
     for (size_t i = 1; i < 5; i++) {


### PR DESCRIPTION
https://github.com/RedisLabs/redisraft/actions/runs/3376980389/jobs/5605359643#step:5:257

```
warning: 'bzero' is deprecated [-Wdeprecated-declarations]
    bzero(slots, REDIS_RAFT_HASH_SLOTS);
```