### PR TITLE
Refactor leader check

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -89,43 +89,6 @@ void replyWithFormatErrorString(RedisModuleCtx *ctx, const char *fmt, ...)
     RedisModule_ReplyWithError(ctx, buf);
 }
 
-/* Returns the leader node (raft_node_t), or reply a -CLUSTERDOWN error
- * and return NULL.
- *
- * Note: it's possible to have an elected but unknown leader node, in which
- * case NULL will also be returned.
- */
-raft_node_t *getLeaderRaftNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
-{
-    raft_node_t *node = raft_get_leader_node(rr->raft);
-    if (!node) {
-        replyClusterDown(ctx);
-    }
-
-    return node;
-}
-
-/* Returns the leader node (Node), or reply a -CLUSTERDOWN error
- * and return NULL.
- *
- * Note: it's possible to have an elected but unknown leader node, in which
- * case NULL will also be returned.
- */
-Node *getLeaderNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx)
-{
-    raft_node_t *raft_node = getLeaderRaftNodeOrReply(rr, ctx);
-    if (!raft_node) {
-        return NULL;
-    }
-
-    Node *node = raft_node_get_udata(raft_node);
-    if (!node) {
-        replyClusterDown(ctx);
-    }
-
-    return node;
-}
-
 /* Check that we're not in REDIS_RAFT_LOADING state.  If not, reply with -LOADING
  * and return an error.
  */
@@ -166,6 +129,71 @@ RRStatus checkRaftState(RedisRaftCtx *rr, RedisModuleCtx *ctx)
             break;
     }
     return RR_OK;
+}
+
+RRStatus checkLeaderExists(RedisRaftCtx *rr, RedisModuleCtx *ctx)
+{
+    if (raft_get_leader_node(rr->raft) == NULL) {
+        replyClusterDown(ctx);
+        return RR_ERROR;
+    }
+
+    return RR_OK;
+}
+
+/* Check if this node is leader, if not, redirect or proxy the request. */
+RRStatus checkLeader(RedisRaftCtx *rr, RedisModuleCtx *ctx,
+                     RaftRedisCommandArray *cmds)
+{
+    raft_node_t *n = NULL;
+    Node *leader = NULL;
+
+    if (raft_is_leader(rr->raft)) {
+        return RR_OK;
+    }
+
+    n = raft_get_leader_node(rr->raft);
+    if (n) {
+        leader = raft_node_get_udata(n);
+    }
+
+    if (!leader) {
+        replyClusterDown(ctx);
+        return RR_ERROR;
+    }
+
+    /* reply ASK for ASKING state commands */
+    if (cmds && cmds->asking) {
+        int slot;
+        if (HashSlotCompute(rr, cmds, &slot) != RR_OK) {
+            replyCrossSlot(ctx);
+            return RR_ERROR;
+        }
+
+        if (slot == -1) {
+            /* ASKING mode requests should always have keys */
+            RedisModule_ReplyWithError(ctx, "ERR cmd without keys in asking mode");
+            return RR_ERROR;
+        }
+
+        replyAsk(ctx, (unsigned int) slot, &leader->addr);
+        return RR_ERROR;
+    }
+
+    /* forward commands to the leader in follower_proxy state */
+    if (cmds && rr->config.follower_proxy) {
+        if (ProxyCommand(rr, ctx, cmds, leader) != RR_OK) {
+            RedisModule_ReplyWithError(ctx, "NOTLEADER Failed to proxy command");
+        }
+        return RR_ERROR;
+    }
+
+    /* One anomaly here is that may redirect a client to the leader even for
+     * commands have no keys, which is something Redis Cluster never does. We
+     * still need to consider how this impacts clients which may not expect it.
+     */
+    replyRedirect(ctx, 0, &leader->addr);
+    return RR_ERROR;
 }
 
 /* Parse a -MOVED reply and update the returned address in addr.

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -45,9 +45,6 @@ void *__dso_handle;
 
 #define VALID_NODE_ID(x) ((x) > 0)
 
-static void redirectCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, Node *leader);
-static void handleNonLeaderCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, Node *leader, RaftRedisCommandArray *cmds);
-
 /* Parse a node address from a RedisModuleString */
 static RRStatus getNodeAddrFromArg(RedisModuleCtx *ctx, RedisModuleString *arg, NodeAddr *addr)
 {
@@ -91,15 +88,8 @@ static int cmdRaftNode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         return REDISMODULE_OK;
     }
 
