### PR TITLE
[RR-53] Add pubsub support

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -62,13 +62,13 @@ static const CommandSpec commands[] = {
     {"xdel",                        CMD_SPEC_UNSUPPORTED                         },
     {"xtrim",                       CMD_SPEC_UNSUPPORTED | CMD_SPEC_RANDOM       },
 
- /* Pubsub commands not supported */
-    {"subscribe",                   CMD_SPEC_DONT_INTERCEPT                      },
-    {"psubscribe",                  CMD_SPEC_DONT_INTERCEPT                      },
+ /* Pubsub commands */
     {"unsubscribe",                 CMD_SPEC_DONT_INTERCEPT                      },
+    {"sunsubscribe",                CMD_SPEC_DONT_INTERCEPT                      },
     {"punsubscribe",                CMD_SPEC_DONT_INTERCEPT                      },
-    {"publish",                     CMD_SPEC_DONT_INTERCEPT                      },
-    {"pubsub",                      CMD_SPEC_DONT_INTERCEPT                      },
+    {"publish",                     CMD_SPEC_READONLY                            },
+    {"spublish",                    CMD_SPEC_READONLY                            },
+    {"pubsub",                      CMD_SPEC_READONLY                            },
 
  /* Admin commands - bypassed */
     {"auth",                        CMD_SPEC_DONT_INTERCEPT                      },

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -1563,18 +1563,12 @@ static int cmdRaftRejectSubscribe(RedisModuleCtx *ctx, RedisModuleString **argv,
 
     RedisRaftCtx *rr = &redis_raft;
 
-    if (checkRaftState(rr, ctx) != RR_OK) {
+    if (checkRaftState(rr, ctx) != RR_OK ||
+        checkLeader(rr, ctx, NULL) != RR_OK) {
         return REDISMODULE_OK;
     }
 
-    if (!raft_is_leader(rr->raft)) {
-        Node *leader = getLeaderNodeOrReply(rr, ctx);
-        if (leader) {
-            redirectCommand(rr, ctx, leader);
-        }
-        return REDISMODULE_OK;
-    }
-
+    /* If we reach here, it means log replay isn't completed yet. */
     replyClusterDown(ctx);
     return REDISMODULE_OK;
 }

--- a/tests/integration/test_pubsub.py
+++ b/tests/integration/test_pubsub.py
@@ -1,0 +1,268 @@
+import time
+
+import redis
+from pytest import raises
+from redis import ResponseError
+
+
+def test_pubsub_sanity(cluster):
+    """
+    Test basic functionality of PUBLISH, SUBSCRIBE and PSUBSCRIBE commands
+    """
+    cluster.create(1)
+
+    c1 = cluster.node(1).client
+
+    ps1 = c1.pubsub(ignore_subscribe_messages=True)
+    ps1.subscribe("chan1")
+
+    c1.publish("chan1", "hello")
+
+    while True:
+        msg = ps1.get_message()
+        if not msg:
+            time.sleep(0.1)
+            continue
+
+        assert msg["channel"] == b"chan1"
+        assert msg["data"] == b"hello"
+        break
+
+    ps1.psubscribe("pchan?")
+    c1.publish("pchan1", "hello")
+
+    while True:
+        msg = ps1.get_message()
+        if not msg:
+            time.sleep(0.1)
+            continue
+
+        assert msg["channel"] == b"pchan1"
+        assert msg["data"] == b"hello"
+        break
+
+
+def test_pubsub_followers(cluster):
+    """
+    Test SUBSCRIBE, SSUBSCRIBE and PSUBSCRIBE receive -MOVED reply on followers
+    """
+    cluster.create(3)
+
+    c2 = cluster.node(2).client
+    ps2 = c2.pubsub(ignore_subscribe_messages=True)
+
+    with raises(ResponseError, match='MOVED'):
+        ps2.subscribe("chan1")
+
+        while True:
+            msg = ps2.get_message()
+            if not msg:
+                time.sleep(0.1)
+                continue
+            break
+
+    with raises(ResponseError, match='MOVED'):
+        ps2.psubscribe("chan1?")
+
+        while True:
+            msg = ps2.get_message()
+            if not msg:
+                time.sleep(0.1)
+                continue
+            break
+
+    with raises(ResponseError, match='MOVED'):
+        c2.execute_command("ssubscribe", "chan1?")
+
+
+def test_pubsub_subcommand(cluster):
+    """
+    Test PUBSUB subcommands
+    """
+    cluster.create(3)
+
+    c1 = cluster.node(1).client
+    ps1 = c1.pubsub(ignore_subscribe_messages=True)
+    ps1.subscribe("chan1")
+    ps1.psubscribe("h?llo")
+
+    # Test regular channels
+    assert cluster.execute("pubsub", "channels") == [b"chan1"]
+    assert cluster.execute("pubsub", "numpat") == 1
+    subs = cluster.execute("pubsub", "numsub", b"chan1", "hallo")
+    assert subs == [b"chan1", 1, b"hallo", 0]
+
+    # Test shard channels
+    conn1 = c1.connection_pool.get_connection('c1')
+    conn1.send_command("ssubscribe", "chan2")
+
+    assert c1.execute_command("pubsub", "shardchannels") == [b"chan2"]
+    subs = c1.execute_command("pubsub", "shardnumsub", b"chan2", "hallo")
+    assert subs == [b"chan2", 1, b"hallo", 0]
+
+
+def test_pubsub_leader_change(cluster):
+    """
+    Test subscriber's connection is closed if node becomes a follower
+    """
+    cluster.create(3)
+
+    c1 = cluster.node(1).client
+    ps1 = c1.pubsub(ignore_subscribe_messages=True)
+    ps1.subscribe("chan1")
+
+    cluster.node(1).transfer_leader()
+
+    # Connection will be closed
+    with raises(redis.exceptions.ConnectionError):
+        while True:
+            msg = ps1.get_message()
+            if not msg:
+                time.sleep(0.1)
+                continue
+            break
+
+
+def test_pubsub_log_replay_with_multi(cluster):
+    """
+    Test SUBSCRIBE is not allowed until log replay is completed.
+    """
+    cluster.create(1)
+
+    c1 = cluster.node(1).client
+
+    ps1 = c1.pubsub(ignore_subscribe_messages=True)
+    ps1.subscribe("chan1")
+
+    c1.execute_command("multi")
+    c1.execute_command("set", "x", 1)  # Make multi a write command
+    c1.execute_command("publish", "chan1", "first")
+    c1.execute_command("publish", "chan1", "second")
+    c1.execute_command("exec")
+
+    # Verify subscriber receives pubsub
+    while True:
+        msg = ps1.get_message()
+        if not msg:
+            time.sleep(0.1)
+            continue
+
+        assert msg["channel"] == b"chan1"
+        assert msg["data"] == b"first"
+
+        msg = ps1.get_message()
+        assert msg["channel"] == b"chan1"
+        assert msg["data"] == b"second"
+        break
+
+    # Restart node but prevent log replay
+    cluster.node(1).terminate()
+    cluster.node(1).start(extra_raft_args=["--raft.log-disable-apply", "yes"])
+    cluster.node(1).wait_for_election()
+
+    # Previous subscription should get an error
+    with raises(redis.exceptions.ConnectionError):
+        ps1.get_message()
+
+    # Subscribe is not allowed until log is replayed
+    with raises(redis.exceptions.ResponseError, match="CLUSTERDOWN"):
+        ps2 = c1.pubsub(ignore_subscribe_messages=True)
+        ps2.subscribe("chan1")
+
+        while True:
+            msg = ps2.get_message()
+            if not msg:
+                time.sleep(0.1)
+                continue
+
+    # Replay logs
+    cluster.node(1).config_set("raft.log-disable-apply", "no")
+    cluster.wait_for_unanimity()
+
+    # Subscribe should be allowed now
+    ps3 = c1.pubsub(ignore_subscribe_messages=True)
+    ps3.subscribe("chan3")
+    c1.publish("chan3", "third")
+
+    while True:
+        msg = ps3.get_message()
+        if not msg:
+            time.sleep(0.1)
+            continue
+
+        assert msg["channel"] == b"chan3"
+        assert msg["data"] == b"third"
+        break
+
+
+def test_pubsub_log_replay_with_lua(cluster):
+    """
+    Basic test of PUBLISH in a lua script.
+    """
+    cluster.create(2)
+
+    c1 = cluster.node(1).client
+
+    ps1 = c1.pubsub(ignore_subscribe_messages=True)
+    ps1.subscribe("ch1")
+    c1.execute_command("EVAL", """redis.call('PUBLISH','ch1','hello');""", '0')
+
+    while True:
+        msg = ps1.get_message()
+        if not msg:
+            time.sleep(0.1)
+            continue
+
+        assert msg["channel"] == b"ch1"
+        assert msg["data"] == b"hello"
+        break
+
+    cluster.node(1).transfer_leader()
+
+    with raises(redis.exceptions.ConnectionError):
+        while True:
+            msg = ps1.get_message()
+            if not msg:
+                time.sleep(0.1)
+                continue
+            break
+
+
+def test_pubsub_acl(cluster):
+    """
+    Test PUBSUB with ACL rules
+    """
+    cluster.create(3)
+
+    cluster.execute('acl', 'setuser', 'default', 'resetchannels', '&ch1')
+
+    c1 = cluster.node(1).client
+
+    # Pubsub on an allowed channel
+    ps1 = c1.pubsub(ignore_subscribe_messages=True)
+    ps1.subscribe("ch1")
+    c1.publish("ch1", "hello")
+
+    while True:
+        msg = ps1.get_message()
+        if not msg:
+            time.sleep(0.1)
+            continue
+        assert msg["channel"] == b"ch1"
+        assert msg["data"] == b"hello"
+        break
+
+    # Pubsub on not allowed channel
+    ps2 = c1.pubsub(ignore_subscribe_messages=True)
+    ps2.subscribe("ch2")
+
+    with raises(redis.exceptions.NoPermissionError):
+        while True:
+            msg = ps2.get_message()
+            if not msg:
+                time.sleep(0.1)
+                continue
+            break
+
+    with raises(redis.exceptions.NoPermissionError):
+        c1.publish("ch2", "hello")


### PR DESCRIPTION
This PR adds pubsub support to RedisRaft.

Differences from Redis Cluster:
- In Redis Cluster, clients can subscribe and publish to any node in the cluster. Publish messages will be forwarded to other shards and to the other nodes in the shard. 
In RedisRaft, we'll only allow publish/subscribe on the leader node. Messages will not be forwarded to the other shards. 

- Normally, Redis does not return -MOVED response to PUBLISH/SUBSCRIBE commands. RedisRaft will return -MOVED as it doesn't support subscribe/publish on the followers. 

Implementation details:
- If the node is the leader, allow SUBSCRIBE messages (do not intercept them). If not the leader, reject them with -MOVED or -CLUSTERDOWN response. 
- Process PUBLISH as a read-only command.
- PUBLISH can be inside of multi or lua script and might be written to the log. On log replay, we may process publish message again and if we have subscribers, they might receive the message. To prevent that, we won't allow subscribers until log replay is completed. 
- If the leader node becomes a follower, it will kill subscriber clients. Assumption is that those clients will try to connect back and they will get -MOVED or -CLUSTERDOWN response. 