### PR TITLE
Add spellchecker to CI

### DIFF
--- a/.github/codespell/config.txt
+++ b/.github/codespell/config.txt
@@ -1,0 +1,5 @@
+[codespell]
+quiet-level = 2
+skip = *cmake-*,*build/*,*deps*,*venv*,*git*
+ignore-words = .github/codespell/skiplist.txt
+builtin = code,rare,clear,names,informal

--- a/.github/codespell/skiplist.txt
+++ b/.github/codespell/skiplist.txt
@@ -1,0 +1,3 @@
+smove
+ro
+stdio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install build dependencies
         run: sudo apt-get install -y build-essential autoconf automake libtool cmake lcov clang-format colordiff
+      - name: Setup Python for testing
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
+      - name: Install Python dependencies
+        run:
+          python -m pip install -r tests/integration/requirements.txt
       - name: Check Style - src
         run: |
           clang-format -n -Werror -style=file:src/.clang-format src/* || true
@@ -86,3 +94,6 @@ jobs:
         run: |
           clang-format -n -Werror -style=file:tests/unit/.clang-format tests/unit/* || true
           colordiff -u <(cat tests/unit/*) <(clang-format -style=file:tests/unit/.clang-format tests/unit/*)
+      - name: Spellcheck
+        run:
+          codespell --config=./.github/codespell/config.txt

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -49,7 +49,7 @@ To build, simply run:
 
     make
 
-If successful, this should result in the creation of the `redisraft.so` shared libary.
+If successful, this should result in the creation of the `redisraft.so` shared library.
 
 Cluster Setup
 -------------
@@ -292,7 +292,7 @@ The number of milliseconds to wait for a response to a proxy request sent to a l
 
 ### `response-timeout`
 
-The number of millieconds to wait for a response to a Raft message exchanged between nodes, before giving up and dropping the connection.
+The number of milliseconds to wait for a response to a Raft message exchanged between nodes, before giving up and dropping the connection.
 
 *Default*: 1000
 
@@ -371,7 +371,7 @@ of foreign shardgroup clusters.
 
 ### `ignored-commands`
 
-A comma seperated list of additional commands that RedisRaft should not intercept, and therefore not append to the Raft log before executing.
+A comma separated list of additional commands that RedisRaft should not intercept, and therefore not append to the Raft log before executing.
 
 In general this is useful when used with other modules that don't want some or all of their commands handled via raft.
 

--- a/docs/ExternalSharding.md
+++ b/docs/ExternalSharding.md
@@ -3,7 +3,7 @@ RedisRaft External Sharding Support
 
 ## Introduction
 
-Initially, RedisRaft's [sharding mechanism](Sharding.md) used inter-cluster communication to learn about node configuration changes that occured on its peer clusters containing other shards.
+Initially, RedisRaft's [sharding mechanism](Sharding.md) used inter-cluster communication to learn about node configuration changes that occurred on its peer clusters containing other shards.
 While, much of the terminology hasn't changed, this mechanism for communicating between RedisRaft clusters was only effective at transmitting node changes.
 If one wanted to reconfigure which RedisRaft Clusters own which shards, one wasn't able to do it.
 
@@ -58,4 +58,4 @@ NODE_CONFIGURATION is defined as
 ```
 
 RedisRaft will validate the full configuration passed to a RAFT.SHARDGROUP REPLACE command to ensure that its internally consistent.
-Namely, that every defined slot is in a consistent configuration.  Only one cluster can be defned with a slot if its stable, and while two clusters can be defined to be importing and migrating, respectively, there can be only one cluster of each.
+Namely, that every defined slot is in a consistent configuration.  Only one cluster can be defined with a slot if its stable, and while two clusters can be defined to be importing and migrating, respectively, there can be only one cluster of each.

--- a/src/multi.c
+++ b/src/multi.c
@@ -75,7 +75,7 @@ bool MultiHandleCommand(RedisRaftCtx *rr,
 
         /* TODO: should we check ACL for EXEC?
          * Currently we check ACL for MULTI as part of dry run processing,
-         * but as EXEC is not added to CommandArray, it wont be tested
+         * but as EXEC is not added to CommandArray, it won't be tested
          */
         /* Just swap our commands with the EXEC command and proceed. */
         RaftRedisCommandArrayFree(cmds);

--- a/src/raft.c
+++ b/src/raft.c
@@ -1020,7 +1020,7 @@ static char *raftMembershipInfoString(raft_server_t *raft)
 static void handleTransferLeaderComplete(raft_server_t *raft, raft_leader_transfer_e result);
 
 /* just keep libraft callbacks together
- * so this just calls the redisraft RaftReq compleition function, which is kept together with its functions
+ * so this just calls the redisraft RaftReq completion function, which is kept together with its functions
  */
 static void raftNotifyTransferEvent(raft_server_t *raft, void *user_data, raft_leader_transfer_e result)
 {
@@ -1056,7 +1056,7 @@ static void raftNotifyStateEvent(raft_server_t *raft, void *user_data, raft_stat
 }
 
 /* Apply some backpressure for the node. Helps in two cases, first we don't
- * want to create many appaendentries messages for the node if we don't get
+ * want to create many appendentries messages for the node if we don't get
  * replies. Otherwise, it might cause out of memory. Second, we want to send
  * entries in batches for performance reasons. We are effectively batching
  * entries until we get replies from the previous ones. */
@@ -1689,7 +1689,7 @@ void replaceShardGroups(RedisRaftCtx *rr, raft_entry_t *entry)
     }
 }
 
