### PR TITLE
Skip Redis-Suite test with MONITOR and functions

### DIFF
--- a/tests/redis-suite/skip.txt
+++ b/tests/redis-suite/skip.txt
@@ -37,6 +37,7 @@ SLOWLOG - Rewritten commands are logged as their original command
 -- RAFT command prefix shows up in MONITOR
 MONITOR can log executed commands
 MONITOR can log commands issued by the scripting engine
+MONITOR can log commands issued by functions
 MONITOR correctly handles multi-exec cases
 
 -- TODO: check what's wrong


### PR DESCRIPTION
Redis suite test failure:
https://github.com/RedisLabs/redisraft/actions/runs/3484239943

`RAFT.` prefix breaks the test. Introduced by redis/redis#11510