### PR TITLE
Enforce PEP8 style for Python tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,4 +100,3 @@ jobs:
       - name: Spellcheck
         run:
           codespell --config=./.github/codespell/config.txt
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,14 @@ jobs:
         run: |
           clang-format -n -Werror -style=file:src/.clang-format src/* || true
           colordiff -u <(cat src/*) <(clang-format -style=file:src/.clang-format src/*)
-      - name: CheckStyle - unit tests
+      - name: Check Style - unit tests
         run: |
           clang-format -n -Werror -style=file:tests/unit/.clang-format tests/unit/* || true
           colordiff -u <(cat tests/unit/*) <(clang-format -style=file:tests/unit/.clang-format tests/unit/*)
+      - name: Check Style - integration tests
+        run: |
+          pycodestyle --show-source tests
       - name: Spellcheck
         run:
           codespell --config=./.github/codespell/config.txt
+

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,6 @@ RedisRaft is licensed under the Redis Source Available License (RSAL).
 """
 import os.path
 import subprocess
-import time
 import typing
 from types import SimpleNamespace
 import pytest
@@ -47,12 +46,14 @@ def pytest_addoption(parser):
     parser.addoption(
         "--runslow", action="store_true", default=False, help="run slow tests")
     parser.addoption(
-        '--elle-cli', default='../elle-cli/target/elle-cli-0.1.4-standalone.jar',
+        '--elle-cli',
+        default='../elle-cli/target/elle-cli-0.1.4-standalone.jar',
         help='location for elle-cli jar file')
     parser.addoption(
         '--elle-threads', default=0, help='number of elle worker threads')
     parser.addoption(
-        '--elle-ops-per-tx', default=1, help='number of append/read pairs per transaction')
+        '--elle-ops-per-tx', default=1,
+        help='number of append/read pairs per transaction')
 
 
 def pytest_configure(config):
@@ -113,8 +114,10 @@ def elle(request):
     elle_main.logfile.close()
     # no reason to run elle if failed
     if _config.elle_threads > 0 and not request.session.testsfailed:
-        p = subprocess.run(["/usr/bin/java", "-jar", elle_main.config.elle_cli, "-v", "--model", "list-append",
-                            os.path.join(elle_main.logdir, "logfile.edn")], capture_output=True)
+        p = subprocess.run(["/usr/bin/java", "-jar", elle_main.config.elle_cli,
+                            "-v", "--model", "list-append",
+                            os.path.join(elle_main.logdir, "logfile.edn")],
+                           capture_output=True)
         if p.returncode != 0:
             print(f"stdout = {p.stdout.decode()}")
             print(f"stderr = {p.stderr.decode()}")
@@ -157,7 +160,8 @@ def cluster_factory(request, elle):
 
     marker = request.node.get_closest_marker("elle_test")
     if marker is not None:
-        workers = [ElleWorker(elle, created_clusters, keys) for _ in range(create_config(request.config).elle_threads)]
+        workers = [ElleWorker(elle, created_clusters, keys)
+                   for _ in range(create_config(request.config).elle_threads)]
 
     for worker in workers:
         worker.start()

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -2,3 +2,4 @@ redis==3.4.1
 pytest==7.1.2
 pytest-timeout==1.3.4
 codespell==2.2.2
+pycodestyle==2.9.1

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -263,7 +263,7 @@ def test_module_command_flags(cluster):
     """
     Test commandspec table is updated after module load/unload
     """
-     
+
     node = cluster.add_node(
         redis_args=["--enable-module-command", "yes"],
         cluster_setup=False)

--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -118,7 +118,9 @@ def test_reply_to_cache_invalidated_entry(cluster):
     # Send commands that are guaranteed to overflow the cache
     conns = []
     for i in range(10):
-        conn = cluster.node(1).client.connection_pool.get_connection('deferred')
+        n1 = cluster.node(1)
+        conn = n1.client.connection_pool.get_connection('deferred')
+
         conn.send_command('SET', 'key%s' % i, 'x' * 1000)
         conns.append(conn)
 

--- a/tests/integration/test_random.py
+++ b/tests/integration/test_random.py
@@ -60,9 +60,9 @@ end
 -- Iterate fields and set values according to order
 local vals = redis.call(cmd, key1)
 for i, field in ipairs(vals) do
-    if (not (cmd == "hgetall") or i % 2 == 0) then 
+    if (not (cmd == "hgetall") or i % 2 == 0) then
         redis.call('rpush', output_key, field)
-    end 
+    end
 end
 
 return 1
@@ -150,13 +150,13 @@ end
 
 -- Iterate fields and set values according to order
 local vals
-if not (cmd == "smembers") then 
+if not (cmd == "smembers") then
     vals = redis.call(cmd, key1, key2)
 else
     vals = redis.call(cmd, key1)
-end 
+end
 for i, field in ipairs(vals) do
-    redis.call('rpush', output_key, field) 
+    redis.call('rpush', output_key, field)
 end
 
 return 1
@@ -242,7 +242,7 @@ end
 -- Iterate fields and set values according to order
 local vals = redis.call("keys", "*")
 for i, field in ipairs(vals) do
-    redis.call('rpush', output_key, field) 
+    redis.call('rpush', output_key, field)
 end
 
 return 1

--- a/tests/integration/test_snapshots.py
+++ b/tests/integration/test_snapshots.py
@@ -473,7 +473,7 @@ def test_snapshot_fork_failure(cluster):
     # will fail.
     time.sleep(3)
 
-    assert r1.client.execute_command('RAFT.DEBUG', 'COMPACT', '0', '0') == b'OK'
+    assert r1.execute('RAFT.DEBUG', 'COMPACT', '0', '0') == b'OK'
     assert r1.info()['raft_snapshots_created'] == 1
 
     r1.client.incr('testkey')


### PR DESCRIPTION
Enforce PEP8 style for Python tests
- Added CI checker.  To run the command on your local:
  ` pycodestyle --show-source tests` 

There were previous attempts like: #364 to cleanup linter warnings.
Back then, I didn't introduce CI style checker for Python tests as 
it might be limiting too much. The problem is when there are lots
of warnings, it is easy to miss serious ones. 

Test fixes are mostly regarding line length limit. There is no logical
change.