### PR TITLE
Update debian version for Jepsen docker instances

### DIFF
--- a/jepsen/docker/control/Dockerfile
+++ b/jepsen/docker/control/Dockerfile
@@ -1,11 +1,11 @@
-FROM debian:stretch
+FROM debian:buster
 
 #
 # Jepsen dependencies
 #
 RUN apt-get -y -q update && \
     apt-get install -qqy \
-        openjdk-8-jre \
+        openjdk-11-jdk \
         libjna-java \
         git \
         gnuplot \

--- a/jepsen/docker/node/Dockerfile
+++ b/jepsen/docker/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 # Install packages
 RUN apt-get update && \
@@ -19,7 +19,7 @@ RUN apt-get update && \
         bzip2 \
         curl \
         faketime \
-        iproute \
+        iproute2 \
         iptables \
         iputils-ping \
         libzip4 \


### PR DESCRIPTION
After https://github.com/redis/redis/pull/10273, redis build in our jepsen instances started to see this failure: [link](https://github.com/RedisLabs/redisraft/actions/runs/4421387215/jobs/7752124084#step:8:8508)

Normally, redis build should not trigger python code when there is no change in json files, see [link](https://github.com/redis/redis/blob/unstable/src/Makefile#L438)

Somehow, it triggers build there. Looks like "debian stretch" distro does not have python 3.6+ (python script requires at least this version), so, the script fails. 

As a quick fix, we can use a more recent distro (also needed to update a couple of packages).

**Missing part in this PR:** We also need to upgrade distro and packages in AWS deployment: https://github.com/RedisLabs/redisraft/tree/master/jepsen/aws