### PR TITLE
[RR-232] Fix command serialization format

### DIFF
--- a/tests/unit/test_serialization.c
+++ b/tests/unit/test_serialization.c
@@ -37,7 +37,7 @@ static void test_serialize_redis_command()
     setupRedisCommand(RaftRedisCommandArrayExtend(&cmd_array), cmd3_argv, 1);
     cmd_array.acl = RedisModule_CreateString(NULL, "hello", 5);
 
-    const char *expected = "*0\n*0\n$5\nhello\n*3\n*3\n$3\nSET\n$3\nkey\n$5\nvalue\n*2\n$3\nGET\n$5\nmykey\n*1\n$4\nPING\n";
+    const char *expected = "*2\n*3\n:0\n:0\n$5\nhello\n*3\n*3\n$3\nSET\n$3\nkey\n$5\nvalue\n*2\n$3\nGET\n$5\nmykey\n*1\n$4\nPING\n";
 
     raft_entry_t *e = RaftRedisCommandArraySerialize(&cmd_array);
     assert(e != NULL);
@@ -60,7 +60,7 @@ static void test_deserialize_redis_command()
 
 static void test_deserialize_redis_command_array()
 {
-    const char *serialized = "*0\n*0\n$0\n\n*3\n*3\n$3\nSET\n$3\nkey\n$5\nvalue\n*2\n$3\nGET\n$5\nmykey\n*1\n$4\nPING\n";
+    const char *serialized = "*2\n*3\n:0\n:0\n$0\n\n*3\n*3\n$3\nSET\n$3\nkey\n$5\nvalue\n*2\n$3\nGET\n$5\nmykey\n*1\n$4\nPING\n";
     int serialized_len = strlen(serialized);
 
     RaftRedisCommandArray cmd_array = {0};
@@ -73,7 +73,7 @@ static void test_deserialize_redis_command_array()
 
 static void test_deserialize_redis_command_array_with_acl()
 {
-    const char *serialized = "*0\n*0\n$5\nhello\n*3\n*3\n$3\nSET\n$3\nkey\n$5\nvalue\n*2\n$3\nGET\n$5\nmykey\n*1\n$4\nPING\n";
+    const char *serialized = "*2\n*3\n:0\n:0\n$5\nhello\n*3\n*3\n$3\nSET\n$3\nkey\n$5\nvalue\n*2\n$3\nGET\n$5\nmykey\n*1\n$4\nPING\n";
     int serialized_len = strlen(serialized);
 
     RaftRedisCommandArray cmd_array = {0};


### PR DESCRIPTION
Previously, we were using multibulk compatible format to serialize entries (exception is to use `\n` instead of `\r\n`). 
Later we added some metadata to command array: asking, acl and command flags.  To encode asking and acl, we used `*` which is length identifier in multibulk format. So now, we don't actually serialize in a way compatible with multibulk format.

This PR contains a quick fix to make it compatible with multibulk format.
It encodes command array as two sub-arrays: one sub-array for metadata, one sub-array for commands.

```c
*2\n         <-- array count
*3\n         <-- first array len (metadata elem count)
:0\n         <-- integer encoded "asking"
:0\n         <-- integer encoded "cmd flags"
$-1\n        <-- string encoded acl
*1\n         <-- second array len (command count in the array)
*3\n         <-- command arg count
$3\nSET\n    <-- arg1
$3\nkey\n    <-- arg2
$5\nvalue\n  <-- arg3
```

**TODO:** 
1- Probably better to use same multibulk functions from log impl. 
2- ImportKeys, LockKeys and timeout commands should also follow the same format (be multibulk compatible). 
3- This is a quite verbose, big serialization format. Serialized "set x 1" takes 110 bytes on disk. More compact format should be considered in feature to minimize disk access. 