### PR TITLE
Delete entry id assignments

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -369,7 +369,6 @@ RRStatus ShardGroupAppendLogEntry(RedisRaftCtx *rr, ShardGroup *sg, int type, vo
 
     raft_entry_t *entry = raft_entry_new(strlen(payload));
     entry->type = type;
-    entry->id = rand();
     entry->user_data = user_data;
     memcpy(entry->data, payload, strlen(payload));
     RedisModule_Free(payload);
@@ -404,7 +403,6 @@ RRStatus ShardGroupsAppendLogEntry(RedisRaftCtx *rr, int num_sg, ShardGroup **sg
     size_t payload_len = strlen(buf);
     raft_entry_t *entry = raft_entry_new(payload_len);
     entry->type = type;
-    entry->id = rand();
     entry->user_data = user_data;
     memcpy(entry->data, buf, payload_len);
     RedisModule_Free(buf);

--- a/src/migrate.c
+++ b/src/migrate.c
@@ -177,7 +177,6 @@ int cmdRaftImport(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
     }
 
     raft_entry_t *entry = RaftRedisSerializeImport(&req->r.import_keys);
-    entry->id = rand();
     entry->type = RAFT_LOGTYPE_IMPORT_KEYS;
 
     int e = RedisRaftRecvEntry(rr, entry, req);
@@ -202,7 +201,6 @@ static void raftAppendRaftUnlockDeleteEntry(RedisRaftCtx *rr, RaftReq *req)
     }
 
     raft_entry_t *entry = RaftRedisLockKeysSerialize(req->r.migrate_keys.keys, req->r.migrate_keys.num_keys);
-    entry->id = rand();
     entry->type = RAFT_LOGTYPE_DELETE_UNLOCK_KEYS;
 
     int e = RedisRaftRecvEntry(rr, entry, req);

--- a/src/raft.c
+++ b/src/raft.c
@@ -1124,7 +1124,6 @@ static int raftNodeHasSufficientLogs(raft_server_t *raft, void *user_data, raft_
     LOG_NOTICE("node:%d has sufficient logs, adding as voting node.", node->id);
 
     raft_entry_req_t *entry = raft_entry_new(sizeof(RaftCfgChange));
-    entry->id = rand();
     entry->type = RAFT_LOGTYPE_ADD_NODE;
 
     RaftCfgChange *cfgchange = (RaftCfgChange *) entry->data;

--- a/src/redisraft.c
+++ b/src/redisraft.c
@@ -132,7 +132,6 @@ static int cmdRaftNode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         RaftReq *req = RaftReqInit(ctx, RR_CFGCHANGE_ADDNODE);
 
         raft_entry_req_t *entry = raft_entry_new(sizeof(cfg));
-        entry->id = rand();
         entry->type = RAFT_LOGTYPE_ADD_NONVOTING_NODE;
         memcpy(entry->data, &cfg, sizeof(cfg));
 
@@ -168,7 +167,6 @@ static int cmdRaftNode(RedisModuleCtx *ctx, RedisModuleString **argv, int argc)
         RaftReq *req = RaftReqInit(ctx, RR_CFGCHANGE_REMOVENODE);
 
         raft_entry_req_t *entry = raft_entry_new(sizeof(cfg));
-        entry->id = rand();
         entry->type = RAFT_LOGTYPE_REMOVE_NODE;
         memcpy(entry->data, &cfg, sizeof(cfg));
 
@@ -502,7 +500,6 @@ static void handleMigrateCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedi
     }
 
     raft_entry_t *entry = RaftRedisLockKeysSerialize(req->r.migrate_keys.keys, req->r.migrate_keys.num_keys);
-    entry->id = rand();
     entry->type = RAFT_LOGTYPE_LOCK_KEYS;
     entryAttachRaftReq(rr, entry, req);
 
@@ -593,7 +590,6 @@ static void handleClientCommand(RedisRaftCtx *rr, RedisModuleCtx *ctx, RaftRedis
 static void appendEndClientSession(RedisRaftCtx *rr, RaftReq *req, unsigned long long id, char *reason)
 {
     raft_entry_t *entry = raft_entry_new(strlen(reason) + 1);
-    entry->id = rand();
     entry->type = RAFT_LOGTYPE_END_SESSION;
     entry->session = id;
     strncpy(entry->data, reason, entry->data_len);
@@ -804,7 +800,6 @@ static void handleRedisCommandAppend(RedisRaftCtx *rr,
     RaftRedisCommandArrayMove(&req->r.redis.cmds, cmds);
 
     raft_entry_t *entry = RaftRedisCommandArraySerialize(&req->r.redis.cmds);
-    entry->id = rand();
     entry->session = RedisModule_GetClientId(ctx);
     entry->type = RAFT_LOGTYPE_NORMAL;
 


### PR DESCRIPTION
Starting from https://github.com/RedisLabs/raft/pull/158,  raft library assigns an id automatically, no need to do it in RedisRaft anymore. 