### PR TITLE
Better redis version check

### DIFF
--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -2171,10 +2171,11 @@ __attribute__((__unused__)) int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisMod
                     REDISRAFT_VERSION, REDISRAFT_GIT_SHA1);
 
     const int MIN_SUPPORTED_REDIS_VERSION = 0x00070000;
-    if (!RMAPI_FUNC_SUPPORTED(RedisModule_GetServerVersion) ||
+    if (!RMAPI_FUNC_SUPPORTED(RedisModule_CallReplyPromiseAbort) ||
+        !RMAPI_FUNC_SUPPORTED(RedisModule_GetServerVersion) ||
         RedisModule_GetServerVersion() < MIN_SUPPORTED_REDIS_VERSION) {
         RedisModule_Log(ctx, REDISMODULE_LOGLEVEL_WARNING,
-                        "RedisRaft requires Redis 7.0 or above");
+                        "RedisRaft requires Redis build from 'unstable' branch");
         return REDISMODULE_ERR;
     }
 


### PR DESCRIPTION
Check existence of the latest function that was added to redismodule.h to detect compability better.

Hopefully, it will print helpful warnings for the cases like: https://github.com/RedisLabs/redisraft/issues/608