### PR TITLE
[RR-259] Improve log statements and error replies

### DIFF
--- a/src/migrate.c
+++ b/src/migrate.c
@@ -108,8 +108,7 @@ void importKeys(RedisRaftCtx *rr, raft_entry_t *entry, RaftReq *req)
         if (RedisModule_CallReplyType(reply) == REDISMODULE_REPLY_ERROR) {
             size_t err_len;
             const char *err = RedisModule_CallReplyStringPtr(reply, &err_len);
-            LOG_WARNING("importKeys: restore failed with %.*s", (int) err_len, err);
-            RedisModule_Assert(RedisModule_CallReplyType(reply) != REDISMODULE_REPLY_ERROR);
+            PANIC("importKeys: restore failed with %.*s", (int) err_len, err);
         }
         RedisModule_FreeCallReply(reply);
     }

--- a/src/raft.c
+++ b/src/raft.c
@@ -1014,10 +1014,7 @@ static int raftPersistMetadata(raft_server_t *raft, void *user_data,
     RedisRaftCtx *rr = user_data;
 
     int ret = MetadataWrite(&rr->meta, term, vote);
-    if (ret != RR_OK) {
-        LOG_WARNING("ERROR: RaftMetaWrite()");
-        return RAFT_ERR_SHUTDOWN;
-    }
+    RedisModule_Assert(ret == RR_OK);
 
     return 0;
 }

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -799,7 +799,7 @@ static void handleSnapshotResponse(redisAsyncContext *c, void *r, void *privdata
         reply->element[3]->type != REDIS_REPLY_INTEGER ||
         reply->element[4]->type != REDIS_REPLY_INTEGER ||
         reply->element[5]->type != REDIS_REPLY_INTEGER) {
-        NODE_LOG_WARNING(node, "invalid RAFT.LOADSNAPSHOT reply");
+        NODE_LOG_WARNING(node, "invalid RAFT.SNAPSHOT reply");
         return;
     }
 

--- a/tests/integration/test_sanity.py
+++ b/tests/integration/test_sanity.py
@@ -43,17 +43,13 @@ def test_set_cluster_password(cluster):
 
 
 def test_set_cluster_id_too_short(cluster):
-    cluster_id = "123456789012345678901234567890"
-    msg = 'invalid cluster message \\(cluster id length\\)'
-    with raises(ResponseError, match=msg):
-        cluster.create(3, cluster_id=cluster_id)
+    with raises(ResponseError, match="cluster id must be 32 characters"):
+        cluster.create(3, cluster_id="123456789012345678901234567890")
 
 
 def test_set_cluster_id_too_long(cluster):
-    cluster_id = "1234567890123456789012345678901234"
-    msg = 'invalid cluster message \\(cluster id length\\)'
-    with raises(ResponseError, match=msg):
-        cluster.create(3, cluster_id=cluster_id)
+    with raises(ResponseError, match="cluster id must be 32 characters"):
+        cluster.create(3, cluster_id="1234567890123456789012345678901234")
 
 
 def test_fail_cluster_enabled(cluster):

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -219,7 +219,7 @@ def test_shard_group_validation(cluster):
     c = cluster.node(1).client
 
     # Invalid range
-    with raises(ResponseError, match='invalid'):
+    with raises(ResponseError, match='failed to parse slot range'):
         c.execute_command(
             'RAFT.SHARDGROUP', 'ADD',
             '12345678901234567890123456789012',


### PR DESCRIPTION
This PR includes a few improvements:
- Made changes to reply to user rather than printing logs
- Fixes a bug that we assume redismodulestring was null terminated while parsing AUTH2 parameters in MIGRATE command.