### PR TITLE
[RR-111] test to ensure followers in oom still apply log changes

### DIFF
--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -654,5 +654,7 @@ def test_followers_in_oom(cluster):
     cluster.wait_for_unanimity()
 
     assert cluster.execute("get", "abc") == b'1234'
-    assert cluster.node(2).execute("raft.debug", "exec", "get", "abc") == b'1234'
-    assert cluster.node(3).execute("raft.debug", "exec", "get", "abc") == b'1234'
+    node2 = cluster.node(2)
+    node3 = cluster.node(3)
+    assert node2.execute("raft.debug", "exec", "get", "abc") == b'1234'
+    assert node3.execute("raft.debug", "exec", "get", "abc") == b'1234'


### PR DESCRIPTION
create a 3 node cluster, put followers into oom, sets should still apply and be visible on all nodes