### PR TITLE
[RR-183] Use RM_RdbSave() and RM_RdbLoad()

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -225,7 +225,7 @@ jobs:
           ref: ${{ env.REDIS_BRANCH }}
           path: 'redis'
       - name: Build Redis
-        run: cd redis && make -j 4 REDIS_LDFLAGS=-rdynamic
+        run: cd redis && make -j 4
       - name: Setup Python for testing
         uses: actions/setup-python@v1
         with:

--- a/src/raft.c
+++ b/src/raft.c
@@ -1416,11 +1416,6 @@ static bool checkRedisLoading(RedisRaftCtx *rr)
 
 static void handleLoadingState(RedisRaftCtx *rr)
 {
-    if (rr->snapshot_load.pending) {
-        loadPendingSnapshot(rr);
-        return;
-    }
-
     if (!checkRedisLoading(rr)) {
         /* If Redis loaded a snapshot (RDB), log some information and configure the
          * raft library as necessary.

--- a/src/redisraft.h
+++ b/src/redisraft.h
@@ -371,12 +371,6 @@ typedef struct RedisRaftConfig {
 
 } RedisRaftConfig;
 
-typedef struct SnapshotLoad {
-    bool pending;
-    raft_term_t term;
-    raft_index_t index;
-} SnapshotLoad;
-
 /* Global Raft context */
 typedef struct RedisRaftCtx {
     void *raft;                    /* Raft library context */
@@ -396,7 +390,6 @@ typedef struct RedisRaftCtx {
                                                     belong to the same snapshot */
     char incoming_snapshot_file[256];    /* File name for incoming snapshots. When received fully,
                                                     it will be renamed to the original rdb file */
-    SnapshotLoad snapshot_load;          /* Indicates we've received a snapshot waiting to be loaded */
     bool snapshot_in_progress;           /* Indicates we're creating a snapshot in the background */
     raft_index_t curr_snapshot_last_idx; /* Last included idx of the snapshot operation currently in progress */
     raft_term_t curr_snapshot_last_term; /* Last included term of the snapshot operation currently in progress */
@@ -904,7 +897,6 @@ void createOutgoingSnapshotMmap(RedisRaftCtx *ctx);
 RRStatus initiateSnapshot(RedisRaftCtx *rr);
 RRStatus finalizeSnapshot(RedisRaftCtx *rr, SnapshotResult *sr);
 void cancelSnapshot(RedisRaftCtx *rr, SnapshotResult *sr);
-void loadPendingSnapshot(RedisRaftCtx *rr);
 int pollSnapshotStatus(RedisRaftCtx *rr, SnapshotResult *sr);
 void configRaftFromSnapshotInfo(RedisRaftCtx *rr);
 int raftLoadSnapshot(raft_server_t *raft, void *udata, raft_term_t term, raft_index_t idx);

--- a/tests/unit/main.c
+++ b/tests/unit/main.c
@@ -17,10 +17,6 @@ extern struct CMUnitTest log_tests[];
 extern struct CMUnitTest util_tests[];
 extern struct CMUnitTest serialization_tests[];
 
-/* Redis symbols to keep linker happy */
-void *rdbLoad;
-void *rdbSave;
-
 int tests_count(struct CMUnitTest *tests)
 {
     int count = 0;


### PR DESCRIPTION
Use new module APIs to load/save RDBs introduced by https://github.com/redis/redis/pull/11852

Currently, RedisRaft directly calls rdbload and rdbsave functions of Redis. 
This PR changes these calls with proper module API functions. 
Due to this "unofficial" way of using functions in Redis, RedisRaft needed `-rdynamic` compile flag on MacOS. 
After this PR, this is not needed anymore. 