### PR TITLE
[RR-186] recreate locked_keys dict on snapshot load

### DIFF
--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -598,6 +598,9 @@ static void lockedKeysRDBLoad(RedisModuleIO *rdb)
     RedisRaftCtx *rr = &redis_raft;
     size_t count = RedisModule_LoadUnsigned(rdb);
 
+    RedisModule_FreeDict(rr->ctx, rr->locked_keys);
+    rr->locked_keys = RedisModule_CreateDict(rr->ctx);
+
     for (size_t i = 0; i < count; i++) {
         RedisModuleString *key = RedisModule_LoadString(rdb);
         RedisModule_DictSet(rr->locked_keys, key, NULL);

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -598,7 +598,9 @@ static void lockedKeysRDBLoad(RedisModuleIO *rdb)
     RedisRaftCtx *rr = &redis_raft;
     size_t count = RedisModule_LoadUnsigned(rdb);
 
-    RedisModule_FreeDict(rr->ctx, rr->locked_keys);
+    if (rr->locked_keys) {
+        RedisModule_FreeDict(rr->ctx, rr->locked_keys);
+    }
     rr->locked_keys = RedisModule_CreateDict(rr->ctx);
 
     for (size_t i = 0; i < count; i++) {


### PR DESCRIPTION
previously we just inserted keys into the dict, but if loading from a snapshot, we have to ensure its empty first.

As we use the dict as a set, not a hash, there are no values to be freed, so can just free the dict and then recreate it.