### PR TITLE
Fix raft_recv_read_request() error handling

### DIFF
--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -752,6 +752,7 @@ static void handleRedisCommandAppend(RedisRaftCtx *rr,
         int rc = raft_recv_read_request(rr->raft, handleReadOnlyCommand, req);
         if (rc != 0) {
             replyRaftError(ctx, rc);
+            RaftReqFree(req);
         }
         return;
     }


### PR DESCRIPTION
Currently, it is not possible to reproduce this issue as we do leader 
check above but here, if `raft_recv_read_request()` returns error 
we need to free RaftReq and unblock the client. 