-    if (checkRaftState(rr, ctx) == RR_ERROR) {
-        return REDISMODULE_OK;
-    }
-
-    if (!raft_is_leader(rr->raft)) {
-        Node *leader = getLeaderNodeOrReply(rr, ctx);
-        if (leader) {
-            redirectCommand(rr, ctx, leader);
-        }
+    if (checkRaftState(rr, ctx) != RR_OK ||
+        checkLeader(rr, ctx, NULL) != RR_OK) {
         return REDISMODULE_OK;
     }
 
@@ -489,20 +479,13 @@ exit:
 
 static void handleMigrateCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommand *cmd)
 {
-    if (checkRaftState(rr, ctx) == RR_ERROR) {
+    if (checkRaftState(rr, ctx) != RR_OK ||
+        checkLeader(rr, ctx, NULL) != RR_OK) {
         return;
     }
 
     if (rr->migrate_req != NULL) {
         RedisModule_ReplyWithError(ctx, "ERR RedisRaft only supports one concurrent migration currently");
-        return;
-    }
-
-    if (!raft_is_leader(rr->raft)) {
-        Node *leader = getLeaderNodeOrReply(rr, ctx);
-        if (leader) {
-            redirectCommand(rr, ctx, leader);
-        }
         return;
     }
 
@@ -708,17 +691,8 @@ static void handleRedisCommandAppend(RedisRaftCtx *rr,
     /* Check that we're part of a bootstrapped cluster and not in the middle of
      * joining or loading data.
      */
-    if (checkRaftState(rr, ctx) == RR_ERROR) {
-        return;
-    }
-
-    if (!raft_is_leader(rr->raft)) {
-        Node *leader = getLeaderNodeOrReply(rr, ctx);
-        if (!leader) {
-            return;
-        }
-
-        handleNonLeaderCommand(rr, ctx, leader, cmds);
+    if (checkRaftState(rr, ctx) != RR_OK ||
+        checkLeader(rr, ctx, cmds) != RR_OK) {
         return;
     }
 
@@ -857,52 +831,6 @@ static void handleRedisCommand(RedisRaftCtx *rr,
     }
 
     handleRedisCommandAppend(rr, ctx, cmds);
-}
-
-static void redirectCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, Node *leader)
-{
-    RedisModule_Assert(!raft_is_leader(rr->raft));
-
-    /* One anomaly here is that may redirect a client to the leader even for
-     * commands have no keys, which is something Redis Cluster never does. We
-     * still need to consider how this impacts clients which may not expect it.
-     */
-    replyRedirect(ctx, 0, &leader->addr);
-}
-
-static void handleNonLeaderCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, Node *leader, RaftRedisCommandArray *cmds)
-{
-    RedisModule_Assert(!raft_is_leader(rr->raft));
-    RedisModule_Assert(cmds);
-
-    /* reply ASK for ASKING state commands */
-    if (cmds->asking) {
-        int slot;
-        if (HashSlotCompute(rr, cmds, &slot) != RR_OK) {
-            replyCrossSlot(ctx);
-            return;
-        }
-
-        if (slot == -1) {
-            /* ASKING mode requests should always have keys */
-            RedisModule_ReplyWithError(ctx, "ERR cmd without keys in asking mode");
-            return;
-        }
-
-        replyAsk(ctx, (unsigned int) slot, &leader->addr);
-        return;
-    }
-
-    /* forward commands to the leader in follower_proxy state */
-    if (rr->config.follower_proxy) {
-        if (ProxyCommand(rr, ctx, cmds, leader) != RR_OK) {
-            RedisModule_ReplyWithError(ctx, "NOTLEADER Failed to proxy command");
-        }
-        return;
-    }
-
-    /* redirect otherwise */
-    redirectCommand(rr, ctx, leader);
 }
 
 /* RAFT [Redis command to execute]
@@ -1350,15 +1278,8 @@ static int cmdRaftShardGroup(RedisModuleCtx *ctx, RedisModuleString **argv, int 
         return REDISMODULE_OK;
     }
 
-    if (checkRaftState(rr, ctx) == RR_ERROR) {
-        return REDISMODULE_OK;
-    }
-
-    if (!raft_is_leader(rr->raft)) {
-        Node *leader = getLeaderNodeOrReply(rr, ctx);
-        if (leader) {
-            redirectCommand(rr, ctx, leader);
-        }
+    if (checkRaftState(rr, ctx) != RR_OK ||
+        checkLeader(rr, ctx, NULL) != RR_OK) {
         return REDISMODULE_OK;
     }
 

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -794,11 +794,11 @@ typedef struct ClientSession {
 void joinLinkIdleCallback(Connection *conn);
 void joinLinkFreeCallback(void *privdata);
 const char *getStateStr(RedisRaftCtx *rr);
-raft_node_t *getLeaderRaftNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx);
-Node *getLeaderNodeOrReply(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 RRStatus checkRaftNotLoading(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 RRStatus checkRaftUninitialized(RedisRaftCtx *rr, RedisModuleCtx *ctx);
 RRStatus checkRaftState(RedisRaftCtx *rr, RedisModuleCtx *ctx);
+RRStatus checkLeaderExists(RedisRaftCtx *rr, RedisModuleCtx *ctx);
+RRStatus checkLeader(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedisCommandArray *cmds);
 bool parseMovedReply(const char *str, NodeAddr *addr);
 void raftNodeToString(char *output, const char *dbid, raft_node_t *raft_node);
 void raftNodeIdToString(char *output, const char *dbid, raft_node_id_t raft_id);


### PR DESCRIPTION
This PR should not introduce any behavioral change. 

Currently, our leader check looks like:

```c
    if (!raft_is_leader(rr->raft)) {
        Node *leader = getLeaderNodeOrReply(rr, ctx);
        if (leader) {
            redirectCommand(rr, ctx, leader);
        }
        return REDISMODULE_OK;
    }
```

I keep making mistakes while using this pattern. I think main confusion is that it is not obvious where/when we are supposed to reply. 

Changed this to single function: `checkLeader()`.  It can reply with -MOVED, -CLUSTERDOWN, -ASKING or it can proxy the request. So, all ugliness is in a single place. Let me know what you think. 