### PR TITLE
Increase response-timeout for big snapshot tests

### DIFF
--- a/tests/integration/test_fuzzing.py
+++ b/tests/integration/test_fuzzing.py
@@ -151,7 +151,7 @@ def test_snapshot_delivery_with_config_changes(cluster):
     """
     cycles = 10
 
-    cluster.create(1)
+    cluster.create(1, raft_args={'response-timeout': 5000})
     cluster.execute('set', 'x', '1')
     cluster.execute('set', 'x', '1')
 
@@ -163,10 +163,11 @@ def test_snapshot_delivery_with_config_changes(cluster):
     n1.execute('raft.debug', 'compact', 0, 0, 1)
     n1.wait_for_info_param('raft_snapshots_created', 1, 30)
 
-    cluster.add_node()
-    cluster.add_node()
-    cluster.add_node()
-    cluster.add_node()
+    cluster.add_node(use_cluster_args=True)
+    cluster.add_node(use_cluster_args=True)
+    cluster.add_node(use_cluster_args=True)
+    cluster.add_node(use_cluster_args=True)
+
     cluster.wait_for_unanimity()
 
     for i in range(cycles):
@@ -176,7 +177,7 @@ def test_snapshot_delivery_with_config_changes(cluster):
         except ResponseError:
             continue
 
-        cluster.add_node().wait_for_node_voting()
+        cluster.add_node(use_cluster_args=True).wait_for_node_voting()
 
     logging.info('All cycles finished')
     assert int(cluster.execute('GET', 'counter')) == cycles

--- a/tests/integration/test_snapshots.py
+++ b/tests/integration/test_snapshots.py
@@ -94,7 +94,7 @@ def test_big_snapshot_delivery(cluster):
     Ability to properly deliver and load a big snapshot file (~70 Mb on disk).
     """
 
-    cluster.create(1)
+    cluster.create(1, raft_args={'response-timeout': 5000})
     cluster.execute('set', 'x', '1')
     cluster.execute('set', 'x', '1')
 
@@ -102,8 +102,8 @@ def test_big_snapshot_delivery(cluster):
     n1.raft_debug_exec('debug', 'populate', 2000000, 100000)
     n1.client.execute_command('raft.debug', 'compact')
 
-    cluster.add_node()
-    cluster.add_node()
+    cluster.add_node(use_cluster_args=True)
+    cluster.add_node(use_cluster_args=True)
 
     cluster.wait_for_unanimity()
     assert cluster.node(2).info()['raft_snapshots_received'] > 0


### PR DESCRIPTION
https://github.com/RedisLabs/redisraft/actions/runs/3991700932/jobs/6846775748

Ran this test with trace level logs, looks like due to extreme slow-down on MacOS instance, followers send snapshot message responses after a second. Default `response-timeout` is 1 second. So, leader node marks the request failed and retries. It takes quite a time to finish snapshot delivery, sometimes test fails due to `wait_for_unanimity()` timeout which is 20 seconds. 

For the two tests that use big snapshots, this PR increases `response-timeout` to 5 seconds. 

