### PR TITLE
Fix session test for MacOS

### DIFF
--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -849,7 +849,7 @@ def test_session_not_persisting(cluster):
     assert_num_sessions(0)
 
     # was in the middle of a session
-    with raises(ConnectionError, match="Connection closed by server"):
+    with raises(ConnectionError, match="Connection (closed|reset)"):
         conn1.execute("get", "X")
 
     # not in the middle of a session
@@ -898,6 +898,6 @@ def test_session_same_id_clients_persisting(cluster):
 
     assert_num_sessions(0)
 
-    with raises(ConnectionError, match="Connection closed by server"):
+    with raises(ConnectionError, match="Connection (closed|reset)"):
         conn1.execute("get", "X")
     conn2.execute("get", "X")


### PR DESCRIPTION
> AssertionError: Regex pattern 'Connection closed by server' does not match "Error while reading from socket: (54, 'Connection reset by peer')".

https://github.com/RedisLabs/redisraft/actions/runs/4257999761/jobs/7408744012#step:10:393

Look like MacOS throws error with another string occasionally.