### PR TITLE
Clean up unused code, include statements and asserts

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -389,7 +389,7 @@ RRStatus ConnConnect(Connection *conn, const NodeAddr *addr, ConnectionCallbackF
 {
     CONN_TRACE(conn, "ConnConnect: connecting %s:%u.", addr->host, addr->port);
 
-    assert(ConnIsIdle(conn));
+    RedisModule_Assert(ConnIsIdle(conn));
 
     conn->addr = *addr;
     conn->state = CONN_RESOLVING;

--- a/src/connection.c
+++ b/src/connection.c
@@ -8,7 +8,6 @@
 #include "redisraft.h"
 
 #include <arpa/inet.h>
-#include <assert.h>
 #include <netdb.h>
 #include <string.h>
 

--- a/src/fsync.c
+++ b/src/fsync.c
@@ -6,7 +6,6 @@
 
 #include "redisraft.h"
 
-#include <errno.h>
 #include <pthread.h>
 #include <string.h>
 

--- a/src/join.c
+++ b/src/join.c
@@ -60,7 +60,7 @@ static void handleNodeAddResponse(redisAsyncContext *c, void *r, void *privdata)
 
         rr->config.id = reply->element[0]->integer;
         state->complete_callback(state->req);
-        assert(rr->state == REDIS_RAFT_UP);
+        RedisModule_Assert(rr->state == REDIS_RAFT_UP);
 
         ConnAsyncTerminate(conn);
     }

--- a/src/join.c
+++ b/src/join.c
@@ -16,7 +16,6 @@
 
 #include "redisraft.h"
 
-#include <assert.h>
 #include <string.h>
 
 /* Callback for the RAFT.NODE ADD command.

--- a/src/log.c
+++ b/src/log.c
@@ -12,7 +12,6 @@
 
 #include "common/sc_crc32.h"
 
-#include <assert.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/log.c
+++ b/src/log.c
@@ -897,7 +897,7 @@ static void logImplReset(void *arg, raft_index_t index, raft_term_t term)
     /* Note: the RaftLogImpl API specifies the specified index is the one
      * to be assigned to the *next* entry, hence the adjustments below.
      */
-    assert(index >= 1);
+    RedisModule_Assert(index >= 1);
     LogReset(&rr->log, index - 1, term);
 
     RAFTLOG_TRACE("Reset(index=%lu,term=%lu)", index, term);

--- a/src/raft.c
+++ b/src/raft.c
@@ -8,7 +8,6 @@
 #include "log.h"
 #include "redisraft.h"
 
-#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>

--- a/src/raft.c
+++ b/src/raft.c
@@ -960,7 +960,9 @@ void raftNotifyMembershipEvent(raft_server_t *raft, void *user_data,
             }
 
             /* Ignore our own node, as we don't maintain a Node structure for it */
-            assert(entry->type == RAFT_LOGTYPE_ADD_NODE || entry->type == RAFT_LOGTYPE_ADD_NONVOTING_NODE);
+            RedisModule_Assert(entry->type == RAFT_LOGTYPE_ADD_NODE ||
+                               entry->type == RAFT_LOGTYPE_ADD_NONVOTING_NODE);
+
             cfgchange = (RaftCfgChange *) entry->data;
             if (cfgchange->id == my_id) {
                 break;
@@ -968,7 +970,7 @@ void raftNotifyMembershipEvent(raft_server_t *raft, void *user_data,
 
             /* Allocate a new node */
             node = NodeCreate(rr, cfgchange->id, &cfgchange->addr);
-            assert(node != NULL);
+            RedisModule_Assert(node != NULL);
 
             addUsedNodeId(rr, cfgchange->id);
 
@@ -984,7 +986,7 @@ void raftNotifyMembershipEvent(raft_server_t *raft, void *user_data,
             break;
 
         default:
-            assert(0);
+            RedisModule_Assert(0);
     }
 }
 
@@ -1303,7 +1305,7 @@ void callRaftPeriodic(RedisModuleCtx *ctx, void *arg)
         shutdownAfterRemoval(rr);
     }
 
-    assert(ret == 0);
+    RedisModule_Assert(ret == 0);
 
     /* Compact cache */
     if (rr->config.log_max_cache_size) {

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -12,7 +12,6 @@
 #include "common/sc_crc32.h"
 
 #include <dlfcn.h>
-#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -257,10 +257,6 @@ void cancelSnapshot(RedisRaftCtx *rr, SnapshotResult *sr)
 
 RRStatus finalizeSnapshot(RedisRaftCtx *rr, SnapshotResult *sr)
 {
-    char temp_log_filename[256];
-    snprintf(temp_log_filename, sizeof(temp_log_filename) - 1, "%s.tmp",
-             rr->config.log_filename);
-
     RedisModule_Assert(rr->snapshot_in_progress);
 
     LOG_DEBUG("Finalizing snapshot.");

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -8,7 +8,6 @@
 #include "log.h"
 #include "redisraft.h"
 
-#include <assert.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -196,7 +196,7 @@ static SnapshotCfgEntry *generateSnapshotCfgEntryList(RedisRaftCtx *rr)
         } else if (node != NULL) {
             na = &node->addr;
         } else {
-            assert(0);
+            RedisModule_Assert(0);
         }
 
         *entry = RedisModule_Calloc(1, sizeof(SnapshotCfgEntry));
@@ -243,7 +243,7 @@ static void resetSnapshotState(RedisRaftCtx *rr)
 
 void cancelSnapshot(RedisRaftCtx *rr, SnapshotResult *sr)
 {
-    assert(rr->snapshot_in_progress);
+    RedisModule_Assert(rr->snapshot_in_progress);
 
     raft_cancel_snapshot(rr->raft);
     resetSnapshotState(rr);
@@ -261,7 +261,7 @@ RRStatus finalizeSnapshot(RedisRaftCtx *rr, SnapshotResult *sr)
     snprintf(temp_log_filename, sizeof(temp_log_filename) - 1, "%s.tmp",
              rr->config.log_filename);
 
-    assert(rr->snapshot_in_progress);
+    RedisModule_Assert(rr->snapshot_in_progress);
 
     LOG_DEBUG("Finalizing snapshot.");
 
@@ -613,7 +613,7 @@ static int rdbLoadSnapshotInfo(RedisModuleIO *rdb, int encver, int when)
 
     /* dbid */
     buf = RedisModule_LoadStringBuffer(rdb, &len);
-    assert(len <= RAFT_DBID_LEN);
+    RedisModule_Assert(len <= RAFT_DBID_LEN);
     if (len) {
         memcpy(info->dbid, buf, len);
     }
@@ -648,7 +648,7 @@ static int rdbLoadSnapshotInfo(RedisModuleIO *rdb, int encver, int when)
         buf = RedisModule_LoadStringBuffer(rdb, &len);
         entry->addr.port = RedisModule_LoadUnsigned(rdb);
 
-        assert(len < sizeof(entry->addr.host));
+        RedisModule_Assert(len < sizeof(entry->addr.host));
         memcpy(entry->addr.host, buf, len);
         RedisModule_Free(buf);
     } while (1);

--- a/src/util.c
+++ b/src/util.c
@@ -9,7 +9,6 @@
 
 #include "common/crc16.h"
 
-#include <ctype.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
- Delete unused include statements
- Delete unused variable in snapshot.c
- Use `RedisModule_Assert()` instead of `assert()` 
  - `assert()` can be stripped from executable depending on compiler flags. 
     This is not the case with `RedisModule_Assert()`. 
  - `RedisModule_Assert()` prints the backtrace