### PR TITLE
[RR-271] Bug fixes and improvements for File implementation

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -235,7 +235,7 @@ ssize_t FileRead(File *file, void *buf, size_t cap)
         }
 
         remaining -= rd;
-        dest += count;
+        dest += rd;
         file->roffset += rd;
     }
 }

--- a/src/file.h
+++ b/src/file.h
@@ -32,7 +32,7 @@ typedef struct File {
     size_t roffset; /* Read offset relative to the head of the file. */
     char *wpos;     /* In write mode, current write position of the buffer. */
     size_t woffset; /* Write offset relative to the head of the file. */
-    char buf[4096]; /* Userspace buffer. */
+    char *buf;      /* Userspace buffer. */
 } File;
 
 void FileInit(File *file);

--- a/tests/unit/test_file.c
+++ b/tests/unit/test_file.c
@@ -247,7 +247,7 @@ static void test_file_big()
 
     char *orig = calloc(1, LEN);
     /* Set some random bytes. */
-    for (size_t i = 0; i < 4096; i ++) {
+    for (size_t i = 0; i < 4096; i++) {
         orig[rand() % (LEN - 1)] = rand();
     }
 


### PR DESCRIPTION
This PR includes three changes and can be reviewed commit by commit

1- Bug fix when readv() returns with partial data. 
    This is a bit hard to reproduce but it happens when a large buffer read from file. 
    Conditions to reproduce:
     - There must be some data in the internal buffer of FILE object.
     - readv() should return with partial read.

 2- An improvement. Previously, File impl used internal buffer in the struct. This is fine as long as you don't copy/move the struct. 
     If you do that, pointers that point to that buffer will be invalid after moving. (e.g. `wpos`, `rpos`, `rend` ). Switching to heap allocated buffer to prevent future confusion. 

3- Looks like `readv()` and `writev()` with larger than INT_MAX buffer sizes don't work on macOS. So, adding a change to use regular `read()` and `write()` on macOS. 