### PR TITLE
Trace level logs in integration tests

### DIFF
--- a/src/raft.c
+++ b/src/raft.c
@@ -1513,11 +1513,13 @@ void RaftLibraryInit(RedisRaftCtx *rr, bool cluster_init)
 
     int eltimeo = rr->config.election_timeout;
     int reqtimeo = rr->config.request_timeout;
+    int log = redisraft_trace & TRACE_RAFTLIB ? 1 : 0;
 
     if (raft_config(rr->raft, 1, RAFT_CONFIG_ELECTION_TIMEOUT, eltimeo) != 0 ||
         raft_config(rr->raft, 1, RAFT_CONFIG_REQUEST_TIMEOUT, reqtimeo) != 0 ||
         raft_config(rr->raft, 1, RAFT_CONFIG_AUTO_FLUSH, 0) != 0 ||
-        raft_config(rr->raft, 1, RAFT_CONFIG_NONBLOCKING_APPLY, 1) != 0) {
+        raft_config(rr->raft, 1, RAFT_CONFIG_NONBLOCKING_APPLY, 1) != 0 ||
+        raft_config(rr->raft, 1, RAFT_CONFIG_LOG_ENABLED, log) != 0) {
         PANIC("Failed to configure libraft");
     }
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,6 +22,9 @@ def pytest_addoption(parser):
         '--raft-loglevel', default='debug',
         help='RedisRaft Module log level.')
     parser.addoption(
+        '--raft-trace', default='off',
+        help='RedisRaft Module trace log levels.')
+    parser.addoption(
         '--raft-module', default='redisraft.so',
         help='RedisRaft Module filename.')
     parser.addoption(
@@ -89,6 +92,7 @@ def create_config(pytest_config):
     config.raftmodule = pytest_config.getoption('--raft-module')
     config.up_timeout = pytest_config.getoption('--redis-up-timeout')
     config.raft_loglevel = pytest_config.getoption('--raft-loglevel')
+    config.raft_trace = pytest_config.getoption('--raft-trace')
     config.workdir = pytest_config.getoption('--work-dir')
     config.keepfiles = pytest_config.getoption('--keep-files')
     config.fsync = pytest_config.getoption('--fsync')

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -154,6 +154,7 @@ class RedisRaft(object):
                         'log-filename': self._raftlog,
                         'log-fsync': 'yes' if config.fsync else 'no',
                         'loglevel': config.raft_loglevel,
+                        'trace': config.raft_trace,
                         'tls-enabled': 'yes' if config.tls else 'no'}
 
         for defkey, defval in default_args.items():


### PR DESCRIPTION
- First commit fixes a bug. If `raft.trace` config is given on startup and 
  then we initialize the cluster, we don't pass log config to the raft library
  after the initialization. This commit changes it and passes log config to
   the raft library. 
- Second commit adds an option to pass `raft.trace` config to the pytest. 
  This is useful when we want detailed logs from a test. 
