### PR TITLE
Fix crash on raft.debug compact if there is no entry

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -845,7 +845,7 @@ int LogCompactionBegin(Log *log)
         return RR_OK;
     }
 
-    if (p0->num_entries == 1) {
+    if (p0->num_entries <= 1) {
         return RR_ERROR;
     }
 

--- a/tests/unit/test_log.c
+++ b/tests/unit/test_log.c
@@ -680,7 +680,14 @@ static void test_log_compaction(void **state)
     LogInit(&log);
     LogCreate(&log, LOGNAME, DBID, 1, 1, 0);
 
+    /* If there is no entry, it should fail. */
+    assert_int_equal(LogCompactionBegin(&log), RR_ERROR);
+
     append_entry(&log, ++idx, NULL);
+
+    /* If there is one entry, it should fail. */
+    assert_int_equal(LogCompactionBegin(&log), RR_ERROR);
+
     append_entry(&log, ++idx, NULL);
     append_entry(&log, ++idx, NULL);
 


### PR DESCRIPTION
Normally, RedisRaft will not start compaction when there is no entry
in the log but if we call `raft.debug compact` manually, currently it 
crashes if there is no entry. 

Added a check to fail `LogCompactionBegin()` if there is no entry in 
the log. 