### PR TITLE
Fix compile

### DIFF
--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1762,7 +1762,7 @@ void handleClientEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
 
     if (eid.id == REDISMODULE_EVENT_CLIENT_CHANGE) {
         switch (subevent) {
-            case REDISMODULE_SUBEVENT_CLIENT_CHANGE_DISCONNECTED:
+            case REDISMODULE_SUBEVENT_CLIENT_CHANGE_DISCONNECTED: {
                 ClientState *cs = ClientStateGetById(rr, ci->id);
                 /* NOTE: see comment in rediraft.h on ClientState->watched
                  *
@@ -1776,10 +1776,11 @@ void handleClientEvent(RedisModuleCtx *ctx, RedisModuleEvent eid,
                     appendEndClientSession(rr, NULL, ci->id, "disconnect");
                 }
                 ClientStateFree(rr, ci->id);
-                break;
-            case REDISMODULE_SUBEVENT_CLIENT_CHANGE_CONNECTED:
+            } break;
+
+            case REDISMODULE_SUBEVENT_CLIENT_CHANGE_CONNECTED: {
                 ClientStateAlloc(rr, ci->id);
-                break;
+            } break;
         }
     }
 }


### PR DESCRIPTION
We cannot declare variables inside switch-case statements according to C standard.

Somehow, GCC still compiles the code but Clang build fails:
https://github.com/RedisLabs/redisraft/actions/runs/3888360524/jobs/6635594125

Adding { } to case statements fixes the issue. 