### PR TITLE
[RR-209] Snapshot metrics

### DIFF
--- a/src/migrate.c
+++ b/src/migrate.c
@@ -202,7 +202,7 @@ fail:
 
 static void raftAppendRaftUnlockDeleteEntry(RedisRaftCtx *rr, RaftReq *req)
 {
-    if (rr->migration_debug == DEBUG_MIGRATION_EMULATE_UNLOCK_FAILED) {
+    if (rr->config.migration_debug == DEBUG_MIGRATION_EMULATE_UNLOCK_FAILED) {
         RedisModule_ReplyWithError(req->ctx, "ERR Unable to unlock/delete migrated keys, try again");
         RaftReqFree(req);
         return;
@@ -273,7 +273,7 @@ static void transferKeys(Connection *conn)
         return;
     }
 
-    if (rr->migration_debug == DEBUG_MIGRATION_EMULATE_IMPORT_FAILED) {
+    if (rr->config.migration_debug == DEBUG_MIGRATION_EMULATE_IMPORT_FAILED) {
         ConnAsyncTerminate(conn);
         RedisModule_ReplyWithError(req->ctx, "ERR failed to submit RAFT.IMPORT command, try again");
         RaftReqFree(req);
@@ -344,7 +344,7 @@ static RRStatus getMigrationSessionKey(RedisRaftCtx *rr, RaftReq *req, unsigned 
 
 void MigrateKeys(RedisRaftCtx *rr, RaftReq *req)
 {
-    if (rr->migration_debug == DEBUG_MIGRATION_EMULATE_CONNECT_FAILED) {
+    if (rr->config.migration_debug == DEBUG_MIGRATION_EMULATE_CONNECT_FAILED) {
         RedisModule_ReplyWithError(req->ctx, "ERR failed to connect to import cluster, try again");
         goto exit;
     }

--- a/src/raft.c
+++ b/src/raft.c
@@ -352,8 +352,8 @@ void RaftExecuteCommandArray(RedisRaftCtx *rr,
         }
     }
 
-    if (rr->debug_delay_apply) {
-        usleep(rr->debug_delay_apply);
+    if (rr->config.log_delay_apply) {
+        usleep(rr->config.log_delay_apply);
     }
 
     /* When we're in cluster mode, go through handleSharding. This will perform
@@ -1423,7 +1423,7 @@ void callRaftPeriodic(RedisModuleCtx *ctx, void *arg)
 
         /* Step-2: If we've committed all the entries of the first log page, we
          * can start the snapshot. */
-        start = (rr->debug_req || !rr->disable_snapshot);
+        start = (rr->debug_req || !rr->config.snapshot_disable);
         if (start && LogCompactionStarted(&rr->log) &&
             raft_get_commit_idx(rr->raft) >= LogCompactionIdx(&rr->log)) {
 
@@ -1513,9 +1513,11 @@ void RaftLibraryInit(RedisRaftCtx *rr, bool cluster_init)
 
     int eltimeo = rr->config.election_timeout;
     int reqtimeo = rr->config.request_timeout;
+    int noapply = rr->config.log_disable_apply;
 
     if (raft_config(rr->raft, 1, RAFT_CONFIG_ELECTION_TIMEOUT, eltimeo) != 0 ||
         raft_config(rr->raft, 1, RAFT_CONFIG_REQUEST_TIMEOUT, reqtimeo) != 0 ||
+        raft_config(rr->raft, 1, RAFT_CONFIG_DISABLE_APPLY, noapply) != 0 ||
         raft_config(rr->raft, 1, RAFT_CONFIG_AUTO_FLUSH, 0) != 0 ||
         raft_config(rr->raft, 1, RAFT_CONFIG_NONBLOCKING_APPLY, 1) != 0) {
         PANIC("Failed to configure libraft");

--- a/src/raft.c
+++ b/src/raft.c
@@ -1334,7 +1334,6 @@ static void handleLoadingState(RedisRaftCtx *rr)
         }
 
         RaftLibraryInit(rr, false);
-        initSnapshotTransferData(rr);
 
         if (rr->snapshot_info.loaded) {
             createOutgoingSnapshotMmap(rr);

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1386,7 +1386,7 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
 
         if (argc > 2) {
             if (RedisModule_StringToLongLong(argv[2], &async) != REDISMODULE_OK) {
-                RedisModule_ReplyWithError(ctx, "ERR invalid compact fail value");
+                RedisModule_ReplyWithError(ctx, "ERR invalid compact async value");
                 return REDISMODULE_OK;
             }
         }

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1342,14 +1342,10 @@ static int cmdRaftShardGroup(RedisModuleCtx *ctx, RedisModuleString **argv, int 
     }
 }
 
-/* RAFT.DEBUG COMPACT [delay] [fail] [async]
+/* RAFT.DEBUG COMPACT [async]
  *     Initiate the snapshot.
- *     If [delay] is specified, introduce an artificial delay of [delay] seconds
- *        in the background child process.
- *     If [fail] is non-zero, snapshot will fail.
  *     If [async] is non-zero, snapshot will be triggered and client will get
- *        the reply without waiting the snapshot result. [delay] ahd [fail]
- *        parameters will be ignored.
+ *        the reply without waiting the snapshot result.
  * Reply:
  *   +OK
  *
@@ -1367,24 +1363,6 @@ static int cmdRaftShardGroup(RedisModuleCtx *ctx, RedisModuleString **argv, int 
  *     Execute Redis commands locally (commands do not go through Raft interception)
  * Reply:
  *     Any standard Redis reply, depending on the commands.
- *
- * RAFT.DEBUG DISABLE_SNAPSHOT <disable_snapshot> <disable_snapshot_load>
- *     Set/unset disable_snapshot and disable_snapshot_load flags.
- *     If disable_snapshot is set, node will not create a snapshot.
- *     If disable_snapshot_load is set, node will not load the received snapshot.
- * Reply:
- *   +OK
- *
- * RAFT.DEBUG DISABLE_APPLY <val>
- *     Set/unset disable_apply raft configuration flag
- *
- * RAFT.DEBUG DELAY_APPLY <val>
- *     Sleep <val> microseconds before executing a command
- *
- * RAFT.DEBUG MIGRATION_DEBUG [fail_connect|fail_import|fail_unlock|none]
- *     Inject errors at specific places in migration flow to test consistency
- * Reply:
- *     +OK
  *
  * RAFT.DEBUG COMMANDSPEC <command>
  *     Returns the flags associated with this command in the commandspec dict
@@ -1406,26 +1384,10 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     cmd[cmdlen] = '\0';
 
     if (!strncasecmp(cmd, "compact", cmdlen)) {
-        long long fail = 0;
-        long long delay = 0;
         long long async = 0;
 
-        if (argc == 3) {
-            if (RedisModule_StringToLongLong(argv[2], &delay) != REDISMODULE_OK) {
-                RedisModule_ReplyWithError(ctx, "ERR invalid compact delay value");
-                return REDISMODULE_OK;
-            }
-        }
-
-        if (argc == 4) {
-            if (RedisModule_StringToLongLong(argv[3], &fail) != REDISMODULE_OK) {
-                RedisModule_ReplyWithError(ctx, "ERR invalid compact fail value");
-                return REDISMODULE_OK;
-            }
-        }
-
-        if (argc == 5) {
-            if (RedisModule_StringToLongLong(argv[4], &async) != REDISMODULE_OK) {
+        if (argc > 2) {
+            if (RedisModule_StringToLongLong(argv[2], &async) != REDISMODULE_OK) {
                 RedisModule_ReplyWithError(ctx, "ERR invalid compact fail value");
                 return REDISMODULE_OK;
             }
@@ -1445,11 +1407,7 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
             return REDISMODULE_OK;
         }
 
-        RaftReq *req = RaftReqInit(ctx, RR_DEBUG);
-        req->r.debug.delay = (int) delay;
-        req->r.debug.fail = (int) fail;
-
-        rr->debug_req = req;
+        rr->debug_req = RaftReqInit(ctx, RR_DEBUG);
     } else if (!strncasecmp(cmd, "nodecfg", cmdlen)) {
         if (argc != 4) {
             RedisModule_WrongArity(ctx);
@@ -1527,75 +1485,6 @@ static int cmdRaftDebug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
             RedisModule_ReplyWithCallReply(ctx, reply);
             RedisModule_FreeCallReply(reply);
         }
-    } else if (!strncasecmp(cmd, "disable_snapshot", cmdlen) && argc >= 3) {
-        long long val;
-
-        if (RedisModule_StringToLongLong(argv[2], &val) != REDISMODULE_OK) {
-            RedisModule_ReplyWithError(ctx, "ERR invalid value");
-            return REDISMODULE_OK;
-        }
-
-        if (argc == 4) {
-            long long load;
-
-            if (RedisModule_StringToLongLong(argv[3], &load) != REDISMODULE_OK) {
-                RedisModule_ReplyWithError(ctx, "ERR invalid value");
-                return REDISMODULE_OK;
-            }
-            rr->disable_snapshot_load = load;
-        }
-
-        rr->disable_snapshot = val;
-
-        RedisModule_ReplyWithSimpleString(ctx, "OK");
-    } else if (!strncasecmp(cmd, "disable_apply", cmdlen) && argc == 3) {
-        long long val;
-        if (RedisModule_StringToLongLong(argv[2], &val) != REDISMODULE_OK) {
-            RedisModule_ReplyWithError(ctx, "ERR invalid disable apply value");
-            return REDISMODULE_OK;
-        }
-
-        if (checkRaftState(rr, ctx) != RR_OK) {
-            return REDISMODULE_OK;
-        }
-
-        if (raft_config(rr->raft, 1, RAFT_CONFIG_DISABLE_APPLY, val) != 0) {
-            RedisModule_ReplyWithError(ctx, "ERR failed to configure libraft");
-            return REDISMODULE_OK;
-        }
-
-        RedisModule_ReplyWithSimpleString(ctx, "OK");
-    } else if (!strncasecmp(cmd, "delay_apply", cmdlen) && argc == 3) {
-        long long val;
-        if (RedisModule_StringToLongLong(argv[2], &val) != REDISMODULE_OK) {
-            RedisModule_ReplyWithError(ctx, "ERR invalid delay apply value");
-            return REDISMODULE_OK;
-        }
-
-        rr->debug_delay_apply = val;
-        RedisModule_ReplyWithSimpleString(ctx, "OK");
-    } else if (!strncasecmp(cmd, "migration_debug", cmdlen) && argc == 3) {
-        MigrationDebug val;
-
-        size_t len;
-        const char *str = RedisModule_StringPtrLen(argv[2], &len);
-        if (!strncasecmp(str, "fail_connect", len)) {
-            val = DEBUG_MIGRATION_EMULATE_CONNECT_FAILED;
-        } else if (!strncasecmp(str, "fail_import", len)) {
-            val = DEBUG_MIGRATION_EMULATE_IMPORT_FAILED;
-        } else if (!strncasecmp(str, "fail_unlock", len)) {
-            val = DEBUG_MIGRATION_EMULATE_UNLOCK_FAILED;
-        } else if (!strncasecmp(str, "none", len)) {
-            val = DEBUG_MIGRATION_NONE;
-        } else {
-            RedisModule_ReplyWithError(ctx, "ERR invalid migration debug value");
-            return REDISMODULE_OK;
-        }
-
-        rr->migration_debug = val;
-
-        RedisModule_ReplyWithSimpleString(ctx, "OK");
-        return REDISMODULE_OK;
     } else if (!strncasecmp(cmd, "commandspec", cmdlen) && argc == 3) {
         const CommandSpec *cs = CommandSpecTableGet(redis_raft.commands_spec_table, argv[2]);
         if (cs == NULL) {

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -396,10 +396,10 @@ typedef struct RedisRaftCtx {
                                                     it will be renamed to the original rdb file */
     SnapshotLoad snapshot_load;          /* Indicates we've received a snapshot waiting to be loaded */
     bool snapshot_in_progress;           /* Indicates we're creating a snapshot in the background */
-    mstime_t curr_snapshot_start_time;   /* start time of the snapshot operation currently in progress */
     raft_index_t curr_snapshot_last_idx; /* Last included idx of the snapshot operation currently in progress */
     raft_term_t curr_snapshot_last_term; /* Last included term of the snapshot operation currently in progress */
-    mstime_t last_snapshot_time;         /* Total time (ms) of a last local snapshot operation */
+    uint64_t curr_snapshot_start_time;   /* Start time of the snapshot operation currently in progress */
+    uint64_t last_snapshot_time;         /* Total time (seconds) of a last local snapshot operation */
     int snapshot_child_fd;               /* Pipe connected to snapshot child process */
     SnapshotFile outgoing_snapshot_file; /* Snapshot file memory table to send to followers */
     RaftSnapshotInfo snapshot_info;      /* Current snapshot info */
@@ -865,7 +865,6 @@ void ConfigRedisEventCallback(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_
 /* snapshot.c */
 extern RedisModuleTypeMethods RedisRaftTypeMethods;
 extern RedisModuleType *RedisRaftType;
-void initSnapshotTransferData(RedisRaftCtx *ctx);
 void createOutgoingSnapshotMmap(RedisRaftCtx *ctx);
 RRStatus initiateSnapshot(RedisRaftCtx *rr);
 RRStatus finalizeSnapshot(RedisRaftCtx *rr, SnapshotResult *sr);
@@ -879,6 +878,7 @@ int raftClearSnapshot(raft_server_t *raft, void *udata);
 int raftGetSnapshotChunk(raft_server_t *raft, void *udata, raft_node_t *node, raft_size_t offset, raft_snapshot_chunk_t *chunk);
 int raftStoreSnapshotChunk(raft_server_t *raft, void *udata, raft_index_t idx, raft_size_t offset, raft_snapshot_chunk_t *chunk);
 void archiveSnapshot(RedisRaftCtx *rr);
+void SnapshotInit(RedisRaftCtx *rr);
 
 /* proxy.c */
 RRStatus ProxyCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds, Node *leader);

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -412,12 +412,11 @@ RRStatus initiateSnapshot(RedisRaftCtx *rr)
 
         /* Handle compact delay, used for strictly as a debugging tool for testing */
         if (rr->debug_req) {
-            int delay = rr->debug_req->r.debug.delay;
-            if (delay) {
-                sleep(delay);
+            if (rr->config.snapshot_delay) {
+                sleep(rr->config.snapshot_delay);
             }
 
-            if (rr->debug_req->r.debug.fail) {
+            if (rr->config.snapshot_fail) {
                 strncpy(sr.err, "debug rdbSave() failed", sizeof(sr.err));
                 sr.err[sizeof(sr.err) - 1] = '\0';
                 goto exit;
@@ -502,7 +501,7 @@ void loadPendingSnapshot(RedisRaftCtx *rr)
 {
     RedisModule_Assert(rr->state == REDIS_RAFT_LOADING);
 
-    if (rr->disable_snapshot_load) {
+    if (rr->config.snapshot_disable_load) {
         return;
     }
 

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -25,23 +25,6 @@ int rdbSave(int flags, const char *filename, void *info);
 
 /* ------------------------------------ Snapshot metadata ------------------------------------ */
 
-void initSnapshotTransferData(RedisRaftCtx *ctx)
-{
-    ctx->outgoing_snapshot_file.mmap = NULL;
-    ctx->outgoing_snapshot_file.len = 0;
-
-    /* Generate temp file name for incoming snapshots */
-    snprintf(ctx->incoming_snapshot_file, sizeof(ctx->incoming_snapshot_file),
-             "%s.tmp.recv", ctx->config.rdb_filename);
-
-    /* Delete if there is a partial incoming snapshot file from previous run */
-    int ret = unlink(ctx->incoming_snapshot_file);
-    if (ret != 0 && errno != ENOENT) {
-        PANIC("Unlink file: %s, error: %s \n", ctx->incoming_snapshot_file,
-              strerror(errno));
-    }
-}
-
 static void releaseSnapshotMmap(RedisRaftCtx *ctx)
 {
     if (ctx->outgoing_snapshot_file.mmap != NULL) {
@@ -241,9 +224,9 @@ static void freeNodeIdEntryList(NodeIdEntry *head)
 static void resetSnapshotState(RedisRaftCtx *rr)
 {
     rr->snapshot_in_progress = false;
-    rr->curr_snapshot_last_term = 0;
-    rr->curr_snapshot_last_idx = 0;
-    rr->curr_snapshot_start_time = -1;
+    rr->curr_snapshot_last_term = -1;
+    rr->curr_snapshot_last_idx = -1;
+    rr->curr_snapshot_start_time = 0;
 }
 
 void cancelSnapshot(RedisRaftCtx *rr, SnapshotResult *sr)
@@ -287,8 +270,12 @@ RRStatus finalizeSnapshot(RedisRaftCtx *rr, SnapshotResult *sr)
     LOG_NOTICE("Snapshot has been completed (snapshot idx=%lu).",
                raft_get_snapshot_last_idx(rr->raft));
 
+    uint64_t took;
+
+    took = RedisModule_MonotonicMicroseconds() - rr->curr_snapshot_start_time;
+    rr->last_snapshot_time = took / 1000 / 1000;
     rr->snapshots_created++;
-    rr->last_snapshot_time = RedisModule_Milliseconds() - rr->curr_snapshot_start_time;
+
     resetSnapshotState(rr);
 
     return RR_OK;
@@ -367,7 +354,7 @@ RRStatus initiateSnapshot(RedisRaftCtx *rr)
     rr->curr_snapshot_last_idx = rr->snapshot_info.last_applied_idx;
     rr->curr_snapshot_last_term = rr->snapshot_info.last_applied_term;
     rr->snapshot_in_progress = true;
-    rr->curr_snapshot_start_time = RedisModule_Milliseconds();
+    rr->curr_snapshot_start_time = RedisModule_MonotonicMicroseconds();
 
     /* Create a snapshot of the nodes configuration */
     freeSnapshotCfgEntryList(rr->snapshot_info.cfg);
@@ -410,17 +397,14 @@ RRStatus initiateSnapshot(RedisRaftCtx *rr)
         snprintf(sr.rdb_filename, sizeof(sr.rdb_filename) - 1, "%s.tmp.%d",
                  rr->config.rdb_filename, (int) getpid());
 
-        /* Handle compact delay, used for strictly as a debugging tool for testing */
-        if (rr->debug_req) {
-            if (rr->config.snapshot_delay) {
-                sleep(rr->config.snapshot_delay);
-            }
+        if (rr->config.snapshot_delay) {
+            sleep(rr->config.snapshot_delay);
+        }
 
-            if (rr->config.snapshot_fail) {
-                strncpy(sr.err, "debug rdbSave() failed", sizeof(sr.err));
-                sr.err[sizeof(sr.err) - 1] = '\0';
-                goto exit;
-            }
+        if (rr->config.snapshot_fail) {
+            strncpy(sr.err, "debug rdbSave() failed", sizeof(sr.err));
+            sr.err[sizeof(sr.err) - 1] = '\0';
+            goto exit;
         }
 
         if (rdbSave(0, sr.rdb_filename, NULL) != 0) {
@@ -881,4 +865,22 @@ void archiveSnapshot(RedisRaftCtx *rr)
     snprintf(bak_rdb_filename, bak_rdb_filename_maxlen - 1,
              "%s.bak.%d", rr->config.rdb_filename, raft_get_nodeid(rr->raft));
     rename(rr->config.rdb_filename, bak_rdb_filename);
+}
+
+void SnapshotInit(RedisRaftCtx *rr)
+{
+    rr->outgoing_snapshot_file = (SnapshotFile){0};
+
+    /* Generate temp file name for incoming snapshots */
+    snprintf(rr->incoming_snapshot_file, sizeof(rr->incoming_snapshot_file),
+             "%s.tmp.recv", rr->config.rdb_filename);
+
+    /* Delete if there is a partial snapshot file from the previous run */
+    int ret = unlink(rr->incoming_snapshot_file);
+    if (ret != 0 && errno != ENOENT) {
+        PANIC("Unlink file: %s, error: %s \n", rr->incoming_snapshot_file,
+              strerror(errno));
+    }
+
+    resetSnapshotState(rr);
 }

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -7,7 +7,6 @@ or the Server Side Public License v1 (SSPLv1).
 import pytest
 from redis import ResponseError
 from pytest import raises
-import os
 
 
 def test_config_sanity(cluster):
@@ -37,6 +36,8 @@ def test_config_sanity(cluster):
     verify('raft.log-max-cache-size', 999)
     verify('raft.log-max-file-size', 999)
     verify('raft.scan-size', 999)
+    verify('raft.log-delay-apply', 999)
+    verify('raft.snapshot-delay', 999)
 
     verify('raft.log-fsync', 'yes')
     verify('raft.log-fsync', 'no')
@@ -47,6 +48,14 @@ def test_config_sanity(cluster):
     verify('raft.sharding', 'yes')
     verify('raft.sharding', 'no')
     verify('raft.tls-enabled', 'no')
+    verify('raft.log-disable-apply', 'yes')
+    verify('raft.log-disable-apply', 'no')
+    verify('raft.snapshot-fail', 'yes')
+    verify('raft.snapshot-fail', 'no')
+    verify('raft.snapshot-disable', 'yes')
+    verify('raft.snapshot-disable', 'no')
+    verify('raft.snapshot-disable-load', 'yes')
+    verify('raft.snapshot-disable-load', 'no')
 
     verify('raft.ignored-commands', 'get')
     verify('raft.cluster-user', 'username')
@@ -56,6 +65,11 @@ def test_config_sanity(cluster):
     verify('raft.loglevel', 'verbose')
     verify('raft.loglevel', 'notice')
     verify('raft.loglevel', 'warning')
+
+    verify('raft.migration-debug', 'none')
+    verify('raft.migration-debug', 'fail-connect')
+    verify('raft.migration-debug', 'fail-import')
+    verify('raft.migration-debug', 'fail-unlock')
 
     verify('raft.trace', 'node conn')
 
@@ -148,12 +162,18 @@ def test_config_args(cluster):
                  'log-max-cache-size':         8011,
                  'log-max-file-size':          8012,
                  'scan-size':                  8013,
+                 'log-delay-apply':            8014,
+                 'snapshot-delay':             8015,
                  'log-fsync':                  'no',
                  'follower-proxy':             'yes',
                  'quorum-reads':               'no',
                  'sharding':                   'yes',
                  'external-sharding':          'yes',
                  'tls-enabled':                'no',
+                 'log-disable-apply':          'yes',
+                 'snapshot-fail':              'yes',
+                 'snapshot-disable':           'yes',
+                 'snapshot-disable-load':      'yes',
                  'log-filename':               'filename8001.log',
                  'addr':                       '80.80.80.80:1002',
                  'slot-config':                '0:8001',
@@ -161,6 +181,7 @@ def test_config_args(cluster):
                  'cluster-user':               'user1',
                  'cluster-password':           'password1',
                  'loglevel':                   'warning',
+                 'migration-debug':            'fail-unlock',
                  'trace':                      'raftlib'}
 
     r1 = cluster.add_node(raft_args, cluster_setup=False)
@@ -210,15 +231,22 @@ def test_invalid_configs(cluster):
     verify_failure('raft.log-max-cache-size', -1)
     verify_failure('raft.log-max-file-size', -1)
     verify_failure('raft.scan-size', -1)
+    verify_failure('raft.log-delay-apply', -1)
+    verify_failure('raft.snapshot-delay', -1)
 
     verify_failure('raft.log-fsync', 'someinvalidvalue')
     verify_failure('raft.follower-proxy', 'someinvalidvalue')
     verify_failure('raft.quorum-reads', 'someinvalidvalue')
     verify_failure('raft.sharding', 'someinvalidvalue')
     verify_failure('raft.tls-enabled', 'someinvalidvalue')
+    verify_failure('raft.log-disable-apply', 'someinvalidvalue')
+    verify_failure('raft.snapshot-fail', 'someinvalidvalue')
+    verify_failure('raft.snapshot-disable', 'someinvalidvalue')
+    verify_failure('raft.snapshot-disable-load', 'someinvalidvalue')
 
     verify_failure('raft.loglevel', 'somelevel')
     verify_failure('raft.trace', 'sometracelevel')
+    verify_failure('raft.migration-debug', 'somevalue')
 
 
 def test_ignored_commands(cluster):

--- a/tests/integration/test_fuzzing.py
+++ b/tests/integration/test_fuzzing.py
@@ -160,7 +160,7 @@ def test_snapshot_delivery_with_config_changes(cluster):
 
     # After populating 2 million keys, snapshot can take a while. We just
     # trigger it asynchronously and wait until completed for 30 seconds.
-    n1.execute('raft.debug', 'compact', 0, 0, 1)
+    n1.execute('raft.debug', 'compact', 1)
     n1.wait_for_info_param('raft_snapshots_created', 1, 30)
 
     cluster.add_node(use_cluster_args=True)

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -530,7 +530,7 @@ def test_sad_path_migrate(cluster_factory):
             cluster2.leader_node().client.get(key_name)
 
         # remove injected error, should pass
-        cluster1.execute("raft.debug", "migration_debug", 'none')
+        cluster1.config_set("raft.migration-debug", "none")
         assert cluster1.execute("migrate", "", "", "", "", "", "keys",
                                 key_name) == b'OK'
 
@@ -544,15 +544,15 @@ def test_sad_path_migrate(cluster_factory):
         assert conn.execute('asking') == b'OK'
         assert conn.execute('get', key_name) == value
 
-    cluster1.execute("raft.debug", "migration_debug", 'fail_connect')
+    cluster1.config_set("raft.migration-debug", "fail-connect")
     verify_migration_fails("key1", b'value1', 9189,
                            "failed to connect to import cluster, try again")
 
-    cluster1.execute("raft.debug", "migration_debug", 'fail_import')
+    cluster1.config_set("raft.migration-debug", "fail-import")
     verify_migration_fails("key2", b'value2', 4998,
                            "failed to submit RAFT.IMPORT command, try again")
 
-    cluster1.execute("raft.debug", "migration_debug", 'fail_unlock')
+    cluster1.config_set("raft.migration-debug", "fail-unlock")
     verify_migration_fails("key3", b'value3', 935,
                            "Unable to unlock/delete migrated keys, try again")
 

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -204,7 +204,7 @@ def test_nonquorum_reads(cluster):
 
     # Disable apply on node-2 and make it leader. Node-2 will not be able to
     # apply NOOP entry and read requests should fail.
-    cluster.node(2).client.execute_command('raft.debug', 'disable_apply', '1')
+    cluster.node(2).config_set('raft.log-disable-apply', 'yes')
     cluster.node(2).timeout_now()
     cluster.node(2).wait_for_info_param('raft_leader_id', 2)
 
@@ -214,7 +214,7 @@ def test_nonquorum_reads(cluster):
 
     # Disable delay. The new leader can apply NOOP entry and verify it can
     # process read requests.
-    cluster.node(2).client.execute_command('raft.debug', 'disable_apply', '0')
+    cluster.node(2).config_set('raft.log-disable-apply', 'no')
     cluster.node(2).client.get('x')
 
 
@@ -512,14 +512,14 @@ def test_throttle_applying_entries(cluster):
     for i in range(60):
         cluster.execute('set', 'key', 'value')
 
-    # Restart nodes with delay_apply config.
+    # Restart nodes with log-delay-apply config.
     cluster.terminate()
     cluster.node(1).start()
-    cluster.node(1).execute('raft.debug', 'delay_apply', 100000)
+    cluster.node(1).config_set('raft.log-delay-apply', 100000)
     cluster.node(1).pause()
 
     cluster.node(2).start()
-    cluster.node(2).execute('raft.debug', 'delay_apply', 100000)
+    cluster.node(2).config_set('raft.log-delay-apply', 100000)
 
     # Resume node-1, so, nodes will elect a leader and start applying entries.
     cluster.node(1).resume()


### PR DESCRIPTION
This PR can be reviewed commit by commit.

- First commit makes debug configs actual configs that are set by 
`raft.config` command. IIRC this was @fadidahanna's idea, I now realize
 that we can use `REDISMODULE_CONFIG_HIDDEN` for these configs, so they
 won't be listed when we call `config get raft*`. 

- Second commit adds last index and last term of ongoing snapshot 
process to the info string. 