### PR TITLE
[RR-120] Rename files in a durable way

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -97,11 +97,11 @@ int FileFlush(File *file)
 
 int FileFsync(File *file)
 {
-    int rc = fsync(file->fd);
-    if (rc != 0) {
+    int rc = fsyncFile(file->fd);
+    if (rc != RR_OK) {
         LOG_WARNING("error fd:%d, fsync:%s", file->fd, strerror(errno));
     }
-    return rc == 0 ? RR_OK : RR_ERROR;
+    return rc;
 }
 
 /* Set read position of the file. Required before read functions. */

--- a/src/fsync.c
+++ b/src/fsync.c
@@ -65,8 +65,8 @@ static void *fsyncLoop(void *arg)
         pthread_mutex_unlock(&th->mtx);
 
         uint64_t begin = RedisModule_MonotonicMicroseconds();
-        rc = fsync(fd);
-        if (rc != 0) {
+        rc = fsyncFile(fd);
+        if (rc != RR_OK) {
             PANIC("fsync(): %s \n", strerror(errno));
         }
 

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -95,8 +95,9 @@ int MetadataWrite(Metadata *m, raft_term_t term, raft_node_id_t vote)
         PANIC("FileTerm(): %s", strerror(errno));
     }
 
-    if (rename(tmp, m->filename) != 0) {
-        PANIC("rename(): %s", strerror(errno));
+    if (fsyncFileAt(tmp) != RR_OK ||
+        syncRename(tmp, m->filename) != RR_OK) {
+        return RR_ERROR;
     }
 
     m->term = term;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -810,6 +810,10 @@ int multibulkWriteLen(void *buf, size_t cap, char prefix, int len);
 int multibulkWriteInt(void *buf, size_t cap, int val);
 int multibulkWriteLong(void *buf, size_t cap, long val);
 int multibulkWriteStr(void *buf, size_t cap, const char *val);
+int fsyncFile(int fd);
+int fsyncFileAt(const char *path);
+void fsyncDir(const char *path);
+int syncRename(const char *oldname, const char *newname);
 
 /* config.c */
 RRStatus ConfigInit(RedisModuleCtx *ctx, RedisRaftConfig *c);

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -269,7 +269,7 @@ RRStatus finalizeSnapshot(RedisRaftCtx *rr, SnapshotResult *sr)
      * data if we fail now before renaming the log -- all we'll have to do is
      * skip redundant log entries.
      */
-    if (rename(sr->rdb_filename, rr->config.rdb_filename) < 0) {
+    if (syncRename(sr->rdb_filename, rr->config.rdb_filename) != RR_OK) {
         LOG_WARNING("Failed to switch snapshot filename (%s to %s): %s",
                     sr->rdb_filename, rr->config.rdb_filename, strerror(errno));
         cancelSnapshot(rr, sr);
@@ -546,7 +546,6 @@ void loadPendingSnapshot(RedisRaftCtx *rr)
 int raftLoadSnapshot(raft_server_t *raft, void *user_data, raft_term_t term,
                      raft_index_t index)
 {
-    int ret;
     RedisRaftCtx *rr = user_data;
 
     if (rr->snapshot_in_progress || rr->state == REDIS_RAFT_LOADING) {
@@ -562,8 +561,12 @@ int raftLoadSnapshot(raft_server_t *raft, void *user_data, raft_term_t term,
 
     LOG_NOTICE("Received snapshot file, size: %lld", (long long) st.st_size);
 
-    ret = rename(rr->incoming_snapshot_file, rr->config.rdb_filename);
-    if (ret != 0) {
+    if (fsyncFileAt(rr->incoming_snapshot_file) != RR_OK) {
+        return -1;
+    }
+
+    int rc = syncRename(rr->incoming_snapshot_file, rr->config.rdb_filename);
+    if (rc != RR_OK) {
         LOG_WARNING("rename(): %s to %s failed with error: %s",
                     rr->incoming_snapshot_file, rr->config.rdb_filename,
                     strerror(errno));


### PR DESCRIPTION
This PR introduces:

- `fsyncFile()` : A wrapper to support fsync on MacOS. fsync() on  
     MacOS does not persist data to the disk. It requires 
     `fcntl(fd, F_FULLSYNC)` call.
   
- Proper fsync usage
   - Directory operations require fsync() on the directory.
       e.g creation or deletion of files require fsync on the directory. 
    
  - To rename files in a durable way
    - Both files should be under same filesystem
    - fsync() must be called for the both files
    - After rename(), fsync must be called for the directory. 