### PR TITLE
Detect crashes from logs in tests

### DIFF
--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -22,7 +22,7 @@ import redis
 LOG = logging.getLogger('sandbox')
 
 
-class RedisRaftSanitizer(Exception):
+class RedisRaftBug(Exception):
     pass
 
 
@@ -266,10 +266,21 @@ class RedisRaft(object):
                             'RedisRaft<%s> failed to start' % self.id)
                 time.sleep(0.1)
 
-    def check_sanitizer_error(self):
-        if (self.stdout and 'sanitizer' in self.stdout.loglines.lower() or
-                self.stderr and 'sanitizer' in self.stderr.loglines.lower()):
-            raise RedisRaftSanitizer('Sanitizer error.')
+    def check_error_in_logs(self):
+        stdout = ""
+        stderr = ""
+
+        if self.stdout:
+            stdout = self.stdout.loglines.lower()
+
+        if self.stderr:
+            stderr = self.stderr.loglines.lower()
+
+        if 'sanitizer' in stdout or 'sanitizer' in stderr:
+            raise RedisRaftBug('Sanitizer error')
+
+        if 'redis bug report' in stdout or 'redis bug report' in stderr:
+            raise RedisRaftBug('RedisRaft crash')
 
     def terminate(self):
         if self.process:
@@ -285,7 +296,7 @@ class RedisRaft(object):
             else:
                 LOG.info('RedisRaft<%s> terminated', self.id)
         self.process = None
-        self.check_sanitizer_error()
+        self.check_error_in_logs()
 
     def kill(self):
         if self.process:
@@ -299,7 +310,7 @@ class RedisRaft(object):
             else:
                 LOG.info('RedisRaft<%s> killed', self.id)
         self.process = None
-        self.check_sanitizer_error()
+        self.check_error_in_logs()
 
     def restart(self, retries=5):
         self.terminate()
@@ -693,7 +704,7 @@ class Cluster(object):
         for node in self.nodes.values():
             try:
                 node.destroy()
-            except RedisRaftSanitizer as e:
+            except RedisRaftBug as e:
                 err = e
         if err:
             raise err
@@ -703,7 +714,7 @@ class Cluster(object):
         for node in self.nodes.values():
             try:
                 node.terminate()
-            except RedisRaftSanitizer as e:
+            except RedisRaftBug as e:
                 err = e
         if err:
             raise err


### PR DESCRIPTION
Currently, if a node crashes in the background, we don't detect it
and test passes succesfully. 

Adding a check to detect crashes from the logs.