### PR TITLE
[RR-158] Use redis client-id as raft session.

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -751,7 +751,7 @@ static int raftSendAppendEntries(raft_server_t *raft, void *user_data,
     for (i = 0; i < msg->n_entries; i++) {
         raft_entry_t *e = msg->entries[i];
         argv[5 + i * 2] = RedisModule_Alloc(64);
-        argvlen[5 + i * 2] = snprintf(argv[5 + i * 2], 63, "%ld:%d:%lld:%d", e->term, e->id, e->session, e->type);
+        argvlen[5 + i * 2] = snprintf(argv[5 + i * 2], 63, "%ld:%d:%llu:%d", e->term, e->id, e->session, e->type);
         argvlen[6 + i * 2] = e->data_len;
         argv[6 + i * 2] = e->data;
     }

--- a/src/raft.c
+++ b/src/raft.c
@@ -543,6 +543,7 @@ static void executeLogEntry(RedisRaftCtx *rr, raft_entry_t *entry, raft_index_t 
                                              entry->data_len) != RR_OK) {
             PANIC("Invalid Raft entry");
         }
+        tmp.client_id = entry->session;
 
         RaftExecuteCommandArray(rr, rr->ctx, NULL, &tmp);
         RaftRedisCommandArrayFree(&tmp);
