### PR TITLE
[RR-159] setup/teardown sessions on the log

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -20,8 +20,6 @@ static const CommandSpec commands[] = {
     {"slaveof",                     CMD_SPEC_UNSUPPORTED                     },
     {"replicaof",                   CMD_SPEC_UNSUPPORTED                     },
     {"debug",                       CMD_SPEC_UNSUPPORTED                     },
-    {"watch",                       CMD_SPEC_UNSUPPORTED                     },
-    {"unwatch",                     CMD_SPEC_UNSUPPORTED                     },
     {"save",                        CMD_SPEC_UNSUPPORTED                     },
     {"bgsave",                      CMD_SPEC_UNSUPPORTED                     },
 

--- a/src/log.c
+++ b/src/log.c
@@ -138,6 +138,7 @@ static size_t generateEntryHeader(raft_entry_t *ety, unsigned char *buf, size_t 
     pos += multibulkWriteLong(pos, end - pos, ety->id);
     pos += multibulkWriteUInt64(pos, end - pos, ety->session);
     pos += multibulkWriteInt(pos, end - pos, ety->type);
+
     pos += multibulkWriteLen(pos, end - pos, '$', (int) ety->data_len);
 
     return pos - buf;

--- a/src/multi.c
+++ b/src/multi.c
@@ -103,6 +103,12 @@ bool MultiHandleCommand(RedisRaftCtx *rr,
 
     /* Are we in MULTI? */
     if (multiState->active) {
+        /* can't call WATCH within a MULTI, but doesn't error out MULTI */
+        if (cmd_len == 5 && !strncasecmp(cmd_str, "WATCH", 5)) {
+            RedisModule_ReplyWithError(ctx, "ERR WATCH inside MULTI is not allowed");
+            return true;
+        }
+
         /* We have to detect commands that are unsupported or must not be
          * intercepted and reject the transaction.
          */

--- a/src/raft.c
+++ b/src/raft.c
@@ -367,7 +367,7 @@ void RaftExecuteCommandArray(RedisRaftCtx *rr,
     }
 
     void *client_session = getClientSession(rr, cmds);
-    (void) client_sessions;
+    (void) client_session;
 
     for (int i = 0; i < cmds->len; i++) {
         RaftRedisCommand *c = cmds->commands[i];

--- a/src/raft.c
+++ b/src/raft.c
@@ -948,6 +948,7 @@ static int raftApplyLog(raft_server_t *raft, void *user_data, raft_entry_t *entr
             break;
         case RAFT_LOGTYPE_END_SESSION:
             handleEndClientSession(rr, entry);
+            break;
         default:
             break;
     }

--- a/src/raft.c
+++ b/src/raft.c
@@ -367,7 +367,7 @@ void RaftExecuteCommandArray(RedisRaftCtx *rr,
     }
 
     void *client_session = getClientSession(rr, cmds);
-    if (client_session) {} /* avoid unused variable check */
+    (void) client_sessions;
 
     for (int i = 0; i < cmds->len; i++) {
         RaftRedisCommand *c = cmds->commands[i];

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -419,7 +419,7 @@ typedef struct RedisRaftCtx {
     unsigned long exec_throttled;                /* Number of command executions throttled due to slow execution */
 
     int entered_eval;                     /* handling a lua script */
-    RedisModuleDict *locked_keys;         /* keys thar have been locked for migration */
+    RedisModuleDict *locked_keys;         /* keys that have been locked for migration */
     RedisModuleDict *acl_dict;            /* maps acl strings to RedisModuleUser * objects */
     RedisModuleDict *client_session_dict; /* maps session IDs to Session Objects */
 } RedisRaftCtx;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -418,10 +418,10 @@ typedef struct RedisRaftCtx {
     unsigned long snapshotreq_received;          /* Number of received snapshotreq messages */
     unsigned long exec_throttled;                /* Number of command executions throttled due to slow execution */
 
-    int entered_eval;              /* handling a lua script */
-    RedisModuleDict *locked_keys;  /* keys thar have been locked for migration */
-    RedisModuleDict *acl_dict;     /* maps acl strings to RedisModuleUser * objects */
-    RedisModuleDict *session_dict; /* maps session IDs to Session Objects */
+    int entered_eval;                     /* handling a lua script */
+    RedisModuleDict *locked_keys;         /* keys thar have been locked for migration */
+    RedisModuleDict *acl_dict;            /* maps acl strings to RedisModuleUser * objects */
+    RedisModuleDict *client_session_dict; /* maps session IDs to Session Objects */
 } RedisRaftCtx;
 
 extern RedisRaftCtx redis_raft;

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -418,9 +418,10 @@ typedef struct RedisRaftCtx {
     unsigned long snapshotreq_received;          /* Number of received snapshotreq messages */
     unsigned long exec_throttled;                /* Number of command executions throttled due to slow execution */
 
-    int entered_eval;             /* handling a lua script */
-    RedisModuleDict *locked_keys; /* keys thar have been locked for migration */
-    RedisModuleDict *acl_dict;    /* maps acl strings to RedisModuleUser * objects */
+    int entered_eval;              /* handling a lua script */
+    RedisModuleDict *locked_keys;  /* keys thar have been locked for migration */
+    RedisModuleDict *acl_dict;     /* maps acl strings to RedisModuleUser * objects */
+    RedisModuleDict *session_dict; /* maps session IDs to Session Objects */
 } RedisRaftCtx;
 
 extern RedisRaftCtx redis_raft;
@@ -489,6 +490,7 @@ enum RaftReqType {
     RR_IMPORT_KEYS,
     RR_MIGRATE_KEYS,
     RR_DELETE_UNLOCK_KEYS,
+    RR_END_SESSION,
     RR_RAFTREQ_MAX
 };
 
@@ -578,6 +580,7 @@ typedef struct ShardGroup {
 #define RAFT_LOGTYPE_LOCK_KEYS           (RAFT_LOGTYPE_NUM + 4)
 #define RAFT_LOGTYPE_DELETE_UNLOCK_KEYS  (RAFT_LOGTYPE_NUM + 5)
 #define RAFT_LOGTYPE_IMPORT_KEYS         (RAFT_LOGTYPE_NUM + 6)
+#define RAFT_LOGTYPE_END_SESSION         (RAFT_LOGTYPE_NUM + 7)
 
 #define MAX_AUTH_STRING_ARG_LENGTH 255
 

--- a/src/serialization.c
+++ b/src/serialization.c
@@ -53,6 +53,7 @@ void RaftRedisCommandArrayMove(RaftRedisCommandArray *target, RaftRedisCommandAr
     }
 
     target->asking |= source->asking;
+    target->client_id = source->client_id;
 }
 
 /* Free a RaftRedisCommand */


### PR DESCRIPTION
handle watch/unwatch at a basic level to support sessions on the log
    
doesn't do anything with it besides allocating a void * on session creation and free on session deletion.
    
includes metrics to count number of active sessions for testing purposes