### PR TITLE
[RR-224] Add tests with big snapshots

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,7 +8,7 @@ on:
       skipjobs:
         description: 'jobs to skip (delete the ones you want to keep, do not leave empty)'
         required: false
-        default: 'address,undefined,macos,tls,elle,alpine'
+        default: 'address,undefined,macos,tls,elle,alpine,slow'
       redisraft_repo:
         description: 'redisraft repo owner and name'
         required: false
@@ -367,6 +367,56 @@ jobs:
           path: 'redis'
       - name: Build Redis
         run: cd redis && make -j 4
+      - name: Install Python dependencies
+        run:
+          python -m pip install -r tests/integration/requirements.txt
+      - name: Run tests
+        run: |
+          cd build
+          make tests
+
+  test-slow:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'schedule' && github.repository == 'redislabs/redisraft')) && !contains(github.event.inputs.skipjobs, 'slow')
+    timeout-minutes: 14400
+    steps:
+      - name: Set variables
+        env:
+          DEFAULT_REDIS_REPO: redis/redis
+          DEFAULT_REDIS_BRANCH: unstable
+          DEFAULT_REDISRAFT_REPO: redislabs/redisraft
+          DEFAULT_REDISRAFT_BRANCH: master
+        run: |
+          echo "REDIS_REPO=${{github.event.inputs.redis_repo || env.DEFAULT_REDIS_REPO}}" >> $GITHUB_ENV
+          echo "REDIS_BRANCH=${{github.event.inputs.redis_branch || env.DEFAULT_REDIS_BRANCH}}" >> $GITHUB_ENV
+          echo "REDISRAFT_REPO=${{github.event.inputs.redisraft_repo || env.DEFAULT_REDISRAFT_REPO}}" >> $GITHUB_ENV
+          echo "REDISRAFT_BRANCH=${{github.event.inputs.redisraft_branch || env.DEFAULT_REDISRAFT_BRANCH}}" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+        with:
+          repository: ${{ env.REDISRAFT_REPO }}
+          ref: ${{ env.REDISRAFT_BRANCH }}
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential autoconf automake libtool cmake lcov
+      - name: Build
+        run: |
+          mkdir build && cd build
+          cmake .. -DPYTEST_OPTS="--redis-executable=redis/src/redis-server -v --runslow ${{github.event.inputs.pytest_args}}"
+          make
+      - name: Checkout Redis
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.REDIS_REPO }}
+          ref: ${{ env.REDIS_BRANCH }}
+          path: 'redis'
+      - name: Build Redis
+        run: cd redis && make -j 4
+      - name: Setup Python for testing
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.9'
+          architecture: 'x64'
       - name: Install Python dependencies
         run:
           python -m pip install -r tests/integration/requirements.txt

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,7 +31,7 @@ def pytest_addoption(parser):
         '--work-dir', default='tests/tmp',
         help='Working directory for tests temporary files.')
     parser.addoption(
-        '--redis-up-timeout', default=3,
+        '--redis-up-timeout', default=120,
         help='Seconds to wait for Redis to start before timing out.')
     parser.addoption(
         '--valgrind', default=False, action='store_true',

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -708,10 +708,13 @@ class Cluster(object):
         return self.nodes[self.leader]
 
     def follower_node(self):
-        for _id, node in self.nodes.items():
+        if len(self.nodes) <= 1:
+            raise RedisRaftError('No followers in the cluster')
+
+        while True:
+            _id = random.choice(list(self.nodes.keys()))
             if _id != self.leader:
-                return node
-        raise RedisRaftError('No followers in the cluster')
+                return self.node(_id)
 
     def pause_leader(self) -> int:
         old_leader = self.leader

--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -299,7 +299,7 @@ class RedisRaft(object):
             try:
                 self.client.ping()
                 return
-            except redis.exceptions.ConnectionError:
+            except (redis.exceptions.ConnectionError, redis.TimeoutError):
                 if retries is not None:
                     retries -= 1
                     if not retries:
@@ -433,7 +433,7 @@ class RedisRaft(object):
             try:
                 if test_func():
                     return
-            except redis.ConnectionError:
+            except (redis.ConnectionError, redis.TimeoutError):
                 pass
 
             retries -= 1
@@ -548,9 +548,12 @@ class RedisRaft(object):
 
         self._wait_for_condition(check_voting, raise_not_voting, timeout)
 
-    def wait_for_info_param(self, name, value, timeout=20):
+    def wait_for_info_param(self, name, value, greater=False, timeout=20):
         def check_param():
             info = self.info()
+            if greater:
+                return bool(info.get(name) > value)
+
             return bool(info.get(name) == value)
 
         def raise_not_matched():
@@ -704,6 +707,12 @@ class Cluster(object):
     def leader_node(self):
         return self.nodes[self.leader]
 
+    def follower_node(self):
+        for _id, node in self.nodes.items():
+            if _id != self.leader:
+                return node
+        raise RedisRaftError('No followers in the cluster')
+
     def pause_leader(self) -> int:
         old_leader = self.leader
         self.node(old_leader).pause()
@@ -717,13 +726,13 @@ class Cluster(object):
             self.node(self.leader).client.execute_command('get x')
         self.raft_retry(_func)
 
-    def wait_for_unanimity(self, exclude=None):
+    def wait_for_unanimity(self, exclude=None, timeout=20):
         commit_idx = self.node(self.leader).commit_index()
         for _id, node in self.nodes.items():
             if exclude is not None and int(_id) in exclude:
                 continue
-            node.wait_for_commit_index(commit_idx, gt_ok=True)
-            node.wait_for_log_applied()
+            node.wait_for_commit_index(commit_idx, gt_ok=True, timeout=timeout)
+            node.wait_for_log_applied(timeout=timeout)
 
     def wait_for_replication(self, exclude=None):
         current_idx = self.node(self.leader).current_index()
@@ -731,6 +740,12 @@ class Cluster(object):
             if exclude is not None and int(_id) in exclude:
                 continue
             node.wait_for_current_index(current_idx)
+
+    def wait_for_info_param(self, name, value, exclude=None, timeout=20):
+        for _id, node in self.nodes.items():
+            if exclude is not None and int(_id) in exclude:
+                continue
+            node.wait_for_info_param(name, value, timeout=timeout)
 
     def raft_retry(self, func):
         start_time = time.time()
@@ -810,10 +825,6 @@ class Cluster(object):
             node.terminate()
         for node in self.nodes.values():
             node.start()
-
-    def wait_for_info_param(self, name, value, timeout=20):
-        for node in self.nodes.values():
-            node.wait_for_info_param(name, value, timeout)
 
 
 class ElleOp(object):

--- a/tests/integration/test_fuzzing.py
+++ b/tests/integration/test_fuzzing.py
@@ -7,6 +7,8 @@ or the Server Side Public License v1 (SSPLv1).
 import random
 import logging
 import time
+from enum import Enum
+
 import pytest
 from redis import ResponseError
 from .workload import MultiWithLargeReply, MonotonicIncrCheck
@@ -161,7 +163,7 @@ def test_snapshot_delivery_with_config_changes(cluster):
     # After populating 2 million keys, snapshot can take a while. We just
     # trigger it asynchronously and wait until completed for 30 seconds.
     n1.execute('raft.debug', 'compact', 1)
-    n1.wait_for_info_param('raft_snapshots_created', 1, 30)
+    n1.wait_for_info_param('raft_snapshots_created', 1, timeout=30)
 
     cluster.add_node(use_cluster_args=True)
     cluster.add_node(use_cluster_args=True)
@@ -208,6 +210,7 @@ def test_proxy_stability_under_load(cluster, workload):
 
 
 @pytest.mark.slow
+@pytest.mark.timeout(24000)
 def test_stability_with_snapshots_and_restarts(cluster, workload):
     """
     Test stability of the cluster with frequent snapshotting.
@@ -216,8 +219,7 @@ def test_stability_with_snapshots_and_restarts(cluster, workload):
     thread_count = 100
     duration = 300
 
-    cluster.create(5, raft_args={'follower-proxy': 'yes',
-                                 'log-max-file-size': '2000'})
+    cluster.create(5, raft_args={'log-max-file-size': '10kb'})
 
     workload.start(thread_count, cluster, MultiWithLargeReply)
 
@@ -229,3 +231,160 @@ def test_stability_with_snapshots_and_restarts(cluster, workload):
         cluster.random_node().restart()
 
     workload.stop()
+
+
+@pytest.mark.slow
+@pytest.mark.timeout(24000)
+def test_fuzzing_with_large_snapshots(cluster, workload):
+    """
+    Fill nodes with 1,7 Gb of data (~800 mb RDB file) and do some fuzzing.
+    """
+
+    class Operation(Enum):
+        ADD_NODE = 0
+        ADD_MULTIPLE_NODES = 1
+        RESTART_FOLLOWER = 2
+        RESTART_FOLLOWER_WITH_DELAY = 3
+        RESTART_LEADER = 4
+        RESTART_LEADER_WITH_DELAY = 5
+        RESTART_CLUSTER = 6
+        LEADER_TRANSFER = 7
+
+    cluster.create(1)
+
+    n1 = cluster.node(1)
+
+    # Just to avoid socket timeouts, populate db in a few steps.
+    for i in range(0, 4):
+        prefix = '_dummydummykeyname' + str(i)
+        n1.raft_debug_exec('debug', 'populate', 4000000, prefix, 20)
+
+    # Create a snapshot
+    n1.execute('set', 'x', 1)
+    n1.execute('raft.debug', 'compact', 1)
+    n1.wait_for_info_param('raft_snapshots_created', 1, timeout=240)
+
+    # Add followers
+    cluster.add_node()
+    cluster.add_node()
+
+    workload.start(10, cluster, MonotonicIncrCheck)
+
+    for i in range(40):
+        # Starting condition: 3 voting nodes, all entries are applied.
+        cluster.wait_for_info_param("raft_num_voting_nodes", 3, timeout=240)
+        cluster.wait_for_unanimity(timeout=240)
+
+        op = random.choice(list(Operation))
+
+        logging.info("Iteration: %s , Op: %s" % (i, op))
+
+        if op == Operation.ADD_NODE:
+            cluster.remove_node(cluster.random_node_id())
+            cluster.add_node()
+
+        elif op == Operation.ADD_MULTIPLE_NODES:
+            # Remove two nodes and add two new nodes. Snapshot will be
+            # delivered to both of them at the same time.
+            cluster.remove_node(cluster.random_node_id())
+            cluster.wait_for_info_param("raft_num_voting_nodes", 2)
+
+            cluster.remove_node(cluster.random_node_id())
+            cluster.wait_for_info_param("raft_num_voting_nodes", 1)
+
+            cluster.add_node()
+            cluster.add_node()
+
+        elif op == Operation.RESTART_FOLLOWER:
+            n = cluster.follower_node()
+            n.restart()
+
+        elif op == Operation.RESTART_FOLLOWER_WITH_DELAY:
+            # Sleep a bit before starting it back. Node will lag behind and
+            # entries and/or snapshot will be delivered.
+            n = cluster.follower_node()
+            n.terminate()
+            time.sleep(10)
+            n.start()
+
+        elif op == Operation.RESTART_LEADER:
+            n = cluster.leader_node()
+            n.restart()
+
+        elif op == Operation.RESTART_LEADER_WITH_DELAY:
+            # Sleep a bit before starting it back. Node will lag behind and
+            # entries and/or snapshot will be delivered.
+            n = cluster.leader_node()
+            n.terminate()
+            time.sleep(10)
+            n.start()
+
+        elif op == Operation.RESTART_CLUSTER:
+            cluster.restart()
+            cluster.random_node().wait_for_election()
+
+        elif op == Operation.LEADER_TRANSFER:
+            # Leader transfer can fail, e.g. destination node can't catch up
+            # the leader. Then, we just skip the operation.
+            n = cluster.leader_node()
+            try:
+                n.transfer_leader()
+            except ResponseError:
+                continue
+
+            cluster.update_leader()
+            assert cluster.leader_node() != n
+
+    workload.stop()
+
+    logging.info('All cycles finished')
+    logging.info('Stats: ' + workload.stats())
+
+
+@pytest.mark.slow
+@pytest.mark.timeout(24000)
+def test_stability_with_snapshot_delivery(cluster, workload):
+    """
+    Fill nodes with 1,7 Gb of data (~800 mb RDB file) and constantly deliver
+    snapshot to a node under traffic.
+    """
+    cluster.create(1)
+
+    n1 = cluster.node(1)
+
+    # Just to avoid socket timeouts, populate db in a few steps.
+    for i in range(0, 4):
+        prefix = '_dummydummykeyname' + str(i)
+        n1.raft_debug_exec('debug', 'populate', 4000000, prefix, 20)
+
+    # Create a snapshot
+    n1.execute('set', 'x', 1)
+    n1.execute('raft.debug', 'compact', 1)
+    n1.wait_for_info_param('raft_snapshots_created', 1, timeout=240)
+
+    # Add followers
+    cluster.add_node()
+    cluster.add_node()
+
+    cluster.wait_for_info_param("raft_num_voting_nodes", 3, timeout=240)
+    cluster.wait_for_unanimity(timeout=240)
+    cluster.config_set("raft.log-max-file-size", "16mb")
+
+    workload.start(10, cluster, MonotonicIncrCheck)
+
+    for i in range(10):
+        leader = cluster.leader_node()
+        snapshots = leader.info()["raft_snapshots_created"]
+
+        follower = cluster.follower_node()
+        follower.terminate()
+
+        leader.wait_for_info_param("raft_snapshots_created", snapshots,
+                                   timeout=240, greater=True)
+        follower.start()
+        cluster.wait_for_unanimity(timeout=240)
+
+    workload.stop()
+
+    logging.info('All cycles finished')
+    logging.info('Stats: ' + workload.stats())

--- a/tests/integration/test_fuzzing.py
+++ b/tests/integration/test_fuzzing.py
@@ -187,6 +187,31 @@ def test_snapshot_delivery_with_config_changes(cluster):
 
 @pytest.mark.slow
 @pytest.mark.timeout(24000)
+def test_proxy_stability_under_load(cluster, workload):
+    """
+    Test stability of the cluster with follower proxy under load.
+    """
+
+    thread_count = 500
+    duration = 300
+
+    cluster.create(5, raft_args={'follower-proxy': 'yes'})
+    workload.start(thread_count, cluster, MultiWithLargeReply)
+
+    # Monitor progress
+    start = time.time()
+    last_commit_index = 0
+    while start + duration > time.time():
+        time.sleep(2)
+        new_commit_index = cluster.node(cluster.leader).commit_index()
+        assert new_commit_index >= last_commit_index
+        last_commit_index = new_commit_index
+
+    workload.stop()
+
+
+@pytest.mark.slow
+@pytest.mark.timeout(24000)
 def test_stability_with_snapshots_and_restarts(cluster, workload):
     """
     Test stability of the cluster with frequent snapshotting.
@@ -195,7 +220,8 @@ def test_stability_with_snapshots_and_restarts(cluster, workload):
     thread_count = 100
     duration = 300
 
-    cluster.create(5, raft_args={'log-max-file-size': '10kb'})
+    cluster.create(5, raft_args={'follower-proxy': 'yes',
+                                 'log-max-file-size': '2000'})
 
     workload.start(thread_count, cluster, MultiWithLargeReply)
 

--- a/tests/integration/test_fuzzing.py
+++ b/tests/integration/test_fuzzing.py
@@ -186,30 +186,6 @@ def test_snapshot_delivery_with_config_changes(cluster):
 
 
 @pytest.mark.slow
-def test_proxy_stability_under_load(cluster, workload):
-    """
-    Test stability of the cluster with follower proxy under load.
-    """
-
-    thread_count = 500
-    duration = 300
-
-    cluster.create(5, raft_args={'follower-proxy': 'yes'})
-    workload.start(thread_count, cluster, MultiWithLargeReply)
-
-    # Monitor progress
-    start = time.time()
-    last_commit_index = 0
-    while start + duration > time.time():
-        time.sleep(2)
-        new_commit_index = cluster.node(cluster.leader).commit_index()
-        assert new_commit_index >= last_commit_index
-        last_commit_index = new_commit_index
-
-    workload.stop()
-
-
-@pytest.mark.slow
 @pytest.mark.timeout(24000)
 def test_stability_with_snapshots_and_restarts(cluster, workload):
     """


### PR DESCRIPTION
This PR adds two tests with large data-sets (~1.7 Gb on ram, ~800 mb RDB file on disk)
Goal is to test stability when dealing with large data-sets. 
Both tests have 10 clients running operations in the background. 

Tests added:
- test_fuzzing_with_large_snapshots: randomly add/remove/restart nodes
- test_stability_with_snapshot_delivery: Same leader node delivers 800 mb snapshot to the follower in a loop

As these tests are slow, only added to daily to run with `--runslow` pytest option. 