### PR TITLE
Handle corner cases of removing node in tests

### DIFF
--- a/tests/integration/sandbox.py
+++ b/tests/integration/sandbox.py
@@ -682,18 +682,27 @@ class Cluster(object):
         def _func():
             self.node(self.leader).client.execute_command(
                 'RAFT.NODE', 'REMOVE', _id)
-        try:
-            self.raft_retry(_func)
-        except redis.ResponseError as err:
-            # If we are removing the leader, leader will shut down before
-            # sending the reply. On retry, we should get
-            # "node id does not exist" reply. If we get this reply and still
-            # have '_id' in our local list, we know removal was successful.
-            # For other cases, we just propagate the exception.
-            missing_node_id = str(err).startswith("node id does not exist")
-            was_retry = missing_node_id and _id in self.nodes
-            if not was_retry:
-                raise err
+
+        while True:
+            try:
+                self.raft_retry(_func)
+            except redis.ResponseError as err:
+                # If we are removing the leader, leader will shut down before
+                # sending the reply. On retry, we might get "one voting change"
+                # reply. In that case, we should retry the operation. If we get
+                # "node id does not exist" reply and still have '_id' in our
+                # local list, we know removal was successful.
+                # For other cases, we just propagate the exception.
+                if str(err).startswith("one voting change only") or \
+                        str(err).startswith("try again"):
+                    continue
+
+                missing_node_id = str(err).startswith("node id does not exist")
+                was_retry = missing_node_id and _id in self.nodes
+                if was_retry:
+                    break
+                else:
+                    raise err
 
         self.nodes[_id].destroy()
         del self.nodes[_id]


### PR DESCRIPTION
There is one test failure: https://github.com/RedisLabs/redisraft/actions/runs/5232581265/jobs/9447382625

Scenario is
- We call `cluster.remove_node()` for the leader. Leader applies the removal entry and kills itself.
- Test code didn't get response as expected (Leader always dies before sending the reply).
- Another node elected as the leader. This node has removal entry but its commit index is smaller than the removal entry index. 
- In test, we retry the operation. Leader gets this request before it figures out the latest commit index and so, it replies "one voting change only" and the test fails. 

Solution is to retry the operation if we get "one voting change only" (Also, added "try again" reply to this case). We may get "node id does not exist" if the previous operation succeeded but we already handle that case in the related section. 

Response handling here is a bit complex but let's see if it fixes the these corner cases. 
