### PR TITLE
[RR-114] read only script tests with ACL/oom permutations

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -367,8 +367,11 @@ void RaftExecuteCommandArray(RedisRaftCtx *rr,
         int old_entered_eval = rr->entered_eval;
 
         if ((cmdlen == 4 && !strncasecmp(cmd, "eval", 4)) ||
+            (cmdlen == 7 && !strncasecmp(cmd, "eval_ro", 7)) ||
             (cmdlen == 7 && !strncasecmp(cmd, "evalsha", 7)) ||
-            (cmdlen == 5 && !strncasecmp(cmd, "fcall", 5))) {
+            (cmdlen == 10 && !strncasecmp(cmd, "evalsha_ro", 10)) ||
+            (cmdlen == 5 && !strncasecmp(cmd, "fcall", 5)) ||
+            (cmdlen == 8 && !strncasecmp(cmd, "fcall_ro", 8))) {
             rr->entered_eval = 1;
         }
 

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -615,20 +615,20 @@ def test_ro_scripts(cluster):
 
     cluster.execute('acl', 'setuser', 'default', 'resetkeys')
     # no oom, acl deny
-    with (raises(ResponseError, match="No permissions to access a key")):
+    with raises(ResponseError, match="No permissions to access a key"):
         cluster.execute('EVAL_RO', "return redis.call('GET','abc');", '0')
-    with (raises(ResponseError, match="No permissions to access a key")):
+    with raises(ResponseError, match="No permissions to access a key"):
         cluster.execute('EVALSHA_RO', sha.decode(), 0)
-    with (raises(ResponseError, match="No permissions to access a key")):
+    with raises(ResponseError, match="No permissions to access a key"):
         cluster.execute('FCALL_RO', 'testfunc', 0)
 
     print("oom, acl deny")
 
     # oom, acl deny
     cluster.execute('config', 'set', 'maxmemory', 1)
-    with (raises(ResponseError, match="No permissions to access a key")):
+    with raises(ResponseError, match="No permissions to access a key"):
         cluster.execute('EVAL_RO', "return redis.call('GET','abc');", '0')
-    with (raises(ResponseError, match="No permissions to access a key")):
+    with raises(ResponseError, match="No permissions to access a key"):
         cluster.execute('EVALSHA_RO', sha.decode(), 0)
     with raises(ResponseError, match="No permissions to access a key"):
         cluster.execute('FCALL_RO', 'testfunc', 0)

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -630,7 +630,7 @@ def test_ro_scripts(cluster):
         cluster.execute('EVAL_RO', "return redis.call('GET','abc');", '0')
     with (raises(ResponseError, match="No permissions to access a key")):
         cluster.execute('EVALSHA_RO', sha.decode(), 0)
-    with (raises(ResponseError, match="No permissions to access a key")):
+    with raises(ResponseError, match="No permissions to access a key"):
         cluster.execute('FCALL_RO', 'testfunc', 0)
     cluster.execute('config', 'set', 'maxmemory', 0)
 


### PR DESCRIPTION
add tests for eval_ro/evalsha_ro/fcall_ro with 4 permutations for each for acl/oom settings