### PR TITLE
[RR-174] Fix test_maxmemory_with_cluster_ops test failure

### DIFF
--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -660,10 +660,13 @@ class Cluster(object):
         except redis.ResponseError as err:
             # If we are removing the leader, leader will shut down before
             # sending the reply. On retry, we should get
-            # "node id does not exist" reply.
-            if str(err).startswith("node id does not exist"):
-                if _id not in self.nodes:
-                    raise err
+            # "node id does not exist" reply. If we get this reply and still
+            # have '_id' in our local list, we know removal was successful.
+            # For other cases, we just propagate the exception.
+            missing_node_id = str(err).startswith("node id does not exist")
+            was_retry = missing_node_id and _id in self.nodes
+            if not was_retry:
+                raise err
 
         self.nodes[_id].destroy()
         del self.nodes[_id]

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -575,6 +575,8 @@ def test_maxmemory_with_cluster_ops(cluster):
     # Add new nodes. New nodes will receive the snapshot.
     n2 = cluster.add_node(redis_args=["--maxmemory", "1"])
     n3 = cluster.add_node(redis_args=["--maxmemory", "1"])
+
+    n1.wait_for_num_voting_nodes(3)
     cluster.wait_for_unanimity()
     assert n2.info()['raft_snapshots_received'] == 1
     assert n3.info()['raft_snapshots_received'] == 1


### PR DESCRIPTION
There were two issues with this test:

- Leader adds nodes as non-voting first. Then, when leader 
decides that it can promote a node to voting, it submits an entry to
make it voting. While that entry is in the log waiting to be 
committed, we try to remove that node inside the test case. Libraft
rejects second configuration change entry as we don't allow multiple
configuration change entries at the same time.
    To solve the problem, inside the test, we can wait until all nodes 
become voting before trying to remove a node.

- Second problem is when redisraft rejects removal operation, we
don't propagate the exception due to a bug. While checking for 
something else, we ignore the exception by mistake. Added a change to
avoid that. 

Note: Failed part was

```python
        ....
        # Remove the node
        cluster.remove_node(n3.id)
>       n1.wait_for_num_nodes(2)
        ...
```