### PR TITLE
Fix test to cover different disconnect messages

### DIFF
--- a/tests/integration/test_blocking.py
+++ b/tests/integration/test_blocking.py
@@ -268,9 +268,9 @@ def test_blocking_with_term_change(cluster):
 
     cluster.node(1).restart()
 
-    with raises(ConnectionError, match="Connection closed by server"):
+    with raises(ConnectionError, match="Connection (closed|reset)"):
         c1.read_response()
-    with raises(ConnectionError, match="Connection closed by server"):
+    with raises(ConnectionError, match="Connection (closed|reset)"):
         c2.read_response()
 
     cluster.node(1).wait_for_info_param('raft_state', 'up')

--- a/tests/integration/test_snapshots.py
+++ b/tests/integration/test_snapshots.py
@@ -743,5 +743,5 @@ def test_session_cleaned_on_load(cluster):
 
     cluster.wait_for_info_param("raft_num_sessions", 0)
 
-    with raises(ConnectionError, match="Connection closed by server"):
+    with raises(ConnectionError, match="Connection (closed|reset)"):
         conn1.execute("get", "X")


### PR DESCRIPTION
https://github.com/RedisLabs/redisraft/actions/runs/4749046590/jobs/8435886206#step:10:415

Similar to https://github.com/RedisLabs/redisraft/pull/580 
MacOS throws different error messages on disconnect occasionally.

