### PR TITLE
[RR-155] Log system call failures

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -52,15 +52,21 @@ int FileOpen(File *file, const char *filename, int flags)
 
     fd = open(filename, flags, S_IWUSR | S_IRUSR);
     if (fd < 0) {
+        int saved_errno = errno;
         if (errno != ENOENT) {
             LOG_WARNING("error, fd: %d, open(): %s", file->fd, strerror(errno));
         }
+        errno = saved_errno;
+
         return RR_ERROR;
     }
 
     if (stat(filename, &st) != 0) {
+        int saved_errno = errno;
         LOG_WARNING("error, fd: %d, stat(): %s", file->fd, strerror(errno));
         close(fd);
+        errno = saved_errno;
+
         return RR_ERROR;
     }
 

--- a/src/file.c
+++ b/src/file.c
@@ -52,6 +52,9 @@ int FileOpen(File *file, const char *filename, int flags)
 
     fd = open(filename, flags, S_IWUSR | S_IRUSR);
     if (fd < 0) {
+        if (errno != ENOENT) {
+            LOG_WARNING("error, fd: %d, open(): %s", file->fd, strerror(errno));
+        }
         return RR_ERROR;
     }
 

--- a/src/file.c
+++ b/src/file.c
@@ -35,7 +35,7 @@ int FileTerm(File *file)
     file->fd = -1;
 
     if (close(fd) != 0) {
-        LOG_WARNING("error, fd:%d, close():%s", file->fd, strerror(errno));
+        LOG_WARNING("error, fd: %d, close(): %s", file->fd, strerror(errno));
         return RR_ERROR;
     }
 
@@ -56,7 +56,7 @@ int FileOpen(File *file, const char *filename, int flags)
     }
 
     if (stat(filename, &st) != 0) {
-        LOG_WARNING("error, fd:%d, stat():%s", file->fd, strerror(errno));
+        LOG_WARNING("error, fd: %d, stat(): %s", file->fd, strerror(errno));
         close(fd);
         return RR_ERROR;
     }
@@ -84,7 +84,7 @@ int FileFlush(File *file)
 
         ssize_t wr = write(file->fd, wbegin, count);
         if (wr < 0) {
-            LOG_WARNING("error, fd:%d, write():%s", file->fd, strerror(errno));
+            LOG_WARNING("error, fd: %d, write(): %s", file->fd, strerror(errno));
             return RR_ERROR;
         }
 
@@ -102,7 +102,7 @@ int FileFsync(File *file)
 {
     int rc = fsyncFile(file->fd);
     if (rc != RR_OK) {
-        LOG_WARNING("error fd:%d, fsync():%s", file->fd, strerror(errno));
+        LOG_WARNING("error fd:%d, fsync(): %s", file->fd, strerror(errno));
     }
     return rc;
 }
@@ -120,7 +120,7 @@ int FileSetReadOffset(File *file, size_t offset)
 
     off_t ret = lseek(file->fd, (off_t) offset, SEEK_SET);
     if (ret != (off_t) offset) {
-        LOG_WARNING("error, fd:%d, lseek():%s", file->fd, strerror(errno));
+        LOG_WARNING("error, fd: %d, lseek(): %s", file->fd, strerror(errno));
         return RR_ERROR;
     }
 
@@ -299,7 +299,7 @@ int FileTruncate(File *file, size_t len)
     }
 
     if (ftruncate(file->fd, (off_t) len) != 0) {
-        LOG_WARNING("error, fd:%d, ftruncate():%s", file->fd, strerror(errno));
+        LOG_WARNING("error, fd: %d, ftruncate(): %s", file->fd, strerror(errno));
         return RR_ERROR;
     }
 

--- a/src/file.c
+++ b/src/file.c
@@ -35,6 +35,7 @@ int FileTerm(File *file)
     file->fd = -1;
 
     if (close(fd) != 0) {
+        LOG_WARNING("error, fd:%d, close():%s", file->fd, strerror(errno));
         return RR_ERROR;
     }
 
@@ -55,6 +56,7 @@ int FileOpen(File *file, const char *filename, int flags)
     }
 
     if (stat(filename, &st) != 0) {
+        LOG_WARNING("error, fd:%d, stat():%s", file->fd, strerror(errno));
         close(fd);
         return RR_ERROR;
     }
