### PR TITLE
remove cluster-mode flag from redis suite run

### DIFF
--- a/tests/redis-suite/run.sh
+++ b/tests/redis-suite/run.sh
@@ -31,7 +31,6 @@ run_tests() {
     ./runtest \
         --host 127.0.0.1 \
         --port 5001 \
-        --cluster-mode \
         --singledb \
         --ignore-encoding \
         --ignore-digest \

--- a/tests/redis-suite/skip.txt
+++ b/tests/redis-suite/skip.txt
@@ -56,3 +56,6 @@ SWAPDB is able to touch the watched keys that do not exist
 -- After fixing this: https://github.com/RedisLabs/redisraft/issues/367
 -- We don't need to skip this test as it doesn't actually configure a replica.
 not enough good replicas
+
+-- We can't handle normal plain eval (without flags) the same way as redis aborting oom on demand
+Consistent eval error reporting


### PR DESCRIPTION
skip less tests, but have to skip one eval oom test because of different semantics in rediraft