### PR TITLE
Delete RAFT.DEBUG SENDSNAPSHOT

### DIFF
--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1283,11 +1283,6 @@ static int cmdRaftShardGroup(RedisModuleCtx *ctx, RedisModuleString **argv, int 
  * Reply:
  *    +OK
  *
- * RAFT.DEBUG SENDSNAPSHOT <node_id>
- *     Send node snapshot
- * Reply:
- *     +OK
- *
  * RAFT.DEBUG USED_NODE_IDS
  *     return an array of used node ids
  * Reply:
@@ -1408,32 +1403,6 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 
         RedisModule_Free(cfg);
         RedisModule_ReplyWithSimpleString(ctx, "OK");
-    } else if (!strncasecmp(cmd, "sendsnapshot", cmdlen)) {
-        if (argc != 3) {
-            RedisModule_WrongArity(ctx);
-            return REDISMODULE_OK;
-        }
-
-        long long node_id;
-        if (RedisModule_StringToLongLong(argv[2], &node_id) != REDISMODULE_OK) {
-            RedisModule_ReplyWithError(ctx, "ERR invalid node id");
-            return REDISMODULE_OK;
-        }
-
-        raft_node_t *node = raft_get_node(rr->raft, (raft_node_id_t) node_id);
-        if (!node) {
-            RedisModule_ReplyWithError(ctx, "ERR node does not exist");
-            return REDISMODULE_OK;
-        }
-
-        if (node_id == raft_get_nodeid(rr->raft)) {
-            RedisModule_ReplyWithError(ctx, "ERR cannot send snapshot itself");
-            return REDISMODULE_OK;
-        }
-
-        raft_node_set_next_idx(node, raft_get_snapshot_last_idx(rr->raft));
-        RedisModule_ReplyWithSimpleString(ctx, "OK");
-
     } else if (!strncasecmp(cmd, "used_node_ids", cmdlen)) {
         RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
 


### PR DESCRIPTION
Currently, `RAFT.DEBUG SENDSNAPSHOT` is unused and it is leftover. 
If a node is not lagging behind, it won't load the snapshot.  As it has all 
the entries, it will realize that snapshot is not necessary. So, this 
command does not work.

In tests, we make target node lag behind (by killing it for a while) to
trigger snapshot delivery or we add a new node instead. 