@@ -750,7 +751,7 @@ static int raftSendAppendEntries(raft_server_t *raft, void *user_data,
     for (i = 0; i < msg->n_entries; i++) {
         raft_entry_t *e = msg->entries[i];
         argv[5 + i * 2] = RedisModule_Alloc(64);
-        argvlen[5 + i * 2] = snprintf(argv[5 + i * 2], 63, "%ld:%d:%d", e->term, e->id, e->type);
+        argvlen[5 + i * 2] = snprintf(argv[5 + i * 2], 63, "%ld:%d:%lld:%d", e->term, e->id, e->session, e->type);
         argvlen[6 + i * 2] = e->data_len;
         argv[6 + i * 2] = e->data;
     }

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -930,7 +930,7 @@ static int cmdRaftAppendEntries(RedisModuleCtx *ctx, RedisModuleString **argv, i
 
         /* Parse additional entry fields */
         tmpstr = RedisModule_StringPtrLen(argv[5 + 2 * i], &tmplen);
-        if (sscanf(tmpstr, "%ld:%d:%lld:%d", &e->term, &e->id, &e->session, &e->type) != 4) {
+        if (sscanf(tmpstr, "%ld:%d:%llu:%d", &e->term, &e->id, &e->session, &e->type) != 4) {
             RedisModule_ReplyWithError(ctx, "invalid entry");
             goto out;
         }

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -806,6 +806,7 @@ static int cmdRaft(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 
     RaftRedisCommandArray cmds = {0};
     RaftRedisCommand *cmd = RaftRedisCommandArrayExtend(&cmds);
+    cmds.client_id = RedisModule_GetClientId(ctx);
 
     cmd->argc = argc - 1;
     cmd->argv = RedisModule_Alloc((argc - 1) * sizeof(RedisModuleString *));
@@ -853,7 +854,7 @@ static int cmdRaftEntry(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 
 /* RAFT.AE [target_node_id] [src_node_id]
  *         [leader_id]:[term]:[prev_log_idx]:[prev_log_term]:[leader_commit]:[msg_id]
- *         [n_entries] [<term>:<id>:<type> <entry>]...
+ *         [n_entries] [<term>:<id>:<session>:<type> <entry>]...
  *
  *   A leader request to append entries to the Raft log (per Raft paper).
  * Reply:
@@ -929,7 +930,7 @@ static int cmdRaftAppendEntries(RedisModuleCtx *ctx, RedisModuleString **argv, i
 
         /* Parse additional entry fields */
         tmpstr = RedisModule_StringPtrLen(argv[5 + 2 * i], &tmplen);
-        if (sscanf(tmpstr, "%ld:%d:%d", &e->term, &e->id, &e->type) != 3) {
+        if (sscanf(tmpstr, "%ld:%d:%lld:%d", &e->term, &e->id, &e->session, &e->type) != 4) {
             RedisModule_ReplyWithError(ctx, "invalid entry");
             goto out;
         }

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -505,9 +505,10 @@ typedef struct {
 } RaftRedisCommand;
 
 typedef struct {
-    bool asking; /* if this command array is in an asking mode */
-    int size;    /* Size of allocated array */
-    int len;     /* Number of elements in array */
+    unsigned long long client_id; /* client id for maintaining sessions */
+    bool asking;                  /* if this command array is in an asking mode */
+    int size;                     /* Size of allocated array */
+    int len;                      /* Number of elements in array */
     RaftRedisCommand **commands;
     RedisModuleString *acl;
 } RaftRedisCommandArray;
@@ -805,10 +806,12 @@ bool parseInt(const char *str, char **end, int *val);
 bool multibulkReadLen(File *fp, char type, int *length);
 bool multibulkReadInt(File *fp, int *value);
 bool multibulkReadLong(File *fp, long *value);
+bool multibulkReadUInt64(File *fp, unsigned long long *value);
 bool multibulkReadStr(File *fp, char *buf, size_t size);
 int multibulkWriteLen(void *buf, size_t cap, char prefix, int len);
 int multibulkWriteInt(void *buf, size_t cap, int val);
 int multibulkWriteLong(void *buf, size_t cap, long val);
+int multibulkWriteUInt64(void *buf, size_t cap, unsigned long long val);
 int multibulkWriteStr(void *buf, size_t cap, const char *val);
 int fsyncFile(int fd);
 int fsyncFileAt(const char *path);

--- a/src/util.c
+++ b/src/util.c
@@ -285,6 +285,24 @@ bool parseLongLong(const char *str, char **end, long long *val)
     return true;
 }
 
+bool parseULongLong(const char *str, char **end, unsigned long long *val)
+{
+    char *endp;
+
+    errno = 0;
+    *val = strtoull(str, &endp, 0);
+
+    if (end) {
+        *end = endp;
+    }
+
+    if (endp == str || (*val == UINT64_MAX && errno == ERANGE)) {
+        return false;
+    }
+
+    return true;
+}
+
 bool parseLong(const char *str, char **end, long *val)
 {
     long long num;
@@ -353,6 +371,18 @@ bool multibulkReadLong(File *fp, long *value)
     return true;
 }
 
+bool multibulkReadUInt64(File *fp, unsigned long long *value)
+{
+    char buf[64] = {0};
+
+    if (!multibulkReadStr(fp, buf, sizeof(buf)) ||
+        !parseULongLong(buf, NULL, value)) {
+        return false;
+    }
+
+    return true;
+}
+
 bool multibulkReadStr(File *fp, char *buf, size_t size)
 {
     int len;
@@ -387,6 +417,12 @@ int multibulkWriteLong(void *buf, size_t cap, long val)
 {
     int len = lensnprintf("%ld", val);
     return safesnprintf(buf, cap, "$%d\r\n%ld\r\n", len, val);
+}
+
+int multibulkWriteUInt64(void *buf, size_t cap, unsigned long long val)
+{
+    int len = lensnprintf("%llu", val);
+    return safesnprintf(buf, cap, "$%d\r\n%llu\r\n", len, val);
 }
 
 int multibulkWriteStr(void *buf, size_t cap, const char *val)

--- a/tests/integration/raftlog.py
+++ b/tests/integration/raftlog.py
@@ -117,8 +117,11 @@ class LogEntry(RawEntry):
     def id(self):
         return int(self.args[2])
 
+    def session(self):
+        return int(self.args[3])
+
     def type(self):
-        return self.LogType(int(self.args[3]))
+        return self.LogType(int(self.args[4]))
 
     def type_is_cfgchange(self):
         _type = self.type()
@@ -154,7 +157,7 @@ class LogEntry(RawEntry):
         return '|'.join(cmds)
 
     def data(self, decode=False):
-        value = self.args[4]
+        value = self.args[5]
         if self.type_is_cfgchange():
             return self.parse_cfgchange(value)
         elif self.type() == self.LogType.ADD_SHARDGROUP:
@@ -178,12 +181,13 @@ class LogEntry(RawEntry):
         return int(self.locations[5])
 
     def __repr__(self):
-        return '<LogEntry:%s:id=%s,term=%s,data=%s>' % (
-            self.type(), self.id(), self.term(), self.data())
+        return '<LogEntry:%s:id=%s,term=%s,session=%s,data=%s>' % (
+            self.type(), self.id(), self.term(), self.session(), self.data())
 
     def __str__(self):
-        return '{:4d} {:10d} {} {}'.format(
-            self.term(), self.id(), self.type().name, self.data(decode=True))
+        return '{:4d} {:10d} {} {} {}'.format(
+            self.term(), self.id(), self.session(), self.type().name,
+            self.data(decode=True))
 
 
 class RaftLog(object):


### PR DESCRIPTION
* serialize/deserialize it to log file
	- also make decodeInteger/encodeInteger take an unsigned long long instead of size_t
* send it as part of AppendEntry RPC and recieve it correctly
* update unit tests to expect and work with session in raft entry.