### PR TITLE
Fix redis suite test

### DIFF
--- a/tests/redis-suite/skip.txt
+++ b/tests/redis-suite/skip.txt
@@ -32,6 +32,7 @@ MONITOR can log executed commands
 MONITOR can log commands issued by the scripting engine
 MONITOR can log commands issued by functions
 MONITOR correctly handles multi-exec cases
+MONITOR log blocked command only once
 
 -- TODO: check what's wrong
 UNLINK can reclaim memory in background


### PR DESCRIPTION
`RAFT` prefix breaks the test