### PR TITLE
[RR-117] Fix crash while resolving address

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -419,6 +419,9 @@ void ConnMarkDisconnected(Connection *conn)
  */
 bool ConnIsIdle(Connection *conn)
 {
+    /* If the connection is in the "resolving" state, it means the hostname
+     * resolution is in progress in another thread. Even though it was marked as
+     * "terminating", the connection is not idle yet. */
     return conn->state == CONN_DISCONNECTED ||
            conn->state == CONN_CONNECT_ERROR ||
            (conn->state != CONN_RESOLVING && (conn->flags & CONN_TERMINATING));

--- a/src/connection.c
+++ b/src/connection.c
@@ -417,10 +417,11 @@ void ConnMarkDisconnected(Connection *conn)
 /* An idle state is one that will not transition automatically to another
  * state, unless actively mutated.
  */
-
 bool ConnIsIdle(Connection *conn)
 {
-    return (conn->state == CONN_DISCONNECTED || conn->state == CONN_CONNECT_ERROR || (conn->flags & CONN_TERMINATING));
+    return conn->state == CONN_DISCONNECTED ||
+           conn->state == CONN_CONNECT_ERROR ||
+           (conn->state != CONN_RESOLVING && (conn->flags & CONN_TERMINATING));
 }
 
 bool ConnIsConnected(Connection *conn)


### PR DESCRIPTION
RedisRaft does hostname resolution in another thread. If a node is 
removed from the cluster while the server is resolving its address,
its connection object might be freed. This causes use-after-free 
issue just after the address resolution is completed.

1- Connection will be marked for termination here: 
https://github.com/RedisLabs/redisraft/blob/4f0e28b8f4c37a06a7ef0a8e45595ee2fb514c26/src/raft.c#L979

2- Connection will be freed here:
https://github.com/RedisLabs/redisraft/blob/4f0e28b8f4c37a06a7ef0a8e45595ee2fb514c26/src/connection.c#L472

3- Then, it will crash inside `handleResolved()`:
https://github.com/RedisLabs/redisraft/blob/4f0e28b8f4c37a06a7ef0a8e45595ee2fb514c26/src/connection.c#L284

To solve the issue, added a line to prevent `ConnIsIdle()` return `true`
while resolving the address. It will prevent the deallocation. 
Connection handling requires a rewrite. This is just a temporary 
solution.

Introduced by https://github.com/RedisLabs/redisraft/pull/247
