### PR TITLE
[RR-146] Migrate/Import issued to not ready cluster crashes

### DIFF
--- a/src/migrate.c
+++ b/src/migrate.c
@@ -140,6 +140,10 @@ int cmdRaftImport(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 {
     RedisRaftCtx *rr = &redis_raft;
 
+    if (checkRaftState(rr, ctx) == RR_ERROR) {
+        return REDISMODULE_OK;
+    }
+
     /* argc must be at least 5, for 3 static args (cmd/migration_session_key/term) + 2 for 1 key
      * and must be odd, due to 2 args needed for each key
      */

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -501,6 +501,10 @@ exit:
 
 static void handleMigrateCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommand *cmd)
 {
+    if (checkRaftState(rr, ctx) == RR_ERROR) {
+        return;
+    }
+
     if (rr->migrate_req != NULL) {
         RedisModule_ReplyWithError(ctx, "ERR RedisRaft only supports one concurrent migration currently");
         return;

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -635,17 +635,19 @@ def test_migrate_fail_if_not_ready(cluster):
     cluster2 = None
 
     try:
-        cluster1 = RedisRaft(1, cluster.base_port, cluster.config, raft_args={
-            'sharding': 'yes',
-            'external-sharding': 'yes'
-        })
+        cluster1 = RedisRaft(1, cluster.base_port, cluster.config,
+                             raft_args={
+                                 'sharding': 'yes',
+                                 'external-sharding': 'yes'
+                             })
         cluster1.start()
         assert cluster1.info()["raft_state"] == "uninitialized"
 
-        cluster2 = RedisRaft(1, cluster.base_port+1, cluster.config, raft_args={
-            'sharding': 'yes',
-            'external-sharding': 'yes'
-        })
+        cluster2 = RedisRaft(1, cluster.base_port+1, cluster.config,
+                             raft_args={
+                                 'sharding': 'yes',
+                                 'external-sharding': 'yes'
+                             })
         cluster2.init()
 
         cluster2.execute("set", "key", "value")
@@ -663,7 +665,8 @@ def test_migrate_fail_if_not_ready(cluster):
             "{}00000001".format(cluster2_dbid).encode(), cluster2.address,
         ) == b'OK'
 
-        with raises(ResponseError, match="RAFT.IMPORT failed: NOCLUSTER No Raft Cluster"):
+        with raises(ResponseError,
+                    match="RAFT.IMPORT failed: NOCLUSTER No Raft Cluster"):
             cluster2.execute('migrate', '', '', '', '', '', 'keys', "key")
     finally:
         if cluster1 is not None:


### PR DESCRIPTION
- add a test that duplicates bug as is
- prevent migrate command and import from attempting to run on a not ready cluster