### PR TITLE
Add more paths to spellcheck skiplist

### DIFF
--- a/.github/codespell/config.txt
+++ b/.github/codespell/config.txt
@@ -1,5 +1,5 @@
 [codespell]
 quiet-level = 2
-skip = *cmake-*,*build/*,*deps*,*venv*,*git*
+skip = *cmake*,*build/*,*deps*,*env*,*git*,*aws/*,*jepsen/docker/store/*,*.log,*.db*,*/tmp/*,*idea*,*.idx*,*.rdb,core.*
 ignore-words = .github/codespell/skiplist.txt
 builtin = code,rare,clear,names,informal


### PR DESCRIPTION
Spellchecker can scan some generated files on a local run. 
It might slow down the scan if those files are big. 

Adjusted ignore paths to prevent it.

Follow up #530

