### PR TITLE
[RR-300] Use -bsymbolic linker flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ set_property(TARGET redisraft APPEND PROPERTY
 target_compile_options(redisraft PRIVATE -Wall -Werror -Wextra -Wno-unused-parameter)
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
-    set(LINKER_FLAGS "-Wl,-Bsymbolic-functions")
+    set(LINKER_FLAGS "-Wl,-Bsymbolic")
 else ()
     set(LINKER_FLAGS "-Wl,-undefined -Wl,dynamic_lookup")
 endif ()


### PR DESCRIPTION
tls-sanitizer build fails with memory leaks: [link](https://github.com/RedisLabs/redisraft/actions/runs/5194541316/jobs/9366309647)
Though, there is no leak.

Looks like it started to happen after this [commit](https://github.com/redis/redis/pull/12254).
The problem is hiredis symbols in Redis and RedisRaft mix up. This is a known problem when executable and shared library contain different versions of the same library. 

Solution is to use `-bsymbolic` linker flag. Previously, we were using `-bsymbolic-functions` which handles functions only. Effect of this flag is limited (also it has less side effects) compared to `-bsymbolic` which applies to all symbols (functions, variables etc.)
From now on, we need `-bsymbolic`.