@@ -82,7 +84,7 @@ int FileFlush(File *file)
 
         ssize_t wr = write(file->fd, wbegin, count);
         if (wr < 0) {
-            LOG_WARNING("error, fd:%d, write:%s", file->fd, strerror(errno));
+            LOG_WARNING("error, fd:%d, write():%s", file->fd, strerror(errno));
             return RR_ERROR;
         }
 
@@ -100,7 +102,7 @@ int FileFsync(File *file)
 {
     int rc = fsyncFile(file->fd);
     if (rc != RR_OK) {
-        LOG_WARNING("error fd:%d, fsync:%s", file->fd, strerror(errno));
+        LOG_WARNING("error fd:%d, fsync():%s", file->fd, strerror(errno));
     }
     return rc;
 }
@@ -118,6 +120,7 @@ int FileSetReadOffset(File *file, size_t offset)
 
     off_t ret = lseek(file->fd, (off_t) offset, SEEK_SET);
     if (ret != (off_t) offset) {
+        LOG_WARNING("error, fd:%d, lseek():%s", file->fd, strerror(errno));
         return RR_ERROR;
     }
 
@@ -257,6 +260,7 @@ ssize_t FileWrite(File *file, void *buf, size_t len)
     while (true) {
         count = writev(file->fd, iov, iovcnt);
         if (count < 0) {
+            LOG_WARNING("error, fd:%d, writev():%s", file->fd, strerror(errno));
             return -1;
         }
 
@@ -290,8 +294,12 @@ size_t FileGetReadOffset(File *file)
 
 int FileTruncate(File *file, size_t len)
 {
-    if (FileFlush(file) != RR_OK ||
-        ftruncate(file->fd, (off_t) len) != 0) {
+    if (FileFlush(file) != RR_OK) {
+        return RR_ERROR;
+    }
+
+    if (ftruncate(file->fd, (off_t) len) != 0) {
+        LOG_WARNING("error, fd:%d, ftruncate():%s", file->fd, strerror(errno));
         return RR_ERROR;
     }
 

--- a/src/file.c
+++ b/src/file.c
@@ -25,17 +25,18 @@ void FileInit(File *file)
 int FileTerm(File *file)
 {
     int rc;
+    int fd = file->fd;
 
-    if (file->fd == -1) {
+    if (fd == -1) {
         return RR_OK;
     }
 
     rc = FileFlush(file);
+    file->fd = -1;
 
-    if (close(file->fd) != 0) {
+    if (close(fd) != 0) {
         return RR_ERROR;
     }
-    file->fd = -1;
 
     return rc;
 }

--- a/src/file.c
+++ b/src/file.c
@@ -253,32 +253,32 @@ ssize_t FileWrite(File *file, void *buf, size_t len)
     };
 
     struct iovec *iov = iovs;
-    size_t rem = iov[0].iov_len + iov[1].iov_len;
-    int iovcnt = 2;
+    size_t remaining = iov[0].iov_len + iov[1].iov_len;
+    const int IOV_COUNT = 2;
+    int current_iov = 0;
     ssize_t count;
 
     while (true) {
-        count = writev(file->fd, iov, iovcnt);
+        count = writev(file->fd, iov, IOV_COUNT - current_iov);
         if (count < 0) {
             LOG_WARNING("error, fd:%d, writev():%s", file->fd, strerror(errno));
             return -1;
         }
 
-        if ((size_t) count == rem) {
+        if ((size_t) count == remaining) {
             file->wpos = file->buf;
             file->woffset += len;
             return (ssize_t) len;
         }
 
-        rem -= count;
-        if ((size_t) count > iov[0].iov_len) {
-            count -= (ssize_t) iov[0].iov_len;
-            iov++;
-            iovcnt--;
+        remaining -= count;
+        if ((size_t) count > iov[current_iov].iov_len) {
+            count -= (ssize_t) iov[current_iov].iov_len;
+            current_iov++;
         }
 
-        iov[0].iov_base = (char *) iov[0].iov_base + count;
-        iov[0].iov_len -= count;
+        iov[current_iov].iov_base = (char *) iov[current_iov].iov_base + count;
+        iov[current_iov].iov_len -= count;
     }
 }
 

--- a/src/log.c
+++ b/src/log.c
@@ -724,7 +724,7 @@ int LogSync(Log *log, bool sync)
     uint64_t begin = RedisModule_MonotonicMicroseconds();
 
     if (pageSync(curr, sync) != RR_OK) {
-        PANIC("pageFsync() failed for the file :%s", curr->filename);
+        PANIC("pageFsync() failed for the file: %s", curr->filename);
     }
 
     uint64_t took = RedisModule_MonotonicMicroseconds() - begin;
@@ -857,7 +857,7 @@ int LogCompactionBegin(Log *log)
     raft_entry_release(e);
 
     if (pageSync(p0, true) != RR_OK) {
-        PANIC("pageFsync() failed for the file :%s", p0->filename);
+        PANIC("pageFsync() failed for the file: %s", p0->filename);
     }
 
     log->pages[1] = pageCreate(tmp, p0->dbid, p0->node_id, term, idx);

--- a/src/log.c
+++ b/src/log.c
@@ -1036,7 +1036,8 @@ static raft_index_t logImplCount(void *arg)
 static int logImplSync(void *arg)
 {
     RedisRaftCtx *rr = arg;
-    return LogSync(&rr->log, rr->config.log_fsync) == RR_OK ? 0 : -1;
+    LogSync(&rr->log, rr->config.log_fsync);
+    return RR_OK;
 }
 
 raft_log_impl_t LogImpl = {

--- a/src/log.c
+++ b/src/log.c
@@ -156,12 +156,14 @@ static int pageWriteEntry(LogPage *p, raft_entry_t *ety)
     /* header */
     len = generateEntryHeader(ety, buf, sizeof(buf));
     if (FileWrite(&p->file, buf, len) != len) {
+        LOG_WARNING("FileWrite() failed for the file: %s", p->filename);
         goto error;
     }
 
     /* data */
     if (FileWrite(&p->file, ety->data, ety->data_len) != ety->data_len ||
         FileWrite(&p->file, "\r\n", 2) != 2) {
+        LOG_WARNING("FileWrite() failed for the file: %s", p->filename);
         goto error;
     }
 
@@ -174,11 +176,13 @@ static int pageWriteEntry(LogPage *p, raft_entry_t *ety)
     /* write crc as added element */
     len = multibulkWriteLong(buf, sizeof(buf), crc);
     if (FileWrite(&p->file, buf, len) != len) {
+        LOG_WARNING("FileWrite() failed for the file: %s", p->filename);
         goto error;
     }
 
     ssize_t ret = FileWrite(&p->idxfile, &offset, sizeof(offset));
     if (ret != sizeof(offset)) {
+        LOG_WARNING("FileWrite() failed for the file: %s", p->idxfilename);
         goto error;
     }
 
@@ -412,7 +416,9 @@ static int pageLoadEntries(LogPage *p)
                             bytes);
 
                 int rc = FileTruncate(&p->file, offset);
-                RedisModule_Assert(rc == RR_OK);
+                if (rc != RR_OK) {
+                    PANIC("FileTruncate() failed for the file: %s", p->filename);
+                }
             }
 
             return RR_OK;
@@ -424,8 +430,12 @@ static int pageLoadEntries(LogPage *p)
             LOG_WARNING("Entry failed crc32 check, truncating log to "
                         "previous entry: %ld",
                         p->index);
+
             int rc = FileTruncate(&p->file, offset);
-            RedisModule_Assert(rc == RR_OK);
+            if (rc != RR_OK) {
+                PANIC("FileTruncate() failed for the file: %s", p->filename);
+            }
+
             return RR_OK;
         }
 
@@ -434,19 +444,22 @@ static int pageLoadEntries(LogPage *p)
         p->num_entries++;
 
         ssize_t rc = FileWrite(&p->idxfile, &offset, sizeof(offset));
-        RedisModule_Assert(rc == sizeof(offset));
+        if (rc != sizeof(offset)) {
+            PANIC("FileWrite() failed for the file: %s", p->idxfilename);
+        }
     }
 }
 
 static int pageSync(LogPage *p, bool sync)
 {
     if (FileFlush(&p->file) != RR_OK) {
+        LOG_WARNING("FileFlush() failed for the file: %s", p->filename);
         return RR_ERROR;
     }
 
     if (sync) {
         if (FileFsync(&p->file) != RR_OK) {
-            LOG_WARNING("fsync(): %s", strerror(errno));
+            LOG_WARNING("FileFsync() failed for the file: %s", p->filename);
             return RR_ERROR;
         }
     }
@@ -711,7 +724,7 @@ int LogSync(Log *log, bool sync)
     uint64_t begin = RedisModule_MonotonicMicroseconds();
 
     if (pageSync(curr, sync) != RR_OK) {
-        return RR_ERROR;
+        PANIC("pageFsync() failed for the file :%s", curr->filename);
     }
 
     uint64_t took = RedisModule_MonotonicMicroseconds() - begin;
@@ -726,7 +739,12 @@ int LogSync(Log *log, bool sync)
 int LogFlush(Log *log)
 {
     LogPage *curr = log->pages[1] ? log->pages[1] : log->pages[0];
-    return FileFlush(&curr->file);
+
+    if (FileFlush(&curr->file) != RR_OK) {
+        PANIC("FileFlush() failed for the file: %s", curr->filename);
+    }
+
+    return RR_OK;
 }
 
 int LogCurrentFd(Log *log)
@@ -839,7 +857,7 @@ int LogCompactionBegin(Log *log)
     raft_entry_release(e);
 
     if (pageSync(p0, true) != RR_OK) {
-        return RR_ERROR;
+        PANIC("pageFsync() failed for the file :%s", p0->filename);
     }
 
     log->pages[1] = pageCreate(tmp, p0->dbid, p0->node_id, term, idx);

--- a/src/metadata.c
+++ b/src/metadata.c
@@ -123,6 +123,8 @@ int MetadataRead(Metadata *m, const char *filename)
         if (errno != ENOENT) {
             PANIC("FileOpen(): %s", strerror(errno));
         }
+
+        FileTerm(&f);
         return RR_ERROR;
     }
 

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -37,8 +37,8 @@ void initSnapshotTransferData(RedisRaftCtx *ctx)
     /* Delete if there is a partial incoming snapshot file from previous run */
     int ret = unlink(ctx->incoming_snapshot_file);
     if (ret != 0 && errno != ENOENT) {
-        LOG_WARNING("Unlink file:%s, error :%s \n", ctx->incoming_snapshot_file,
-                    strerror(errno));
+        PANIC("Unlink file: %s, error: %s \n", ctx->incoming_snapshot_file,
+              strerror(errno));
     }
 }
 
