### PR TITLE
Bump elle-cli version

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Build
       run: |
         mkdir build && cd build
-        cmake .. -DPYTEST_OPTS="--redis-executable=redis/src/redis-server --elle-cli=elle-cli/target/elle-cli-0.1.4-standalone.jar --elle-threads=3 -v"
+        cmake .. -DPYTEST_OPTS="--redis-executable=redis/src/redis-server --elle-cli=elle-cli/target/elle-cli-0.1.5-standalone.jar --elle-threads=3 -v"
         make
     - name: Checkout Redis
       uses: actions/checkout@v2

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -55,6 +55,7 @@ jobs:
       with:
         repository: 'ligurio/elle-cli'
         path: 'elle-cli'
+        ref: '0.1.5'
     - name: Build elle-cli
       run: cd elle-cli && lein deps && lein uberjar
     - name: Setup Python for testing

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -46,7 +46,7 @@ def pytest_addoption(parser):
         "--runslow", action="store_true", default=False, help="run slow tests")
     parser.addoption(
         '--elle-cli',
-        default='../elle-cli/target/elle-cli-0.1.4-standalone.jar',
+        default='../elle-cli/target/elle-cli-0.1.5-standalone.jar',
         help='location for elle-cli jar file')
     parser.addoption(
         '--elle-threads', default=0, help='number of elle worker threads')


### PR DESCRIPTION
A new version is released and causing a test failure:
https://github.com/RedisLabs/redisraft/actions/runs/3634573321/jobs/6132789114



