### PR TITLE
[RR-184] Force close clients that exist while clearing sessions

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -368,7 +368,7 @@ void RaftExecuteCommandArray(RedisRaftCtx *rr,
     }
 
     ClientSession *client_session = getClientSession(rr, cmds);
-    if (reply_ctx) {
+    if (client_session && reply_ctx) {
         client_session->local = true;
     }
     (void) client_session;

--- a/src/raft.c
+++ b/src/raft.c
@@ -318,6 +318,7 @@ static void *getClientSession(RedisRaftCtx *rr, RaftRedisCommandArray *cmds)
         if (cmd_len == 5 && strncasecmp("watch", cmd, cmd_len) == 0) {
             client_session = RedisModule_Alloc(sizeof(ClientSession));
             client_session->client_id = id;
+            client_session->local = false;
             RedisModule_DictSetC(rr->client_session_dict, &id, sizeof(id), client_session);
         }
     }

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -728,8 +728,8 @@ typedef struct ClientState {
 } ClientState;
 
 typedef struct ClientSession {
-    raft_term_t session_term;
     unsigned long long client_id;
+    bool local;
 } ClientSession;
 
 /* common.c */

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -727,6 +727,11 @@ typedef struct ClientState {
     bool asking;
 } ClientState;
 
+typedef struct ClientSession {
+    raft_term_t session_term;
+    unsigned long long client_id;
+} ClientSession;
+
 /* common.c */
 void joinLinkIdleCallback(Connection *conn);
 void joinLinkFreeCallback(void *privdata);

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -83,6 +83,9 @@ class RawConnection(object):
         self._conn.disconnect()
         self.release()
 
+    def getClientId(self):
+        return self.execute("CLIENT", "ID")
+
 
 class RedisRaft(object):
     def __init__(self, _id, port, config, redis_args=None, raft_args=None,

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -5,6 +5,7 @@ or the Server Side Public License v1 (SSPLv1).
 """
 
 import socket
+import typing
 
 import pytest as pytest
 import time
@@ -853,3 +854,50 @@ def test_session_not_persisting(cluster):
 
     # not in the middle of a session
     conn2.execute("get", "x")
+
+
+def test_session_same_id_clients_persisting(cluster):
+    cluster.create(3)
+
+    @retry(delay=1, tries=10)
+    def assert_num_sessions(val):
+        assert cluster.node(1).info()["raft_num_sessions"] == val
+        assert cluster.node(2).info()["raft_num_sessions"] == val
+        assert cluster.node(3).info()["raft_num_sessions"] == val
+
+    assert_num_sessions(0)
+
+    conn1: typing.Optional[RawConnection] = None
+
+    for i in range(100):
+        if conn1 is not None:
+            conn1.disconnect()
+        conn1 = RawConnection(cluster.leader_node().client)
+
+    conn1_id = conn1.getClientId()
+
+    conn2: typing.Optional[RawConnection] = None
+    conn2_id = -1
+
+    while conn2_id < conn1_id:
+        if conn2 is not None:
+            conn2.disconnect()
+        conn2 = RawConnection(cluster.node(2).client)
+        conn2_id = conn2.getClientId()
+
+    assert conn1_id == conn2_id
+
+    conn1.execute("WATCH", "X")
+    cluster.wait_for_unanimity()
+
+    assert_num_sessions(1)
+
+    cluster.leader_node().transfer_leader(2)
+    cluster.leader_node().wait_for_election()
+    cluster.wait_for_unanimity()
+
+    assert_num_sessions(0)
+
+    with raises(ConnectionError, match="Connection closed by server"):
+        conn1.execute("get", "X")
+    conn2.execute("get", "X")


### PR DESCRIPTION
In order to prevent clients with sessions from persisting if leadership transfers away and then returns, we force close them when clearing the session.

If we did not do this, a client that sent a WATCH could believe that its WATCH is still valid.  terminating the client connection will force the client to reconnect.

To not require all clients to do this, we only close those that are in the middle of a session.