@@ -61,7 +61,7 @@ void createOutgoingSnapshotMmap(RedisRaftCtx *ctx)
 
     int fd = open(ctx->config.rdb_filename, O_RDONLY, mode);
     if (fd == -1) {
-        PANIC("Cannot open rdb file at : %s \n", ctx->config.rdb_filename);
+        PANIC("Cannot open rdb file at: %s \n", ctx->config.rdb_filename);
     }
 
     int rc = stat(ctx->config.rdb_filename, &st);
@@ -74,7 +74,10 @@ void createOutgoingSnapshotMmap(RedisRaftCtx *ctx)
         PANIC("mmap failed: %s \n", strerror(errno));
     }
 
-    close(fd);
+    if (close(fd) != 0) {
+        LOG_WARNING("close() failure for the file:%s, error: %s",
+                    ctx->config.rdb_filename, strerror(errno));
+    }
 
     ctx->outgoing_snapshot_file.mmap = p;
     ctx->outgoing_snapshot_file.len = st.st_size;
@@ -121,7 +124,7 @@ int raftStoreSnapshotChunk(raft_server_t *raft, void *user_data,
     }
 
     if (rr->incoming_snapshot_idx != snapshot_index) {
-        PANIC("Snapshot index was : %ld, received a chunk for %ld \n",
+        PANIC("Snapshot index was: %ld, received a chunk for %ld \n",
               rr->incoming_snapshot_idx, snapshot_index);
     }
 
@@ -132,28 +135,31 @@ int raftStoreSnapshotChunk(raft_server_t *raft, void *user_data,
 
     int fd = open(rr->incoming_snapshot_file, flags, S_IWUSR | S_IRUSR);
     if (fd == -1) {
-        LOG_WARNING("open file:%s, error:%s \n", rr->incoming_snapshot_file,
+        LOG_WARNING("open() file: %s, error: %s \n", rr->incoming_snapshot_file,
                     strerror(errno));
         return -1;
     }
 
     off_t ret_offset = lseek(fd, (off_t) offset, SEEK_SET);
     if (ret_offset != (off_t) offset) {
-        LOG_WARNING("lseek file:%s, error:%s \n", rr->incoming_snapshot_file,
-                    strerror(errno));
+        LOG_WARNING("lseek() file: %s, error: %s \n",
+                    rr->incoming_snapshot_file, strerror(errno));
         close(fd);
         return -1;
     }
 
-    size_t len = write(fd, chunk->data, chunk->len);
-    if (len != chunk->len) {
-        LOG_WARNING("write, written: %zu, chunk len : %llu, err :%s \n", len,
+    ssize_t len = write(fd, chunk->data, chunk->len);
+    if (len != (ssize_t) chunk->len) {
+        LOG_WARNING("write(), written: %zd, chunk len: %llu, err: %s \n", len,
                     chunk->len, strerror(errno));
         close(fd);
         return -1;
     }
 
-    close(fd);
+    if (close(fd) != 0) {
+        LOG_WARNING("close() failure: %s, file: %s", strerror(errno),
+                    rr->incoming_snapshot_file);
+    }
     return 0;
 }
 
@@ -163,7 +169,7 @@ int raftClearSnapshot(raft_server_t *raft, void *user_data)
 
     int ret = unlink(rr->incoming_snapshot_file);
     if (ret != 0 && errno != ENOENT) {
-        LOG_WARNING("Unlink file:%s, error :%s \n", rr->incoming_snapshot_file,
+        LOG_WARNING("Unlink file: %s, error: %s \n", rr->incoming_snapshot_file,
                     strerror(errno));
     }
 
@@ -562,9 +568,6 @@ int raftLoadSnapshot(raft_server_t *raft, void *user_data, raft_term_t term,
 
     int rc = syncRename(rr->incoming_snapshot_file, rr->config.rdb_filename);
     if (rc != RR_OK) {
-        LOG_WARNING("rename(): %s to %s failed with error: %s",
-                    rr->incoming_snapshot_file, rr->config.rdb_filename,
-                    strerror(errno));
         return -1;
     }
 

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -75,7 +75,7 @@ void createOutgoingSnapshotMmap(RedisRaftCtx *ctx)
     }
 
     if (close(fd) != 0) {
-        LOG_WARNING("close() failure for the file:%s, error: %s",
+        LOG_WARNING("close() failure for the file: %s, error: %s",
                     ctx->config.rdb_filename, strerror(errno));
     }
 

--- a/src/util.c
+++ b/src/util.c
@@ -454,7 +454,7 @@ int fsyncFileAt(const char *path)
     }
 
     if (fsyncFile(fd) != RR_OK) {
-        LOG_WARNING("fsyncFile(): file %s, error: %s", path, strerror(errno));
+        LOG_WARNING("fsyncFile(): file: %s, error: %s", path, strerror(errno));
         close(fd);
         return RR_ERROR;
     }

--- a/src/util.c
+++ b/src/util.c
@@ -454,7 +454,7 @@ int fsyncFileAt(const char *path)
     }
 
     if (fsyncFile(fd) != RR_OK) {
-        LOG_WARNING("fsyncFile(): %s, error: %s", path, strerror(errno));
+        LOG_WARNING("fsyncFile(): file %s, error: %s", path, strerror(errno));
         close(fd);
         return RR_ERROR;
     }


### PR DESCRIPTION
This PR contains a couple changes:
- Adjusment in the file.c to retry after write/writev calls
- Log statements on unexpected system call failures: write(), fsync(), close() etc.

Currently, file.c prints a log line on unexpected failures and returns an error code.
Caller can also print some extra log line with some more info, like filename. 
For these failures, we can see multiple log lines but it should be okay as these
are rare failures (shouldn't happen ever). Reasoning is, even caller forgets printing
the log line, file.c will print log on these unexpected cases. Please comment if you
have any other idea. 

It's hard to find a rule when to abort or continue but in general, this PR does it
case by case. 
e.g If we cannot truncate a file, we cannot continue if we are going to append to it later. 
If fsync fails for a file, we cannot keep it open. (Actually, fsync failures are not handled
well in Linux, probably best way is just crash)