-/* Callback for fsync thread. This will be triggerred by fsync thread but will
+/* Callback for fsync thread. This will be triggered by fsync thread but will
  * be called by Redis thread. */
 void handleFsyncCompleted(void *result)
 {

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1317,7 +1317,7 @@ static int cmdRaftShardGroup(RedisModuleCtx *ctx, RedisModuleString **argv, int 
  *     +OK
  *
  * RAFT.DEBUG COMMANDSPEC <command>
- *     Retruns the flags associated with this command in the commandspec dict
+ *     Returns the flags associated with this command in the commandspec dict
  */
 static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 {
@@ -1842,7 +1842,7 @@ static int registerRaftCommands(RedisModuleCtx *ctx)
     /* Register commands.
      *
      * NOTE: Internal RedisRaft module commands must also be set with
-     * their apropriate flags in commands.c, typically with a
+     * their appropriate flags in commands.c, typically with a
      * CMD_SPEC_DONT_INTERCEPT flag.
      * */
     if (RedisModule_CreateCommand(ctx, "raft", cmdRaft,

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -584,7 +584,7 @@ typedef struct ShardingInfo {
      *
      * Note that a one-based index into the shard_groups array is used,
      * since a zero value indicates the slot is unassigned. The index
-     * should therefore be adjusted before refering the array.
+     * should therefore be adjusted before referring the array.
      */
     ShardGroup *stable_slots_map[REDIS_RAFT_HASH_SLOTS];
     ShardGroup *importing_slots_map[REDIS_RAFT_HASH_SLOTS];

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -347,7 +347,7 @@ int pollSnapshotStatus(RedisRaftCtx *rr, SnapshotResult *sr)
         goto exit;
     }
 
-    LOG_VERBOSE("Snapshot created successfuly.");
+    LOG_VERBOSE("Snapshot created successfully.");
     ret = 1;
 
 exit:

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,3 +1,4 @@
 redis==3.4.1
 pytest==7.1.2
 pytest-timeout==1.3.4
+codespell==2.2.2

--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -115,7 +115,7 @@ def test_reply_to_cache_invalidated_entry(cluster):
     cluster.node(2).terminate()
     cluster.node(3).terminate()
 
-    # Send commands that are guarnateed to overflow the cache
+    # Send commands that are guaranteed to overflow the cache
     conns = []
     for i in range(10):
         conn = cluster.node(1).client.connection_pool.get_connection('deferred')

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -593,7 +593,7 @@ def test_metadata_restore_after_restart(cluster):
     cluster.node(1).start()
     n1.wait_for_info_param('raft_state', 'up')
 
-    # n2 triggerred an election, so n1 should have voted for n2.
+    # n2 triggered an election, so n1 should have voted for n2.
     assert n1.info()['raft_current_term'] == 2
     assert n1.info()['raft_voted_for'] == 2
 
@@ -602,7 +602,7 @@ def test_metadata_restore_after_restart(cluster):
     cluster.node(2).start()
     n2.wait_for_info_param('raft_state', 'up')
 
-    # n2 triggerred an election, so n2 should have voted for itself.
+    # n2 triggered an election, so n2 should have voted for itself.
     assert n2.info()['raft_current_term'] == 2
     assert n2.info()['raft_voted_for'] == 2
 


### PR DESCRIPTION
Add spellchecker to the CI and fix findings

Sample output is

```
Run codespell --config=./.github/codespell/config.txt
./docs/ExternalSharding.md:6: occured ==> occurred
./docs/ExternalSharding.md:61: defned ==> defend, defined
./docs/Deployment.md:52: libary ==> library
./docs/Deployment.md:374: seperated ==> separated
./tests/integration/test_sanity.py:596: triggerred ==> triggered
./tests/integration/test_sanity.py:605: triggerred ==> triggered
./tests/integration/test_log.py:118: guarnateed ==> guaranteed
./src/multi.c:78: wont ==> won't
./src/redisraft.h:587: refering ==> referring
./src/redisraft.c:1320: Retruns ==> Returns
./src/redisraft.c:1845: apropriate ==> appropriate
./src/raft.c:1692: triggerred ==> triggered
./src/snapshot.c:350: successfuly ==> successfully
```

Not sure if this is the best checker (it misses some), CLion's 
integrated proofreading tool(hunspell) seems better but this one
relatively easy to use.