### PR TITLE
[RR-187] Add migration trace level

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -27,6 +27,7 @@ static const char *trace_names[] = {
     "raftlib",
     "raftlog",
     "generic",
+    "migration",
     "all",
 };
 
@@ -37,6 +38,7 @@ static const int trace_flags[] = {
     TRACE_RAFTLIB,
     TRACE_RAFTLOG,
     TRACE_GENERIC,
+    TRACE_MIGRATION,
     TRACE_ALL,
 };
 

--- a/src/raft.c
+++ b/src/raft.c
@@ -497,7 +497,7 @@ static void lockKeys(RedisRaftCtx *rr, raft_entry_t *entry)
         if (RedisModule_KeyExists(rr->ctx, keys[i])) {
             size_t str_len;
             const char *str = RedisModule_StringPtrLen(keys[i], &str_len);
-            LOG_VERBOSE("locking %.*s", (int) str_len, str);
+            MIGRATION_TRACE("Locking key: %.*s", (int) str_len, str);
 
             RedisModule_DictSet(rr->locked_keys, keys[i], NULL);
         }
@@ -539,6 +539,11 @@ static void unlockDeleteKeys(RedisRaftCtx *rr, raft_entry_t *entry)
     RedisModule_FreeCallReply(reply);
 
     for (size_t i = 0; i < num_keys; i++) {
+        size_t str_len;
+        const char *str = RedisModule_StringPtrLen(keys[i], &str_len);
+
+        MIGRATION_TRACE("Unlocking key: %.*s", (int) str_len, str);
+
         RedisModule_DictDel(rr->locked_keys, keys[i], NULL);
         RedisModule_FreeString(rr->ctx, keys[i]);
     }

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -73,13 +73,14 @@ extern RedisModuleCtx *redisraft_log_ctx;
 #define LOG_LEVEL_WARNING 3
 #define LOG_LEVEL_COUNT   (LOG_LEVEL_WARNING + 1)
 
-#define TRACE_OFF     0
-#define TRACE_NODE    1
-#define TRACE_CONN    2
-#define TRACE_RAFTLIB 4
-#define TRACE_RAFTLOG 8
-#define TRACE_GENERIC 16
-#define TRACE_ALL     ((TRACE_GENERIC * 2) - 1)
+#define TRACE_OFF       0
+#define TRACE_NODE      (1 << 0)
+#define TRACE_CONN      (1 << 1)
+#define TRACE_RAFTLIB   (1 << 2)
+#define TRACE_RAFTLOG   (1 << 3)
+#define TRACE_GENERIC   (1 << 4)
+#define TRACE_MIGRATION (1 << 5)
+#define TRACE_ALL       ((TRACE_MIGRATION * 2) - 1)
 
 #define LOG(level, fmt, ...)                                                 \
     do {                                                                     \
@@ -122,6 +123,9 @@ extern RedisModuleCtx *redisraft_log_ctx;
 #define NODE_LOG_VERBOSE(node, fmt, ...) NODE_LOG(LOG_LEVEL_VERBOSE, node, fmt, ##__VA_ARGS__)
 #define NODE_LOG_NOTICE(node, fmt, ...)  NODE_LOG(LOG_LEVEL_NOTICE, node, fmt, ##__VA_ARGS__)
 #define NODE_LOG_WARNING(node, fmt, ...) NODE_LOG(LOG_LEVEL_WARNING, node, fmt, ##__VA_ARGS__)
+
+#define MIGRATION_TRACE(fmt, ...) \
+    TRACE_MODULE(MIGRATION, "<migration> " fmt, ##__VA_ARGS__)
 
 /* -------------------- Connections -------------------- */
 


### PR DESCRIPTION
Adding TRACE level log for migration. 

Currently, it only prints logs for locked_keys operations. 
It can be extend further if required. 

To enable TRACE level logs, we need to set log level of Redis and RedisRaft first: 

```
config set loglevel debug
config set raft.loglevel debug
```

Then, we can enable TRACE log for migration:

```
config set raft.trace migration
```

Example log would be:

```
21168:M 18 Jan 2023 12:08:53.107 . <raft> <migration> Locking key: {key}10311
22230:M 18 Jan 2023 12:22:11.735 . <raft> <migration> Unlocking key: {key}1783
21236:C 18 Jan 2023 12:08:52.705 . <raft> <migration> Saving locked key to RDB: {key}0
21236:C 18 Jan 2023 12:08:52.705 . <raft> <migration> Saving locked key to RDB: {key}10005
21237:M 18 Jan 2023 12:08:53.132 . <raft> <migration> Rebuilding locked_keys dict from RDB
21237:M 18 Jan 2023 12:08:53.132 . <raft> <migration> Loading key to locked_keys from RDB: {key}0
21237:M 18 Jan 2023 12:08:53.132 . <raft> <migration> Loading key to locked_keys from RDB: {key}10005
```