### PR TITLE
Update Debian version for Jepsen tests

### DIFF
--- a/jepsen/aws/README.md
+++ b/jepsen/aws/README.md
@@ -3,7 +3,7 @@
 This is a Terraform script to launch a Jepsen test environment on AWS.
 It launches and configures 5 cluster test nodes and one control node.
 
-All nodes run Debian stretch.
+All nodes run Debian.
 
 ## Getting started
 

--- a/jepsen/aws/main.tf
+++ b/jepsen/aws/main.tf
@@ -65,7 +65,7 @@ data "aws_ami" "debian" {
 
   filter {
     name    = "name"
-    values  = ["debian-stretch-hvm-x86_64-*"]
+    values  = ["debian-10-amd64-*"]
   }
 
   owners = ["379101102735"]

--- a/jepsen/docker/README.md
+++ b/jepsen/docker/README.md
@@ -4,7 +4,7 @@ This is a `docker-compose` setup for running a RedisRaft/Jepsen test on a docker
 environment.
 
 The environment consists of a single control container and 5 cluster containers
-running RedisRaft. All containers are based on Debian stretch.
+running RedisRaft. All containers are based on Debian.
 
 ## Getting started
 

--- a/jepsen/docker/control/Dockerfile
+++ b/jepsen/docker/control/Dockerfile
@@ -1,11 +1,11 @@
-FROM debian:stretch
+FROM debian:buster
 
 #
 # Jepsen dependencies
 #
 RUN apt-get -y -q update && \
     apt-get install -qqy \
-        openjdk-8-jre \
+        openjdk-11-jdk \
         libjna-java \
         git \
         gnuplot \

--- a/jepsen/docker/node/Dockerfile
+++ b/jepsen/docker/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 # Install packages
 RUN apt-get update && \
@@ -19,7 +19,7 @@ RUN apt-get update && \
         bzip2 \
         curl \
         faketime \
-        iproute \
+        iproute2 \
         iptables \
         iputils-ping \
         libzip4 \


### PR DESCRIPTION
Older debian version is being removed from debian repo (?), Jepsen tests are currently failing because that version does not exist anymore. 
This PR updates debian version and a few dependencies. 