### PR TITLE
Add option to repeat tests

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -17,6 +17,10 @@ on:
         description: 'git branch or sha to use'
         required: false
         default: 'master'
+      pytest_args:
+        description: 'additional pytest args (e.g. run tests matching a regex n times: -k lua --repeat 3)'
+        required: false
+        default: ''
 
 jobs:
   tests-with-elle:
@@ -40,7 +44,7 @@ jobs:
     - name: Build
       run: |
         mkdir build && cd build
-        cmake .. -DPYTEST_OPTS="--redis-executable=redis/src/redis-server --elle-cli=elle-cli/target/elle-cli-0.1.5-standalone.jar --elle-threads=3 -v"
+        cmake .. -DPYTEST_OPTS="--redis-executable=redis/src/redis-server --elle-cli=elle-cli/target/elle-cli-0.1.5-standalone.jar --elle-threads=3 -v ${{github.event.inputs.pytest_args}}"
         make
     - name: Checkout Redis
       uses: actions/checkout@v2
@@ -92,7 +96,7 @@ jobs:
     - name: Build
       run: |
         mkdir build && cd build
-        cmake .. -DSANITIZER=address -DPYTEST_OPTS="--redis-executable=redis/src/redis-server -v"
+        cmake .. -DSANITIZER=address -DPYTEST_OPTS="--redis-executable=redis/src/redis-server -v ${{github.event.inputs.pytest_args}}"
         make
     - name: Checkout Redis
       uses: actions/checkout@v2
@@ -136,7 +140,7 @@ jobs:
       - name: Build
         run: |
           mkdir build && cd build
-          cmake .. -DSANITIZER=undefined -DPYTEST_OPTS="--redis-executable=redis/src/redis-server -v"
+          cmake .. -DSANITIZER=undefined -DPYTEST_OPTS="--redis-executable=redis/src/redis-server -v ${{github.event.inputs.pytest_args}}"
           make
       - name: Checkout Redis
         uses: actions/checkout@v2
@@ -180,7 +184,7 @@ jobs:
       - name: Build
         run: |
           mkdir build && cd build
-          cmake .. -DPYTEST_OPTS="--redis-executable=redis/src/redis-server -v"
+          cmake .. -DPYTEST_OPTS="--redis-executable=redis/src/redis-server -v ${{github.event.inputs.pytest_args}}"
           make
       - name: Checkout Redis
         uses: actions/checkout@v2
@@ -225,7 +229,7 @@ jobs:
       - name: Build
         run: |
           mkdir build && cd build
-          cmake .. -DSANITIZER=address -DBUILD_TLS=1 -DPYTEST_OPTS="--redis-executable=redis/src/redis-server --tls -v" 
+          cmake .. -DSANITIZER=address -DBUILD_TLS=1 -DPYTEST_OPTS="--redis-executable=redis/src/redis-server --tls -v ${{github.event.inputs.pytest_args}}" 
           make
       - name: Checkout Redis
         uses: actions/checkout@v2
@@ -257,7 +261,7 @@ jobs:
       - name: Build
         run: |
           mkdir build && cd build
-          cmake .. -DSANITIZER=address -DBUILD_TLS=1 -DPYTEST_OPTS="--redis-executable=redis/src/redis-server --tls -v" 
+          cmake .. -DSANITIZER=address -DBUILD_TLS=1 -DPYTEST_OPTS="--redis-executable=redis/src/redis-server --tls -v ${{github.event.inputs.pytest_args}}" 
           make
       - name: Checkout Redis
         uses: actions/checkout@v2
@@ -303,7 +307,7 @@ jobs:
       - name: Build
         run: |
           mkdir build && cd build
-          cmake .. -DPYTEST_OPTS="--redis-executable=redis/src/redis-server -v" 
+          cmake .. -DPYTEST_OPTS="--redis-executable=redis/src/redis-server -v ${{github.event.inputs.pytest_args}}" 
           make -j 4
       - name: Checkout Redis
         uses: actions/checkout@v2

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -53,6 +53,17 @@ def pytest_addoption(parser):
     parser.addoption(
         '--elle-ops-per-tx', default=1,
         help='number of append/read pairs per transaction')
+    parser.addoption(
+        '--repeat', action='store',
+        help='Number of times to repeat each test')
+
+
+def pytest_generate_tests(metafunc):
+    if metafunc.config.option.repeat is not None:
+        count = int(metafunc.config.option.repeat)
+
+        metafunc.fixturenames.append('repeat_test')
+        metafunc.parametrize('repeat_test', range(count))
 
 
 def pytest_configure(config):


### PR DESCRIPTION
1- First commit adds `--repeat` option to pytest, to run a test 10 times:
`pytest test.py --repeat 10`

2- Second commit adds a github action argument for the daily build, 
we can set additional pytest args from Github:
`-k lua --repeat 10`  : If test name matches `lua`, run it 10 times.

This is useful when we want to run a test many times to reproduce an issue or to fix a flaky test.