### PR TITLE
[RR-45] Log and metadata file clean up

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -662,7 +662,7 @@ void ShardingInfoRDBLoad(RedisModuleIO *rdb)
         RedisModule_Assert(sg != NULL);
 
         /* set local flag */
-        if (!strncmp(sg->id, rr->log->dbid, RAFT_DBID_LEN)) {
+        if (!strncmp(sg->id, rr->meta.dbid, RAFT_DBID_LEN)) {
             sg->local = true;
         }
 
@@ -1200,7 +1200,7 @@ static int addClusterSlotNodeReply(RedisRaftCtx *rr, RedisModuleCtx *ctx, raft_n
     RedisModule_ReplyWithCString(ctx, addr->host);
     RedisModule_ReplyWithLongLong(ctx, addr->port);
 
-    raftNodeToString(node_id, rr->log->dbid, raft_node);
+    raftNodeToString(node_id, rr->meta.dbid, raft_node);
     RedisModule_ReplyWithCString(ctx, node_id);
 
     return 1;
@@ -1358,11 +1358,11 @@ static void addClusterNodeReplyFromNode(RedisRaftCtx *rr,
     int pong_recv = 0;
 
     char node_id[RAFT_SHARDGROUP_NODEID_LEN + 1];
-    raftNodeToString(node_id, rr->log->dbid, raft_node);
+    raftNodeToString(node_id, rr->meta.dbid, raft_node);
 
     char master_node_id[RAFT_SHARDGROUP_NODEID_LEN + 1];
     if (!leader) {
-        raftNodeIdToString(master_node_id, rr->log->dbid, raft_get_leader_id(rr->raft));
+        raftNodeIdToString(master_node_id, rr->meta.dbid, raft_get_leader_id(rr->raft));
         master = master_node_id;
     }
 
@@ -1580,7 +1580,7 @@ static int addClusterShardsLocalNodeReply(RedisRaftCtx *rr, RedisModuleCtx *ctx,
     }
 
     char node_id[RAFT_SHARDGROUP_NODEID_LEN + 1];
-    raftNodeToString(node_id, rr->log->dbid, raft_node);
+    raftNodeToString(node_id, rr->meta.dbid, raft_node);
 
     addClusterShardsNodeReply(rr, ctx, node_id, addr->port, addr->host, role);
 
@@ -1815,7 +1815,7 @@ void ShardGroupLink(RedisRaftCtx *rr,
 
 void ShardGroupGet(RedisRaftCtx *rr, RedisModuleCtx *ctx)
 {
-    ShardGroup *sg = GetShardGroupById(rr, rr->log->dbid);
+    ShardGroup *sg = GetShardGroupById(rr, rr->meta.dbid);
 
     /* 2 arrays
      * 1. slot ranges -> each element is a 3 element array start/end/type
@@ -1857,10 +1857,10 @@ void ShardGroupGet(RedisRaftCtx *rr, RedisModuleCtx *ctx)
         node_count++;
         RedisModule_ReplyWithArray(ctx, 2);
 
-        char node_id[RAFT_SHARDGROUP_NODEID_LEN + 1];
+        char node_id[128];
         raft_node_id_t id = raft_node_get_id(raft_node);
 
-        snprintf(node_id, sizeof(node_id), "%s%08x", rr->log->dbid, id);
+        snprintf(node_id, sizeof(node_id), "%s%08x", rr->meta.dbid, id);
         RedisModule_ReplyWithStringBuffer(ctx, node_id, strlen(node_id));
 
         char addrstr[512];

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1857,10 +1857,8 @@ void ShardGroupGet(RedisRaftCtx *rr, RedisModuleCtx *ctx)
         node_count++;
         RedisModule_ReplyWithArray(ctx, 2);
 
-        char node_id[RAFT_SHARDGROUP_NODEID_LEN * 2];
-        raft_node_id_t id = raft_node_get_id(raft_node);
-
-        snprintf(node_id, sizeof(node_id), "%s%08x", rr->meta.dbid, id);
+        char node_id[RAFT_SHARDGROUP_NODEID_LEN + 1];
+        raftNodeToString(node_id, rr->meta.dbid, raft_node);
         RedisModule_ReplyWithStringBuffer(ctx, node_id, strlen(node_id));
 
         char addrstr[512];

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1857,7 +1857,7 @@ void ShardGroupGet(RedisRaftCtx *rr, RedisModuleCtx *ctx)
         node_count++;
         RedisModule_ReplyWithArray(ctx, 2);
 
-        char node_id[128];
+        char node_id[RAFT_SHARDGROUP_NODEID_LEN * 2];
         raft_node_id_t id = raft_node_get_id(raft_node);
 
         snprintf(node_id, sizeof(node_id), "%s%08x", rr->meta.dbid, id);

--- a/src/file.c
+++ b/src/file.c
@@ -46,7 +46,7 @@ int FileOpen(File *file, const char *filename, int flags)
     struct stat st;
 
     /* Currently, only O_APPEND mode is supported. */
-    RedisModule_Assert(flags & O_APPEND);
+    RedisModule_Assert(flags == O_RDONLY || flags & O_APPEND);
 
     fd = open(filename, flags, S_IWUSR | S_IRUSR);
     if (fd < 0) {

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -17,23 +17,6 @@ static const char *METADATA_STR = "METADATA";
 static const int METADATA_VERSION = 1;
 static const int METADATA_ELEM_COUNT = 4;
 
-static int writeLength(void *buf, size_t cap, char prefix, int len)
-{
-    return safesnprintf(buf, cap, "%c%d\r\n", prefix, len);
-}
-
-static int writeInteger(void *buf, size_t cap, long long val)
-{
-    int len = lensnprintf("%lld", val);
-    return safesnprintf(buf, cap, "$%d\r\n%lld\r\n", len, val);
-}
-
-static int writeString(void *buf, size_t cap, const char *val)
-{
-    int len = lensnprintf("%s", val);
-    return safesnprintf(buf, cap, "$%d\r\n%s\r\n", len, val);
-}
-
 static char *metadataFilename(char *buf, size_t size, const char *filename)
 {
     safesnprintf(buf, size, "%s.meta", filename);
@@ -43,42 +26,34 @@ static char *metadataFilename(char *buf, size_t size, const char *filename)
 int MetadataWrite(Metadata *m, const char *filename, raft_term_t term,
                   raft_node_id_t vote)
 {
+    char buf[2048], orig[PATH_MAX], tmp[PATH_MAX];
     int off = 0;
-    char buf[2048];
-    char orig_buf[PATH_MAX];
-    char tmp_file[PATH_MAX];
+    File f;
 
-    off += writeLength(buf + off, sizeof(buf) - off, '*', METADATA_ELEM_COUNT);
-    off += writeString(buf + off, sizeof(buf) - off, METADATA_STR);
-    off += writeInteger(buf + off, sizeof(buf) - off, METADATA_VERSION);
-    off += writeInteger(buf + off, sizeof(buf) - off, term);
-    off += writeInteger(buf + off, sizeof(buf) - off, vote);
+    off += multibulkWriteLen(buf + off, sizeof(buf) - off, '*', METADATA_ELEM_COUNT);
+    off += multibulkWriteStr(buf + off, sizeof(buf) - off, METADATA_STR);
+    off += multibulkWriteInt(buf + off, sizeof(buf) - off, METADATA_VERSION);
+    off += multibulkWriteLong(buf + off, sizeof(buf) - off, term);
+    off += multibulkWriteInt(buf + off, sizeof(buf) - off, vote);
 
-    char *orig_file = metadataFilename(orig_buf, sizeof(orig_buf), filename);
-    safesnprintf(tmp_file, sizeof(tmp_file), "%s.tmp", orig_file);
+    metadataFilename(orig, sizeof(orig), filename);
+    safesnprintf(tmp, sizeof(tmp), "%s.tmp", orig);
 
-    int fd = open(tmp_file, O_WRONLY | O_CREAT | O_TRUNC, S_IWUSR | S_IRUSR);
-    if (fd < 0) {
-        PANIC("open(): %s", strerror(errno));
+    FileInit(&f);
+
+    if (FileOpen(&f, tmp, O_WRONLY | O_CREAT | O_TRUNC | O_APPEND) != RR_OK) {
+        PANIC("FileOpen(): %s", strerror(errno));
     }
 
-    char *data = buf;
-    size_t remaining = off;
-
-    while (remaining > 0) {
-        ssize_t written = write(fd, data, remaining);
-        if (written < 0) {
-            PANIC("write(): %s", strerror(errno));
-        }
-        data += written;
-        remaining -= written;
+    if (FileWrite(&f, buf, off) != off) {
+        PANIC("FileWrite(): %s", strerror(errno));
     }
 
-    if (close(fd) != 0) {
-        PANIC("close(): %s", strerror(errno));
+    if (FileTerm(&f) != RR_OK) {
+        PANIC("FileTerm(): %s", strerror(errno));
     }
 
-    if (rename(tmp_file, orig_file) != 0) {
+    if (rename(tmp, orig) != 0) {
         PANIC("rename(): %s", strerror(errno));
     }
 
@@ -88,118 +63,48 @@ int MetadataWrite(Metadata *m, const char *filename, raft_term_t term,
     return RR_OK;
 }
 
-static int readItem(char *buf, size_t size, char **item)
-{
-    char *p = memchr(buf, '\n', size);
-    if (!p || p == buf || *(p - 1) != '\r') {
-        PANIC("Corrupt metadata: %s", buf);
-    }
-
-    if (item) {
-        *item = buf;
-    }
-
-    return (int) (p - buf + 1);
-}
-
-static int readLength(char *buf, size_t size, char prefix, int *length)
-{
-    int len_bytes = readItem(buf, size, NULL);
-    if (len_bytes <= 0 || buf[0] != prefix) {
-        PANIC("Corrupt metadata: %s", buf);
-    }
-
-    if (!parseInt(buf + 1, NULL, length)) {
-        PANIC("Corrupt metadata: %s", buf);
-    }
-
-    return len_bytes;
-}
-
-static int readString(char *buf, size_t size, char **item)
-{
-    int bytes, len;
-
-    bytes = readLength(buf, size, '$', &len);
-    bytes += readItem(buf + bytes, size - bytes, item);
-
-    return bytes;
-}
-
-static int readInteger(char *buf, size_t size, long *val)
-{
-    int len, len_bytes;
-
-    len_bytes = readLength(buf, size, '$', &len);
-    if (!parseLong(buf + len_bytes, NULL, val)) {
-        PANIC("Corrupt metadata: %s", buf);
-    }
-
-    return (int) (len_bytes + len + strlen("\r\n"));
-}
-
 int MetadataRead(Metadata *m, const char *filename)
 {
-    char buf[2048];
-    char file[PATH_MAX];
+    char buf[PATH_MAX];
+    char str[128];
+    int version, elem_count;
+    raft_term_t term;
+    raft_node_id_t vote;
+    File f;
 
     *m = (Metadata){
         .term = 0,
         .vote = RAFT_NODE_ID_NONE,
     };
 
-    safesnprintf(file, sizeof(file), "%s.meta", filename);
+    metadataFilename(buf, sizeof(buf), filename);
+    FileInit(&f);
 
-    int fd = open(file, O_RDONLY);
-    if (fd < 0) {
+    if (FileOpen(&f, buf, O_RDONLY) != RR_OK) {
         if (errno != ENOENT) {
-            PANIC("open(): %s", strerror(errno));
+            PANIC("FileOpen(): %s", strerror(errno));
         }
         return RR_ERROR;
     }
 
-    char *data = buf;
-    size_t cap = sizeof(buf);
-    size_t total_bytes = 0;
-    ssize_t bytes;
-
-    do {
-        bytes = read(fd, data + total_bytes, cap);
-        if (bytes < 0) {
-            PANIC("read(): %s", strerror(errno));
-        }
-        total_bytes += bytes;
-        cap -= bytes;
-    } while (cap > 0 && bytes > 0);
-
-    RedisModule_Assert((size_t) total_bytes < sizeof(buf));
-
-    if (close(fd) != 0) {
-        PANIC("close(): %s", strerror(errno));
+    if (!multibulkReadLen(&f, '*', &elem_count) ||
+        !multibulkReadStr(&f, str, sizeof(str)) ||
+        !multibulkReadInt(&f, &version) ||
+        !multibulkReadLong(&f, &term) ||
+        !multibulkReadInt(&f, &vote)) {
+        PANIC("failed to read metadata file!");
     }
 
-    buf[total_bytes] = '\0';
+    if (FileTerm(&f) != RR_OK) {
+        PANIC("FileTerm(): %s", strerror(errno));
+    }
 
-    int off = 0, len = 0;
-    long version, term, vote;
-    char *p = NULL;
-
-    off += readLength(buf + off, total_bytes - off, '*', &len);
-    RedisModule_Assert(len == METADATA_ELEM_COUNT);
-
-    off += readString(buf + off, total_bytes - off, &p);
-    RedisModule_Assert(strncmp(p, METADATA_STR, strlen(METADATA_STR)) == 0);
-
-    off += readInteger(buf + off, total_bytes - off, &version);
+    RedisModule_Assert(elem_count == METADATA_ELEM_COUNT);
+    RedisModule_Assert(strncmp(str, METADATA_STR, strlen(METADATA_STR)) == 0);
     RedisModule_Assert(version == METADATA_VERSION);
 
-    off += readInteger(buf + off, total_bytes - off, &term);
-    RedisModule_Assert(term >= 0);
     m->term = term;
-
-    readInteger(buf + off, total_bytes - off, &vote);
-    RedisModule_Assert(vote >= INT_MIN && vote <= INT_MAX);
-    m->vote = (raft_node_id_t) vote;
+    m->vote = vote;
 
     return RR_OK;
 }

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -54,6 +54,14 @@ void MetadataConfigure(Metadata *m, const char *filename, char *dbid,
     m->node_id = node_id;
 }
 
+void MetadataArchiveFile(Metadata *m)
+{
+    char buf[PATH_MAX];
+
+    safesnprintf(buf, sizeof(buf), "%s.%d.bak", m->filename, m->node_id);
+    rename(m->filename, buf);
+}
+
 int MetadataWrite(Metadata *m, raft_term_t term, raft_node_id_t vote)
 {
     char buf[2048], tmp[PATH_MAX];

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -49,7 +49,7 @@ void MetadataConfigure(Metadata *m, const char *filename, char *dbid,
 
     RedisModule_Assert(strlen(dbid) == RAFT_DBID_LEN);
     memcpy(m->dbid, dbid, RAFT_DBID_LEN);
-    m->dbid[RAFT_DBID_LEN + 1] = '\0';
+    m->dbid[RAFT_DBID_LEN] = '\0';
 
     m->node_id = node_id;
 }

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -38,8 +38,8 @@ void MetadataTerm(Metadata *m)
     RedisModule_Free(m->filename);
 }
 
-void MetadataConfigure(Metadata *m, const char *filename, char *dbid,
-                       raft_node_id_t node_id)
+void MetadataSetClusterConfig(Metadata *m, const char *filename, char *dbid,
+                              raft_node_id_t node_id)
 {
     char buf[PATH_MAX];
 
@@ -144,13 +144,9 @@ int MetadataRead(Metadata *m, const char *filename)
     RedisModule_Assert(version == METADATA_VERSION);
     RedisModule_Assert(strlen(dbid) == RAFT_DBID_LEN);
 
-    strcpy(m->dbid, dbid);
-    m->node_id = node_id;
+    MetadataSetClusterConfig(m, filename, dbid, node_id);
     m->term = term;
     m->vote = vote;
-
-    RedisModule_Free(m->filename);
-    m->filename = RedisModule_Strdup(buf);
 
     return RR_OK;
 }

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -23,6 +23,7 @@ void MetadataInit(Metadata *m);
 void MetadataTerm(Metadata *m);
 void MetadataConfigure(Metadata *m, const char *filename, char *dbid,
                        raft_node_id_t node_id);
+void MetadataArchiveFile(Metadata *m);
 int MetadataRead(Metadata *m, const char *filename);
 int MetadataWrite(Metadata *m, raft_term_t term, raft_node_id_t vote);
 

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -12,12 +12,18 @@
 /* Raft metadata file to store last voted node id and the current term.*/
 
 typedef struct Metadata {
+    char *filename;
+    char dbid[64];
+    raft_node_id_t node_id;
     raft_term_t term;
     raft_node_id_t vote;
 } Metadata;
 
+void MetadataInit(Metadata *m);
+void MetadataTerm(Metadata *m);
+void MetadataConfigure(Metadata *m, const char *filename, char *dbid,
+                       raft_node_id_t node_id);
 int MetadataRead(Metadata *m, const char *filename);
-int MetadataWrite(Metadata *m, const char *filename, raft_term_t term,
-                  raft_node_id_t vote);
+int MetadataWrite(Metadata *m, raft_term_t term, raft_node_id_t vote);
 
 #endif

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -21,8 +21,8 @@ typedef struct Metadata {
 
 void MetadataInit(Metadata *m);
 void MetadataTerm(Metadata *m);
-void MetadataConfigure(Metadata *m, const char *filename, char *dbid,
-                       raft_node_id_t node_id);
+void MetadataSetClusterConfig(Metadata *m, const char *filename, char *dbid,
+                              raft_node_id_t node_id);
 void MetadataArchiveFile(Metadata *m);
 int MetadataRead(Metadata *m, const char *filename);
 int MetadataWrite(Metadata *m, raft_term_t term, raft_node_id_t vote);

--- a/src/raft.c
+++ b/src/raft.c
@@ -43,6 +43,7 @@ void shutdownAfterRemoval(RedisRaftCtx *rr)
 {
     LOG_NOTICE("*** NODE REMOVED, SHUTTING DOWN.");
 
+    MetadataArchiveFile(&rr->meta);
     LogArchiveFiles(rr->log);
 
     if (rr->config.rdb_filename) {

--- a/src/raft.c
+++ b/src/raft.c
@@ -1142,7 +1142,7 @@ static RRStatus loadRaftLog(RedisRaftCtx *rr)
         return RR_ERROR;
     }
 
-    if (rr->meta.dbid != rr->log->dbid) {
+    if (strcmp(rr->meta.dbid, rr->log->dbid) != 0) {
         PANIC("Log and metadata have different dbids: [log=%s/metadata=%s]",
               rr->log->dbid, rr->meta.dbid);
     }

--- a/src/raft.c
+++ b/src/raft.c
@@ -1222,16 +1222,21 @@ static void handleLoadingState(RedisRaftCtx *rr)
         LOG_NOTICE("Loading: Redis loading complete, snapshot %s",
                    rr->snapshot_info.loaded ? "LOADED" : "NOT LOADED");
 
-        /* If id is configured, confirm the log matches.  If not, we set it from
-         * the log.
+        /* If id is configured, confirm the log matches. If not, we set it from
+         * the metadata file.
          */
         if (!rr->config.id) {
-            rr->config.id = rr->log->node_id;
-        } else {
-            if (rr->config.id != rr->log->node_id) {
-                PANIC("Raft log node id [%d] does not match configured id [%d]",
-                      rr->log->node_id, rr->config.id);
-            }
+            rr->config.id = rr->meta.node_id;
+        }
+
+        if (rr->config.id != rr->log->node_id) {
+            PANIC("Raft log node id [%d] does not match configured id [%d]",
+                  rr->log->node_id, rr->config.id);
+        }
+
+        if (rr->config.id != rr->meta.node_id) {
+            PANIC("Metadata node id [%d] does not match configured id [%d]",
+                  rr->meta.node_id, rr->config.id);
         }
 
         if (!rr->sharding_info->shard_groups_num) {

--- a/src/raft.c
+++ b/src/raft.c
@@ -824,7 +824,7 @@ static int raftPersistMetadata(raft_server_t *raft, void *user_data,
 {
     RedisRaftCtx *rr = user_data;
 
-    int ret = MetadataWrite(&rr->meta, rr->config.log_filename, term, vote);
+    int ret = MetadataWrite(&rr->meta, term, vote);
     if (ret != RR_OK) {
         LOG_WARNING("ERROR: RaftMetaWrite()");
         return RAFT_ERR_SHUTDOWN;

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1062,8 +1062,8 @@ static void clusterInit(const char *cluster_id)
         rr->config.id = makeRandomNodeId(rr);
     }
 
-    MetadataConfigure(&rr->meta, rr->config.log_filename,
-                      rr->snapshot_info.dbid, rr->config.id);
+    MetadataSetClusterConfig(&rr->meta, rr->config.log_filename,
+                             rr->snapshot_info.dbid, rr->config.id);
 
     rr->log = LogCreate(rr->config.log_filename, rr->snapshot_info.dbid,
                         1, 0, rr->config.id);
@@ -1095,8 +1095,8 @@ static void clusterJoinCompleted(RaftReq *req)
         PANIC("Failed to initialize Raft log");
     }
 
-    MetadataConfigure(&rr->meta, rr->config.log_filename,
-                      rr->snapshot_info.dbid, rr->config.id);
+    MetadataSetClusterConfig(&rr->meta, rr->config.log_filename,
+                             rr->snapshot_info.dbid, rr->config.id);
 
     AddBasicLocalShardGroup(rr);
     RaftLibraryInit(rr, false);

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1062,6 +1062,9 @@ static void clusterInit(const char *cluster_id)
         rr->config.id = makeRandomNodeId(rr);
     }
 
+    MetadataConfigure(&rr->meta, rr->config.log_filename,
+                      rr->snapshot_info.dbid, rr->config.id);
+
     rr->log = LogCreate(rr->config.log_filename, rr->snapshot_info.dbid,
                         1, 0, rr->config.id);
     if (!rr->log) {
@@ -1091,6 +1094,9 @@ static void clusterJoinCompleted(RaftReq *req)
     if (!rr->log) {
         PANIC("Failed to initialize Raft log");
     }
+
+    MetadataConfigure(&rr->meta, rr->config.log_filename,
+                      rr->snapshot_info.dbid, rr->config.id);
 
     AddBasicLocalShardGroup(rr);
     RaftLibraryInit(rr, false);
@@ -1975,6 +1981,8 @@ RRStatus RedisRaftCtxInit(RedisRaftCtx *rr, RedisModuleCtx *ctx)
      * Nothing will happen until users will initiate a RAFT.CLUSTER INIT
      * or RAFT.CLUSTER JOIN command.
      */
+    MetadataInit(&rr->meta);
+
     int ret = MetadataRead(&rr->meta, rr->config.log_filename);
     if (ret == RR_OK) {
         rr->log = LogOpen(rr->config.log_filename, false);

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -798,6 +798,14 @@ RRStatus parseHashSlots(char *slots, char *string);
 bool parseLongLong(const char *str, char **end, long long *val);
 bool parseLong(const char *str, char **end, long *val);
 bool parseInt(const char *str, char **end, int *val);
+bool multibulkReadLen(File *fp, char type, int *length);
+bool multibulkReadInt(File *fp, int *value);
+bool multibulkReadLong(File *fp, long *value);
+bool multibulkReadStr(File *fp, char *buf, size_t size);
+int multibulkWriteLen(void *buf, size_t cap, char prefix, int len);
+int multibulkWriteInt(void *buf, size_t cap, int val);
+int multibulkWriteLong(void *buf, size_t cap, long val);
+int multibulkWriteStr(void *buf, size_t cap, const char *val);
 
 /* config.c */
 RRStatus ConfigInit(RedisModuleCtx *ctx, RedisRaftConfig *c);

--- a/src/util.c
+++ b/src/util.c
@@ -137,7 +137,7 @@ void AddBasicLocalShardGroup(RedisRaftCtx *rr)
     RedisModule_Assert(sg != NULL);
 
     sg->local = true;
-    memcpy(sg->id, rr->log->dbid, RAFT_DBID_LEN);
+    memcpy(sg->id, rr->meta.dbid, RAFT_DBID_LEN);
     sg->id[RAFT_DBID_LEN] = '\0';
 
     RRStatus ret = ShardingInfoAddShardGroup(rr, sg);

--- a/tests/unit/test_log.c
+++ b/tests/unit/test_log.c
@@ -514,7 +514,7 @@ static void test_meta_persistence(void **state)
     Metadata m;
 
     MetadataInit(&m);
-    MetadataConfigure(&m, LOGNAME, DBID, 1002);
+    MetadataSetClusterConfig(&m, LOGNAME, DBID, 1002);
 
     assert_int_equal(MetadataRead(&m, LOGNAME), RR_ERROR);
     assert_int_equal(MetadataWrite(&m, 0xffffffff, INT32_MAX), RR_OK);

--- a/tests/unit/test_log.c
+++ b/tests/unit/test_log.c
@@ -513,22 +513,33 @@ static void test_meta_persistence(void **state)
 {
     Metadata m;
 
+    MetadataInit(&m);
+    MetadataConfigure(&m, LOGNAME, DBID, 1002);
+
     assert_int_equal(MetadataRead(&m, LOGNAME), RR_ERROR);
-    assert_int_equal(MetadataWrite(&m, LOGNAME, 0xffffffff, INT32_MAX), RR_OK);
+    assert_int_equal(MetadataWrite(&m, 0xffffffff, INT32_MAX), RR_OK);
     assert_int_equal(MetadataRead(&m, LOGNAME), RR_OK);
+    assert_string_equal(m.dbid, DBID);
+    assert_int_equal(m.node_id, 1002);
     assert_int_equal(m.term, 0xffffffff);
     assert_int_equal(m.vote, INT32_MAX);
 
-    assert_int_equal(MetadataWrite(&m, LOGNAME, LONG_MAX, (int) -1), RR_OK);
+    assert_int_equal(MetadataWrite(&m, LONG_MAX, (int) -1), RR_OK);
     assert_int_equal(MetadataRead(&m, LOGNAME), RR_OK);
+    assert_string_equal(m.dbid, DBID);
+    assert_int_equal(m.node_id, 1002);
     assert_int_equal(m.term, LONG_MAX);
     assert_int_equal(m.vote, -1);
 
     /* Test overwrite */
-    assert_int_equal(MetadataWrite(&m, LOGNAME, 5, 5), RR_OK);
-    assert_int_equal(MetadataWrite(&m, LOGNAME, 6, 6), RR_OK);
+    assert_int_equal(MetadataWrite(&m, 5, 5), RR_OK);
+    assert_int_equal(MetadataWrite(&m, 6, 6), RR_OK);
+    assert_string_equal(m.dbid, DBID);
+    assert_int_equal(m.node_id, 1002);
     assert_int_equal(m.term, 6);
     assert_int_equal(m.vote, 6);
+
+    MetadataTerm(&m);
 }
 
 const struct CMUnitTest log_tests[] = {


### PR DESCRIPTION
Changes in this PR:
- Reuse serialization code between the log and the metadata files.
  Added common functions to `util.c`.
- Added `dbid` and `node_id` to the metadata file. 
  These fields are useful for detecting user error on a file mismatch.
  On start-up,  we verify dbid / node id of the metadata file, 
  snapshot file and log file match. 
- Added `MetadataArchive()`
  Similar to the snapshot and the log file, when the node is removed, 
  it will archive metadata file as well. 
- Replaced some `rr->log->dbid` usages with `rr->meta.dbid`.
  In an upcoming PR, we'll move to a multi-logfile scheme. To prevent
  some extra checks, replaced this usage with metadata access as we
  will always have a single metadata instance. 

PR can be reviewed commit by commit. 